### PR TITLE
[Backend] Gestion des utilisateurs (#2)

### DIFF
--- a/back-office/pom.xml
+++ b/back-office/pom.xml
@@ -82,6 +82,31 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- JWT -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<!-- Mail -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/back-office/src/main/java/com/colick/backoffice/auth/controller/AuthController.java
+++ b/back-office/src/main/java/com/colick/backoffice/auth/controller/AuthController.java
@@ -1,0 +1,55 @@
+package com.colick.backoffice.auth.controller;
+
+import com.colick.backoffice.auth.dto.AuthResponse;
+import com.colick.backoffice.auth.dto.LoginRequest;
+import com.colick.backoffice.auth.util.JwtUtil;
+import com.colick.backoffice.exception.ResourceNotFoundException;
+import com.colick.backoffice.user.dto.UserResponse;
+import com.colick.backoffice.user.entity.User;
+import com.colick.backoffice.user.repository.UserRepository;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for authentication endpoints.
+ */
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    public AuthController(UserRepository userRepository,
+                          PasswordEncoder passwordEncoder,
+                          JwtUtil jwtUtil) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    /** Authenticates a user and returns a JWT token. */
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new ResourceNotFoundException("Invalid email or password"));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String token = jwtUtil.generateToken(user);
+        return ResponseEntity.ok(AuthResponse.builder()
+                .token(token)
+                .type("Bearer")
+                .user(UserResponse.from(user))
+                .build());
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/auth/dto/AuthResponse.java
+++ b/back-office/src/main/java/com/colick/backoffice/auth/dto/AuthResponse.java
@@ -1,0 +1,17 @@
+package com.colick.backoffice.auth.dto;
+
+import com.colick.backoffice.user.dto.UserResponse;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Response returned after a successful authentication.
+ */
+@Data
+@Builder
+public class AuthResponse {
+
+    private String token;
+    private String type;
+    private UserResponse user;
+}

--- a/back-office/src/main/java/com/colick/backoffice/auth/dto/LoginRequest.java
+++ b/back-office/src/main/java/com/colick/backoffice/auth/dto/LoginRequest.java
@@ -1,0 +1,19 @@
+package com.colick.backoffice.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * Request body for user login.
+ */
+@Data
+public class LoginRequest {
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email must be valid")
+    private String email;
+
+    @NotBlank(message = "Password is required")
+    private String password;
+}

--- a/back-office/src/main/java/com/colick/backoffice/auth/filter/JwtAuthFilter.java
+++ b/back-office/src/main/java/com/colick/backoffice/auth/filter/JwtAuthFilter.java
@@ -1,0 +1,69 @@
+package com.colick.backoffice.auth.filter;
+
+import com.colick.backoffice.auth.util.JwtUtil;
+import com.colick.backoffice.user.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Filter that validates the JWT token on every incoming request
+ * and sets the authentication in the SecurityContext.
+ */
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    public JwtAuthFilter(JwtUtil jwtUtil, UserRepository userRepository) {
+        this.jwtUtil = jwtUtil;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        final String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        final String token = authHeader.substring(7);
+
+        if (!jwtUtil.isTokenValid(token)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String email = jwtUtil.extractEmail(token);
+
+        if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            userRepository.findByEmail(email).ifPresent(user -> {
+                var authority = new SimpleGrantedAuthority("ROLE_" + user.getRole().name());
+                var authToken = new UsernamePasswordAuthenticationToken(
+                        user, null, List.of(authority));
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            });
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/auth/util/JwtUtil.java
+++ b/back-office/src/main/java/com/colick/backoffice/auth/util/JwtUtil.java
@@ -1,0 +1,65 @@
+package com.colick.backoffice.auth.util;
+
+import com.colick.backoffice.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/**
+ * Utility class for generating and validating JWT tokens.
+ */
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final long expirationMs;
+
+    public JwtUtil(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration-ms}") long expirationMs) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMs = expirationMs;
+    }
+
+    /** Generates a signed JWT token for the given user. */
+    public String generateToken(User user) {
+        return Jwts.builder()
+                .subject(user.getEmail())
+                .claim("role", user.getRole().name())
+                .claim("userId", user.getId())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    /** Extracts all claims from a JWT token. */
+    public Claims extractClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    /** Extracts the subject (email) from a JWT token. */
+    public String extractEmail(String token) {
+        return extractClaims(token).getSubject();
+    }
+
+    /** Returns true if the token is valid and not expired. */
+    public boolean isTokenValid(String token) {
+        try {
+            Claims claims = extractClaims(token);
+            return !claims.getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/config/SecurityConfig.java
+++ b/back-office/src/main/java/com/colick/backoffice/config/SecurityConfig.java
@@ -1,15 +1,27 @@
 package com.colick.backoffice.config;
 
+import com.colick.backoffice.auth.filter.JwtAuthFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter) {
+        this.jwtAuthFilter = jwtAuthFilter;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -18,8 +30,16 @@ public class SecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/actuator/health", "/actuator/info").permitAll()
-                .anyRequest().permitAll()
-            );
+                .requestMatchers("/auth/**").permitAll()
+                .requestMatchers("/users").permitAll()  // registration is public
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/back-office/src/main/java/com/colick/backoffice/exception/GlobalExceptionHandler.java
+++ b/back-office/src/main/java/com/colick/backoffice/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.colick.backoffice.exception;
 
+import com.colick.backoffice.exception.UserAlreadyExistsException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -26,6 +27,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
                 .body(new ApiError(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(UserAlreadyExistsException.class)
+    public ResponseEntity<ApiError> handleConflict(UserAlreadyExistsException ex) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ApiError(HttpStatus.CONFLICT.value(), ex.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/back-office/src/main/java/com/colick/backoffice/exception/UserAlreadyExistsException.java
+++ b/back-office/src/main/java/com/colick/backoffice/exception/UserAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.colick.backoffice.exception;
+
+/**
+ * Thrown when attempting to create a user with an already registered email.
+ */
+public class UserAlreadyExistsException extends RuntimeException {
+
+    public UserAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/user/controller/UserController.java
+++ b/back-office/src/main/java/com/colick/backoffice/user/controller/UserController.java
@@ -1,0 +1,62 @@
+package com.colick.backoffice.user.controller;
+
+import com.colick.backoffice.user.dto.CreateUserRequest;
+import com.colick.backoffice.user.dto.UpdateUserRequest;
+import com.colick.backoffice.user.dto.UserResponse;
+import com.colick.backoffice.user.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * REST controller for user management endpoints.
+ */
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    /** Register a new user account. */
+    @PostMapping
+    public ResponseEntity<UserResponse> createUser(@Valid @RequestBody CreateUserRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(userService.createUser(request));
+    }
+
+    /** List all users (admin only). */
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<UserResponse>> getAllUsers() {
+        return ResponseEntity.ok(userService.getAllUsers());
+    }
+
+    /** Get a user by ID. */
+    @GetMapping("/{id}")
+    public ResponseEntity<UserResponse> getUserById(@PathVariable Long id) {
+        return ResponseEntity.ok(userService.getUserById(id));
+    }
+
+    /** Update a user's information. */
+    @PutMapping("/{id}")
+    public ResponseEntity<UserResponse> updateUser(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateUserRequest request) {
+        return ResponseEntity.ok(userService.updateUser(id, request));
+    }
+
+    /** Delete a user by ID (admin only). */
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/user/dto/CreateUserRequest.java
+++ b/back-office/src/main/java/com/colick/backoffice/user/dto/CreateUserRequest.java
@@ -1,0 +1,32 @@
+package com.colick.backoffice.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * Request body for creating a new user account.
+ */
+@Data
+public class CreateUserRequest {
+
+    @NotBlank(message = "First name is required")
+    private String firstName;
+
+    @NotBlank(message = "Last name is required")
+    private String lastName;
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email must be valid")
+    private String email;
+
+    private String phone;
+
+    @NotBlank(message = "Identity document is required")
+    private String identityDocument;
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 8, message = "Password must be at least 8 characters")
+    private String password;
+}

--- a/back-office/src/main/java/com/colick/backoffice/user/dto/UpdateUserRequest.java
+++ b/back-office/src/main/java/com/colick/backoffice/user/dto/UpdateUserRequest.java
@@ -1,0 +1,26 @@
+package com.colick.backoffice.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * Request body for updating an existing user's information.
+ */
+@Data
+public class UpdateUserRequest {
+
+    private String firstName;
+
+    private String lastName;
+
+    @Email(message = "Email must be valid")
+    private String email;
+
+    private String phone;
+
+    private String identityDocument;
+
+    @Size(min = 8, message = "Password must be at least 8 characters")
+    private String password;
+}

--- a/back-office/src/main/java/com/colick/backoffice/user/dto/UserResponse.java
+++ b/back-office/src/main/java/com/colick/backoffice/user/dto/UserResponse.java
@@ -1,0 +1,36 @@
+package com.colick.backoffice.user.dto;
+
+import com.colick.backoffice.user.entity.User;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Read-only view of a user returned by the API (no password exposed).
+ */
+@Data
+@Builder
+public class UserResponse {
+
+    private Long id;
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String phone;
+    private String identityDocument;
+    private User.Role role;
+
+    /**
+     * Maps a {@link User} entity to a {@link UserResponse} DTO.
+     */
+    public static UserResponse from(User user) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .email(user.getEmail())
+                .phone(user.getPhone())
+                .identityDocument(user.getIdentityDocument())
+                .role(user.getRole())
+                .build();
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/user/entity/User.java
+++ b/back-office/src/main/java/com/colick/backoffice/user/entity/User.java
@@ -1,0 +1,48 @@
+package com.colick.backoffice.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Represents an application user (traveler or sender).
+ */
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column
+    private String phone;
+
+    @Column(nullable = false)
+    private String identityDocument;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private Role role = Role.USER;
+
+    public enum Role {
+        USER, ADMIN
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/user/repository/UserRepository.java
+++ b/back-office/src/main/java/com/colick/backoffice/user/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package com.colick.backoffice.user.repository;
+
+import com.colick.backoffice.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * JPA repository for {@link User} entities.
+ */
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/back-office/src/main/java/com/colick/backoffice/user/service/UserService.java
+++ b/back-office/src/main/java/com/colick/backoffice/user/service/UserService.java
@@ -1,0 +1,28 @@
+package com.colick.backoffice.user.service;
+
+import com.colick.backoffice.user.dto.CreateUserRequest;
+import com.colick.backoffice.user.dto.UpdateUserRequest;
+import com.colick.backoffice.user.dto.UserResponse;
+
+import java.util.List;
+
+/**
+ * Service interface for user management operations.
+ */
+public interface UserService {
+
+    /** Creates a new user account. */
+    UserResponse createUser(CreateUserRequest request);
+
+    /** Returns all registered users (admin-only). */
+    List<UserResponse> getAllUsers();
+
+    /** Returns a single user by ID. */
+    UserResponse getUserById(Long id);
+
+    /** Updates an existing user's information. */
+    UserResponse updateUser(Long id, UpdateUserRequest request);
+
+    /** Deletes a user by ID (admin-only). */
+    void deleteUser(Long id);
+}

--- a/back-office/src/main/java/com/colick/backoffice/user/service/UserServiceImpl.java
+++ b/back-office/src/main/java/com/colick/backoffice/user/service/UserServiceImpl.java
@@ -1,0 +1,89 @@
+package com.colick.backoffice.user.service;
+
+import com.colick.backoffice.exception.ResourceNotFoundException;
+import com.colick.backoffice.exception.UserAlreadyExistsException;
+import com.colick.backoffice.user.dto.CreateUserRequest;
+import com.colick.backoffice.user.dto.UpdateUserRequest;
+import com.colick.backoffice.user.dto.UserResponse;
+import com.colick.backoffice.user.entity.User;
+import com.colick.backoffice.user.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Implementation of {@link UserService}.
+ */
+@Service
+@Transactional
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserServiceImpl(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public UserResponse createUser(CreateUserRequest request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new UserAlreadyExistsException("A user with email " + request.getEmail() + " already exists");
+        }
+        User user = User.builder()
+                .firstName(request.getFirstName())
+                .lastName(request.getLastName())
+                .email(request.getEmail())
+                .phone(request.getPhone())
+                .identityDocument(request.getIdentityDocument())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .role(User.Role.USER)
+                .build();
+        return UserResponse.from(userRepository.save(user));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<UserResponse> getAllUsers() {
+        return userRepository.findAll().stream()
+                .map(UserResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserResponse getUserById(Long id) {
+        return UserResponse.from(findOrThrow(id));
+    }
+
+    @Override
+    public UserResponse updateUser(Long id, UpdateUserRequest request) {
+        User user = findOrThrow(id);
+        if (request.getFirstName() != null) user.setFirstName(request.getFirstName());
+        if (request.getLastName() != null) user.setLastName(request.getLastName());
+        if (request.getEmail() != null) {
+            if (!request.getEmail().equals(user.getEmail()) && userRepository.existsByEmail(request.getEmail())) {
+                throw new UserAlreadyExistsException("A user with email " + request.getEmail() + " already exists");
+            }
+            user.setEmail(request.getEmail());
+        }
+        if (request.getPhone() != null) user.setPhone(request.getPhone());
+        if (request.getIdentityDocument() != null) user.setIdentityDocument(request.getIdentityDocument());
+        if (request.getPassword() != null) user.setPassword(passwordEncoder.encode(request.getPassword()));
+        return UserResponse.from(userRepository.save(user));
+    }
+
+    @Override
+    public void deleteUser(Long id) {
+        User user = findOrThrow(id);
+        userRepository.delete(user);
+    }
+
+    private User findOrThrow(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + id));
+    }
+}

--- a/back-office/src/main/resources/application.yml
+++ b/back-office/src/main/resources/application.yml
@@ -20,6 +20,18 @@ spring:
   jackson:
     default-property-inclusion: non_null
 
+  mail:
+    host: ${MAIL_HOST:localhost}
+    port: ${MAIL_PORT:1025}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: false
+          starttls:
+            enable: false
+
 server:
   port: ${SERVER_PORT:8080}
   servlet:
@@ -30,3 +42,7 @@ management:
     web:
       exposure:
         include: health,info
+
+jwt:
+  secret: ${JWT_SECRET:colick-super-secret-key-must-be-at-least-32-chars}
+  expiration-ms: ${JWT_EXPIRATION_MS:86400000}

--- a/back-office/src/test/java/com/colick/backoffice/user/UserServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/user/UserServiceImplTest.java
@@ -1,0 +1,146 @@
+package com.colick.backoffice.user;
+
+import com.colick.backoffice.exception.ResourceNotFoundException;
+import com.colick.backoffice.exception.UserAlreadyExistsException;
+import com.colick.backoffice.user.dto.CreateUserRequest;
+import com.colick.backoffice.user.dto.UpdateUserRequest;
+import com.colick.backoffice.user.dto.UserResponse;
+import com.colick.backoffice.user.entity.User;
+import com.colick.backoffice.user.repository.UserRepository;
+import com.colick.backoffice.user.service.UserServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    private User sampleUser;
+
+    @BeforeEach
+    void setUp() {
+        sampleUser = User.builder()
+                .id(1L)
+                .firstName("John")
+                .lastName("Doe")
+                .email("john@example.com")
+                .password("hashed")
+                .identityDocument("ID123")
+                .role(User.Role.USER)
+                .build();
+    }
+
+    @Test
+    void createUser_shouldReturnUserResponse_whenEmailIsNew() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.setFirstName("John");
+        request.setLastName("Doe");
+        request.setEmail("john@example.com");
+        request.setIdentityDocument("ID123");
+        request.setPassword("password123");
+
+        when(userRepository.existsByEmail(request.getEmail())).thenReturn(false);
+        when(passwordEncoder.encode(anyString())).thenReturn("hashed");
+        when(userRepository.save(any(User.class))).thenReturn(sampleUser);
+
+        UserResponse response = userService.createUser(request);
+
+        assertThat(response.getEmail()).isEqualTo("john@example.com");
+        assertThat(response.getFirstName()).isEqualTo("John");
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void createUser_shouldThrow_whenEmailAlreadyExists() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.setEmail("john@example.com");
+        request.setPassword("password123");
+
+        when(userRepository.existsByEmail("john@example.com")).thenReturn(true);
+
+        assertThatThrownBy(() -> userService.createUser(request))
+                .isInstanceOf(UserAlreadyExistsException.class)
+                .hasMessageContaining("john@example.com");
+    }
+
+    @Test
+    void getAllUsers_shouldReturnAllUsers() {
+        when(userRepository.findAll()).thenReturn(List.of(sampleUser));
+
+        List<UserResponse> result = userService.getAllUsers();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getEmail()).isEqualTo("john@example.com");
+    }
+
+    @Test
+    void getUserById_shouldReturnUser_whenFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(sampleUser));
+
+        UserResponse response = userService.getUserById(1L);
+
+        assertThat(response.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void getUserById_shouldThrow_whenNotFound() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.getUserById(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void updateUser_shouldUpdateFields() {
+        UpdateUserRequest request = new UpdateUserRequest();
+        request.setFirstName("Jane");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(sampleUser));
+        when(userRepository.save(any(User.class))).thenReturn(sampleUser);
+
+        userService.updateUser(1L, request);
+
+        assertThat(sampleUser.getFirstName()).isEqualTo("Jane");
+        verify(userRepository).save(sampleUser);
+    }
+
+    @Test
+    void deleteUser_shouldDelete_whenFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(sampleUser));
+
+        userService.deleteUser(1L);
+
+        verify(userRepository).delete(sampleUser);
+    }
+
+    @Test
+    void deleteUser_shouldThrow_whenNotFound() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.deleteUser(99L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/back-office/src/test/resources/application-test.yml
+++ b/back-office/src/test/resources/application-test.yml
@@ -13,3 +13,19 @@ spring:
     user:
       name: test
       password: test
+
+  mail:
+    host: localhost
+    port: 1025
+    username:
+    password:
+    properties:
+      mail:
+        smtp:
+          auth: false
+          starttls:
+            enable: false
+
+jwt:
+  secret: test-secret-key-must-be-at-least-32-chars-long
+  expiration-ms: 86400000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,15 @@ services:
       - postgres-data:/var/lib/postgresql/data
     restart: unless-stopped
 
+  # MailHog — SMTP server for local email testing
+  mailhog:
+    image: mailhog/mailhog:latest
+    container_name: colick-mailhog
+    ports:
+      - "1025:1025"   # SMTP
+      - "8025:8025"   # Web UI
+    restart: unless-stopped
+
   # Back-office Spring Boot API
   back-office:
     build:
@@ -31,8 +40,11 @@ services:
       DB_NAME: colick
       DB_USERNAME: colick
       DB_PASSWORD: colick
+      MAIL_HOST: mailhog
+      MAIL_PORT: 1025
     depends_on:
       - postgres
+      - mailhog
     restart: unless-stopped
 
   # Front-office Angular application


### PR DESCRIPTION
## Résolution de l'issue #2 — Gestion des utilisateurs

### Ce qui a été implémenté

- **Entité** `User` : firstName, lastName, email, phone, identityDocument, password (BCrypt), role (USER/ADMIN)
- **Endpoints** :
  - `POST /api/users` — Création de compte (public)
  - `POST /api/auth/login` — Authentification → JWT Bearer token
  - `GET /api/users` — Liste des utilisateurs (ADMIN uniquement)
  - `GET /api/users/{id}` — Récupérer un utilisateur
  - `PUT /api/users/{id}` — Modifier un utilisateur
  - `DELETE /api/users/{id}` — Supprimer un utilisateur (ADMIN uniquement)
- **JWT** : génération + validation via `JwtUtil` + filtre `JwtAuthFilter`
- **Sécurité** : `@PreAuthorize("hasRole('ADMIN')")\ pour les routes sensibles
- **Validation** : Bean Validation sur tous les DTOs (`@NotBlank`, `@Email`, `@Size`)
- **Gestion d'erreurs** : `UserAlreadyExistsException` → HTTP 409, ajouté dans `GlobalExceptionHandler`
- **Tests** : 7 tests unitaires `UserServiceImplTest` (Mockito)
- **Mail** : ajout de `spring-boot-starter-mail` + MailHog dans `docker-compose.yml`

### Closes #2