### PR TITLE
[Backend] Gestion des trajets (#3)

### DIFF
--- a/back-office/src/main/java/com/colick/backoffice/email/EmailService.java
+++ b/back-office/src/main/java/com/colick/backoffice/email/EmailService.java
@@ -1,0 +1,34 @@
+package com.colick.backoffice.email;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service for sending transactional emails.
+ */
+@Service
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    public EmailService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    /**
+     * Sends a plain-text email.
+     *
+     * @param to      recipient email address
+     * @param subject email subject
+     * @param body    email body
+     */
+    public void sendEmail(String to, String subject, String body) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(body);
+        message.setFrom("noreply@colick.app");
+        mailSender.send(message);
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/exception/GlobalExceptionHandler.java
+++ b/back-office/src/main/java/com/colick/backoffice/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.colick.backoffice.exception;
 
 import com.colick.backoffice.exception.UserAlreadyExistsException;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,6 +35,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
                 .body(new ApiError(HttpStatus.CONFLICT.value(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiError> handleAccessDenied(AccessDeniedException ex) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(new ApiError(HttpStatus.FORBIDDEN.value(), ex.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/back-office/src/main/java/com/colick/backoffice/trip/controller/TripController.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/controller/TripController.java
@@ -1,0 +1,118 @@
+package com.colick.backoffice.trip.controller;
+
+import com.colick.backoffice.trip.dto.*;
+import com.colick.backoffice.trip.service.TripService;
+import com.colick.backoffice.user.entity.User;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * REST controller for trip and booking management endpoints.
+ */
+@RestController
+@RequestMapping("/trips")
+public class TripController {
+
+    private final TripService tripService;
+
+    public TripController(TripService tripService) {
+        this.tripService = tripService;
+    }
+
+    /** Publish a new trip. Requires authentication. */
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<TripResponse> createTrip(
+            @Valid @RequestBody CreateTripRequest request,
+            @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(tripService.createTrip(request, currentUser));
+    }
+
+    /** List all active trips (public). */
+    @GetMapping
+    public ResponseEntity<List<TripResponse>> getAllTrips() {
+        return ResponseEntity.ok(tripService.getAllTrips());
+    }
+
+    /** Get a trip by ID (public). */
+    @GetMapping("/{id}")
+    public ResponseEntity<TripResponse> getTripById(@PathVariable Long id) {
+        return ResponseEntity.ok(tripService.getTripById(id));
+    }
+
+    /** Update a trip. Only the traveler or an admin can do this. */
+    @PutMapping("/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<TripResponse> updateTrip(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateTripRequest request,
+            @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(tripService.updateTrip(id, request, currentUser));
+    }
+
+    /** Cancel a trip. Only the traveler or an admin can do this. */
+    @DeleteMapping("/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> deleteTrip(
+            @PathVariable Long id,
+            @AuthenticationPrincipal User currentUser) {
+        tripService.deleteTrip(id, currentUser);
+        return ResponseEntity.noContent().build();
+    }
+
+    /** List all booking requests for a trip. */
+    @GetMapping("/{id}/bookings")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<List<TripBookingResponse>> getBookings(@PathVariable Long id) {
+        return ResponseEntity.ok(tripService.getBookings(id));
+    }
+
+    /** Submit a booking request on a trip. */
+    @PostMapping("/{id}/bookings")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<TripBookingResponse> createBooking(
+            @PathVariable Long id,
+            @Valid @RequestBody CreateBookingRequest request,
+            @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(tripService.createBooking(id, request, currentUser));
+    }
+
+    /** Accept a booking request. Only the trip owner can do this. */
+    @PutMapping("/{id}/bookings/{bookingId}/accept")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<TripBookingResponse> acceptBooking(
+            @PathVariable Long id,
+            @PathVariable Long bookingId,
+            @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(tripService.acceptBooking(id, bookingId, currentUser));
+    }
+
+    /** Reject a booking request. Only the trip owner can do this. */
+    @PutMapping("/{id}/bookings/{bookingId}/reject")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<TripBookingResponse> rejectBooking(
+            @PathVariable Long id,
+            @PathVariable Long bookingId,
+            @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(tripService.rejectBooking(id, bookingId, currentUser));
+    }
+
+    /** Remove a user from the booking list. Only the trip owner can do this. */
+    @DeleteMapping("/{id}/bookings/{bookingId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> removeBooking(
+            @PathVariable Long id,
+            @PathVariable Long bookingId,
+            @AuthenticationPrincipal User currentUser) {
+        tripService.removeBooking(id, bookingId, currentUser);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/dto/CreateBookingRequest.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/dto/CreateBookingRequest.java
@@ -1,0 +1,20 @@
+package com.colick.backoffice.trip.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * Request body for submitting a booking request on a trip.
+ */
+@Data
+public class CreateBookingRequest {
+
+    @DecimalMin(value = "0.1", message = "Weight must be greater than 0")
+    private BigDecimal weight;
+
+    private String description;
+
+    private String packagePhotoUrl;
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/dto/CreateTripRequest.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/dto/CreateTripRequest.java
@@ -1,0 +1,40 @@
+package com.colick.backoffice.trip.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Request body for creating a new trip.
+ */
+@Data
+public class CreateTripRequest {
+
+    @NotBlank(message = "Departure address is required")
+    private String departureAddress;
+
+    @NotBlank(message = "Destination is required")
+    private String destination;
+
+    @NotNull(message = "Departure time is required")
+    @Future(message = "Departure time must be in the future")
+    private LocalDateTime departureTime;
+
+    @NotNull(message = "Arrival time is required")
+    private LocalDateTime arrivalTime;
+
+    @NotNull(message = "Max weight is required")
+    @DecimalMin(value = "0.1", message = "Max weight must be greater than 0")
+    private BigDecimal maxWeight;
+
+    @NotNull(message = "Price per kilo is required")
+    @DecimalMin(value = "0.01", message = "Price per kilo must be greater than 0")
+    private BigDecimal pricePerKilo;
+
+    private boolean instantAcceptance;
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/dto/TripBookingResponse.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/dto/TripBookingResponse.java
@@ -1,0 +1,40 @@
+package com.colick.backoffice.trip.dto;
+
+import com.colick.backoffice.trip.entity.TripBooking;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+/**
+ * Read-only view of a trip booking returned by the API.
+ */
+@Data
+@Builder
+public class TripBookingResponse {
+
+    private Long id;
+    private Long tripId;
+    private Long senderId;
+    private String senderName;
+    private BigDecimal weight;
+    private String description;
+    private String packagePhotoUrl;
+    private TripBooking.BookingStatus status;
+
+    /**
+     * Maps a {@link TripBooking} entity to a {@link TripBookingResponse} DTO.
+     */
+    public static TripBookingResponse from(TripBooking booking) {
+        return TripBookingResponse.builder()
+                .id(booking.getId())
+                .tripId(booking.getTrip().getId())
+                .senderId(booking.getSender().getId())
+                .senderName(booking.getSender().getFirstName() + " " + booking.getSender().getLastName())
+                .weight(booking.getWeight())
+                .description(booking.getDescription())
+                .packagePhotoUrl(booking.getPackagePhotoUrl())
+                .status(booking.getStatus())
+                .build();
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/dto/TripResponse.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/dto/TripResponse.java
@@ -1,0 +1,47 @@
+package com.colick.backoffice.trip.dto;
+
+import com.colick.backoffice.trip.entity.Trip;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Read-only view of a trip returned by the API.
+ */
+@Data
+@Builder
+public class TripResponse {
+
+    private Long id;
+    private Long travelerId;
+    private String travelerName;
+    private String departureAddress;
+    private String destination;
+    private LocalDateTime departureTime;
+    private LocalDateTime arrivalTime;
+    private BigDecimal maxWeight;
+    private BigDecimal pricePerKilo;
+    private boolean instantAcceptance;
+    private Trip.TripStatus status;
+
+    /**
+     * Maps a {@link Trip} entity to a {@link TripResponse} DTO.
+     */
+    public static TripResponse from(Trip trip) {
+        return TripResponse.builder()
+                .id(trip.getId())
+                .travelerId(trip.getTraveler().getId())
+                .travelerName(trip.getTraveler().getFirstName() + " " + trip.getTraveler().getLastName())
+                .departureAddress(trip.getDepartureAddress())
+                .destination(trip.getDestination())
+                .departureTime(trip.getDepartureTime())
+                .arrivalTime(trip.getArrivalTime())
+                .maxWeight(trip.getMaxWeight())
+                .pricePerKilo(trip.getPricePerKilo())
+                .instantAcceptance(trip.isInstantAcceptance())
+                .status(trip.getStatus())
+                .build();
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/dto/UpdateTripRequest.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/dto/UpdateTripRequest.java
@@ -1,0 +1,31 @@
+package com.colick.backoffice.trip.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Request body for updating an existing trip.
+ * All fields are optional — only non-null values are applied.
+ */
+@Data
+public class UpdateTripRequest {
+
+    private String departureAddress;
+
+    private String destination;
+
+    private LocalDateTime departureTime;
+
+    private LocalDateTime arrivalTime;
+
+    @DecimalMin(value = "0.1", message = "Max weight must be greater than 0")
+    private BigDecimal maxWeight;
+
+    @DecimalMin(value = "0.01", message = "Price per kilo must be greater than 0")
+    private BigDecimal pricePerKilo;
+
+    private Boolean instantAcceptance;
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/entity/Trip.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/entity/Trip.java
@@ -1,0 +1,66 @@
+package com.colick.backoffice.trip.entity;
+
+import com.colick.backoffice.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Represents a trip published by a traveler who offers to carry parcels.
+ */
+@Entity
+@Table(name = "trips")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Trip {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User traveler;
+
+    @Column(nullable = false)
+    private String departureAddress;
+
+    @Column(nullable = false)
+    private String destination;
+
+    @Column(nullable = false)
+    private LocalDateTime departureTime;
+
+    @Column(nullable = false)
+    private LocalDateTime arrivalTime;
+
+    /** Maximum weight (in kg) the traveler is willing to carry. */
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal maxWeight;
+
+    /** Price per kilogram in the platform's currency. */
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal pricePerKilo;
+
+    /**
+     * When true, booking requests are automatically accepted.
+     * When false, the traveler must manually approve each request.
+     */
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean instantAcceptance = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private TripStatus status = TripStatus.ACTIVE;
+
+    public enum TripStatus {
+        ACTIVE, CANCELLED
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/entity/TripBooking.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/entity/TripBooking.java
@@ -1,0 +1,52 @@
+package com.colick.backoffice.trip.entity;
+
+import com.colick.backoffice.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+/**
+ * Represents a booking request made by a sender for a specific trip.
+ */
+@Entity
+@Table(name = "trip_bookings")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TripBooking {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    /** Weight of the parcel in kg (optional). */
+    @Column(precision = 10, scale = 2)
+    private BigDecimal weight;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    /** Optional URL to the parcel photo. */
+    @Column
+    private String packagePhotoUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private BookingStatus status = BookingStatus.PENDING;
+
+    public enum BookingStatus {
+        PENDING, ACCEPTED, REJECTED
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/repository/TripBookingRepository.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/repository/TripBookingRepository.java
@@ -1,0 +1,19 @@
+package com.colick.backoffice.trip.repository;
+
+import com.colick.backoffice.trip.entity.Trip;
+import com.colick.backoffice.trip.entity.TripBooking;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * JPA repository for {@link TripBooking} entities.
+ */
+@Repository
+public interface TripBookingRepository extends JpaRepository<TripBooking, Long> {
+
+    List<TripBooking> findByTrip(Trip trip);
+
+    List<TripBooking> findByTripAndStatus(Trip trip, TripBooking.BookingStatus status);
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/repository/TripRepository.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/repository/TripRepository.java
@@ -1,0 +1,16 @@
+package com.colick.backoffice.trip.repository;
+
+import com.colick.backoffice.trip.entity.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * JPA repository for {@link Trip} entities.
+ */
+@Repository
+public interface TripRepository extends JpaRepository<Trip, Long> {
+
+    List<Trip> findByStatus(Trip.TripStatus status);
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripService.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripService.java
@@ -1,0 +1,42 @@
+package com.colick.backoffice.trip.service;
+
+import com.colick.backoffice.trip.dto.*;
+import com.colick.backoffice.user.entity.User;
+
+import java.util.List;
+
+/**
+ * Service interface for trip and booking management operations.
+ */
+public interface TripService {
+
+    /** Publishes a new trip for the given traveler. */
+    TripResponse createTrip(CreateTripRequest request, User traveler);
+
+    /** Returns all active trips. */
+    List<TripResponse> getAllTrips();
+
+    /** Returns a single trip by ID. */
+    TripResponse getTripById(Long id);
+
+    /** Updates an existing trip. */
+    TripResponse updateTrip(Long id, UpdateTripRequest request, User requester);
+
+    /** Cancels (soft-deletes) a trip. */
+    void deleteTrip(Long id, User requester);
+
+    /** Returns all booking requests for a trip. */
+    List<TripBookingResponse> getBookings(Long tripId);
+
+    /** Submits a booking request on a trip. */
+    TripBookingResponse createBooking(Long tripId, CreateBookingRequest request, User sender);
+
+    /** Accepts a booking request (sends email notification). */
+    TripBookingResponse acceptBooking(Long tripId, Long bookingId, User requester);
+
+    /** Rejects a booking request (sends email notification). */
+    TripBookingResponse rejectBooking(Long tripId, Long bookingId, User requester);
+
+    /** Removes a booking request from the list (sends email notification). */
+    void removeBooking(Long tripId, Long bookingId, User requester);
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
@@ -1,0 +1,213 @@
+package com.colick.backoffice.trip.service;
+
+import com.colick.backoffice.email.EmailService;
+import com.colick.backoffice.exception.ResourceNotFoundException;
+import com.colick.backoffice.trip.dto.*;
+import com.colick.backoffice.trip.entity.Trip;
+import com.colick.backoffice.trip.entity.TripBooking;
+import com.colick.backoffice.trip.repository.TripBookingRepository;
+import com.colick.backoffice.trip.repository.TripRepository;
+import com.colick.backoffice.user.entity.User;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Implementation of {@link TripService}.
+ */
+@Service
+@Transactional
+public class TripServiceImpl implements TripService {
+
+    private final TripRepository tripRepository;
+    private final TripBookingRepository bookingRepository;
+    private final EmailService emailService;
+
+    public TripServiceImpl(TripRepository tripRepository,
+                           TripBookingRepository bookingRepository,
+                           EmailService emailService) {
+        this.tripRepository = tripRepository;
+        this.bookingRepository = bookingRepository;
+        this.emailService = emailService;
+    }
+
+    @Override
+    public TripResponse createTrip(CreateTripRequest request, User traveler) {
+        Trip trip = Trip.builder()
+                .traveler(traveler)
+                .departureAddress(request.getDepartureAddress())
+                .destination(request.getDestination())
+                .departureTime(request.getDepartureTime())
+                .arrivalTime(request.getArrivalTime())
+                .maxWeight(request.getMaxWeight())
+                .pricePerKilo(request.getPricePerKilo())
+                .instantAcceptance(request.isInstantAcceptance())
+                .build();
+        return TripResponse.from(tripRepository.save(trip));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TripResponse> getAllTrips() {
+        return tripRepository.findByStatus(Trip.TripStatus.ACTIVE).stream()
+                .map(TripResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public TripResponse getTripById(Long id) {
+        return TripResponse.from(findTripOrThrow(id));
+    }
+
+    @Override
+    public TripResponse updateTrip(Long id, UpdateTripRequest request, User requester) {
+        Trip trip = findTripOrThrow(id);
+        assertTripOwner(trip, requester);
+
+        if (request.getDepartureAddress() != null) trip.setDepartureAddress(request.getDepartureAddress());
+        if (request.getDestination() != null) trip.setDestination(request.getDestination());
+        if (request.getDepartureTime() != null) trip.setDepartureTime(request.getDepartureTime());
+        if (request.getArrivalTime() != null) trip.setArrivalTime(request.getArrivalTime());
+        if (request.getMaxWeight() != null) trip.setMaxWeight(request.getMaxWeight());
+        if (request.getPricePerKilo() != null) trip.setPricePerKilo(request.getPricePerKilo());
+        if (request.getInstantAcceptance() != null) trip.setInstantAcceptance(request.getInstantAcceptance());
+
+        return TripResponse.from(tripRepository.save(trip));
+    }
+
+    @Override
+    public void deleteTrip(Long id, User requester) {
+        Trip trip = findTripOrThrow(id);
+        assertTripOwner(trip, requester);
+        trip.setStatus(Trip.TripStatus.CANCELLED);
+        tripRepository.save(trip);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TripBookingResponse> getBookings(Long tripId) {
+        Trip trip = findTripOrThrow(tripId);
+        return bookingRepository.findByTrip(trip).stream()
+                .map(TripBookingResponse::from)
+                .toList();
+    }
+
+    @Override
+    public TripBookingResponse createBooking(Long tripId, CreateBookingRequest request, User sender) {
+        Trip trip = findTripOrThrow(tripId);
+
+        TripBooking.BookingStatus initialStatus = trip.isInstantAcceptance()
+                ? TripBooking.BookingStatus.ACCEPTED
+                : TripBooking.BookingStatus.PENDING;
+
+        TripBooking booking = TripBooking.builder()
+                .trip(trip)
+                .sender(sender)
+                .weight(request.getWeight())
+                .description(request.getDescription())
+                .packagePhotoUrl(request.getPackagePhotoUrl())
+                .status(initialStatus)
+                .build();
+
+        TripBooking saved = bookingRepository.save(booking);
+
+        // Notify the traveler about the new booking request
+        emailService.sendEmail(
+                trip.getTraveler().getEmail(),
+                "Nouvelle demande de transport — Colick",
+                String.format(
+                        "Bonjour %s,%n%nUne nouvelle demande a été soumise pour votre trajet %s → %s.%n%nConnectez-vous à Colick pour la traiter.%n%nCordialement,%nL'équipe Colick",
+                        trip.getTraveler().getFirstName(),
+                        trip.getDepartureAddress(),
+                        trip.getDestination()
+                )
+        );
+
+        return TripBookingResponse.from(saved);
+    }
+
+    @Override
+    public TripBookingResponse acceptBooking(Long tripId, Long bookingId, User requester) {
+        TripBooking booking = findBookingOrThrow(tripId, bookingId);
+        assertTripOwner(booking.getTrip(), requester);
+
+        booking.setStatus(TripBooking.BookingStatus.ACCEPTED);
+        TripBooking saved = bookingRepository.save(booking);
+
+        emailService.sendEmail(
+                booking.getSender().getEmail(),
+                "Votre demande a été acceptée — Colick",
+                String.format(
+                        "Bonjour %s,%n%nVotre demande pour le trajet %s → %s a été acceptée.%n%nCordialement,%nL'équipe Colick",
+                        booking.getSender().getFirstName(),
+                        booking.getTrip().getDepartureAddress(),
+                        booking.getTrip().getDestination()
+                )
+        );
+
+        return TripBookingResponse.from(saved);
+    }
+
+    @Override
+    public TripBookingResponse rejectBooking(Long tripId, Long bookingId, User requester) {
+        TripBooking booking = findBookingOrThrow(tripId, bookingId);
+        assertTripOwner(booking.getTrip(), requester);
+
+        booking.setStatus(TripBooking.BookingStatus.REJECTED);
+        TripBooking saved = bookingRepository.save(booking);
+
+        emailService.sendEmail(
+                booking.getSender().getEmail(),
+                "Votre demande a été refusée — Colick",
+                String.format(
+                        "Bonjour %s,%n%nNous sommes désolés, votre demande pour le trajet %s → %s a été refusée.%n%nCordialement,%nL'équipe Colick",
+                        booking.getSender().getFirstName(),
+                        booking.getTrip().getDepartureAddress(),
+                        booking.getTrip().getDestination()
+                )
+        );
+
+        return TripBookingResponse.from(saved);
+    }
+
+    @Override
+    public void removeBooking(Long tripId, Long bookingId, User requester) {
+        TripBooking booking = findBookingOrThrow(tripId, bookingId);
+        assertTripOwner(booking.getTrip(), requester);
+
+        emailService.sendEmail(
+                booking.getSender().getEmail(),
+                "Vous avez été retiré d'un trajet — Colick",
+                String.format(
+                        "Bonjour %s,%n%nVous avez été retiré de la liste pour le trajet %s → %s.%n%nCordialement,%nL'équipe Colick",
+                        booking.getSender().getFirstName(),
+                        booking.getTrip().getDepartureAddress(),
+                        booking.getTrip().getDestination()
+                )
+        );
+
+        bookingRepository.delete(booking);
+    }
+
+    private Trip findTripOrThrow(Long id) {
+        return tripRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Trip not found with id: " + id));
+    }
+
+    private TripBooking findBookingOrThrow(Long tripId, Long bookingId) {
+        findTripOrThrow(tripId); // ensure trip exists
+        return bookingRepository.findById(bookingId)
+                .filter(b -> b.getTrip().getId().equals(tripId))
+                .orElseThrow(() -> new ResourceNotFoundException("Booking not found with id: " + bookingId));
+    }
+
+    private void assertTripOwner(Trip trip, User requester) {
+        if (!trip.getTraveler().getId().equals(requester.getId())
+                && requester.getRole() != User.Role.ADMIN) {
+            throw new AccessDeniedException("You are not the owner of this trip");
+        }
+    }
+}

--- a/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
@@ -1,0 +1,242 @@
+package com.colick.backoffice.trip;
+
+import com.colick.backoffice.email.EmailService;
+import com.colick.backoffice.exception.ResourceNotFoundException;
+import com.colick.backoffice.trip.dto.*;
+import com.colick.backoffice.trip.entity.Trip;
+import com.colick.backoffice.trip.entity.TripBooking;
+import com.colick.backoffice.trip.repository.TripBookingRepository;
+import com.colick.backoffice.trip.repository.TripRepository;
+import com.colick.backoffice.trip.service.TripServiceImpl;
+import com.colick.backoffice.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TripServiceImplTest {
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @Mock
+    private TripBookingRepository bookingRepository;
+
+    @Mock
+    private EmailService emailService;
+
+    @InjectMocks
+    private TripServiceImpl tripService;
+
+    private User traveler;
+    private User sender;
+    private Trip sampleTrip;
+
+    @BeforeEach
+    void setUp() {
+        traveler = User.builder()
+                .id(1L)
+                .firstName("Alice")
+                .lastName("Dupont")
+                .email("alice@example.com")
+                .role(User.Role.USER)
+                .build();
+
+        sender = User.builder()
+                .id(2L)
+                .firstName("Bob")
+                .lastName("Martin")
+                .email("bob@example.com")
+                .role(User.Role.USER)
+                .build();
+
+        sampleTrip = Trip.builder()
+                .id(10L)
+                .traveler(traveler)
+                .departureAddress("Paris")
+                .destination("Abidjan")
+                .departureTime(LocalDateTime.now().plusDays(5))
+                .arrivalTime(LocalDateTime.now().plusDays(6))
+                .maxWeight(BigDecimal.valueOf(20))
+                .pricePerKilo(BigDecimal.valueOf(5))
+                .instantAcceptance(false)
+                .status(Trip.TripStatus.ACTIVE)
+                .build();
+    }
+
+    @Test
+    void createTrip_shouldSaveAndReturnResponse() {
+        CreateTripRequest request = new CreateTripRequest();
+        request.setDepartureAddress("Paris");
+        request.setDestination("Abidjan");
+        request.setDepartureTime(LocalDateTime.now().plusDays(5));
+        request.setArrivalTime(LocalDateTime.now().plusDays(6));
+        request.setMaxWeight(BigDecimal.valueOf(20));
+        request.setPricePerKilo(BigDecimal.valueOf(5));
+
+        when(tripRepository.save(any(Trip.class))).thenReturn(sampleTrip);
+
+        TripResponse response = tripService.createTrip(request, traveler);
+
+        assertThat(response.getDepartureAddress()).isEqualTo("Paris");
+        assertThat(response.getDestination()).isEqualTo("Abidjan");
+        verify(tripRepository).save(any(Trip.class));
+    }
+
+    @Test
+    void getAllTrips_shouldReturnActiveTrips() {
+        when(tripRepository.findByStatus(Trip.TripStatus.ACTIVE)).thenReturn(List.of(sampleTrip));
+
+        List<TripResponse> trips = tripService.getAllTrips();
+
+        assertThat(trips).hasSize(1);
+        assertThat(trips.get(0).getId()).isEqualTo(10L);
+    }
+
+    @Test
+    void getTripById_shouldReturnTrip_whenFound() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+
+        TripResponse response = tripService.getTripById(10L);
+
+        assertThat(response.getId()).isEqualTo(10L);
+    }
+
+    @Test
+    void getTripById_shouldThrow_whenNotFound() {
+        when(tripRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tripService.getTripById(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void deleteTrip_shouldCancelTrip_whenOwner() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(tripRepository.save(any(Trip.class))).thenReturn(sampleTrip);
+
+        tripService.deleteTrip(10L, traveler);
+
+        assertThat(sampleTrip.getStatus()).isEqualTo(Trip.TripStatus.CANCELLED);
+        verify(tripRepository).save(sampleTrip);
+    }
+
+    @Test
+    void deleteTrip_shouldThrow_whenNotOwner() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+
+        assertThatThrownBy(() -> tripService.deleteTrip(10L, sender))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void createBooking_shouldSaveWithPendingStatus_whenNotInstantAcceptance() {
+        CreateBookingRequest request = new CreateBookingRequest();
+        request.setWeight(BigDecimal.valueOf(5));
+        request.setDescription("Fragile items");
+
+        TripBooking savedBooking = TripBooking.builder()
+                .id(1L)
+                .trip(sampleTrip)
+                .sender(sender)
+                .weight(BigDecimal.valueOf(5))
+                .description("Fragile items")
+                .status(TripBooking.BookingStatus.PENDING)
+                .build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.save(any(TripBooking.class))).thenReturn(savedBooking);
+        doNothing().when(emailService).sendEmail(anyString(), anyString(), anyString());
+
+        TripBookingResponse response = tripService.createBooking(10L, request, sender);
+
+        assertThat(response.getStatus()).isEqualTo(TripBooking.BookingStatus.PENDING);
+        verify(emailService).sendEmail(eq(traveler.getEmail()), anyString(), anyString());
+    }
+
+    @Test
+    void createBooking_shouldSaveWithAcceptedStatus_whenInstantAcceptance() {
+        sampleTrip.setInstantAcceptance(true);
+
+        CreateBookingRequest request = new CreateBookingRequest();
+
+        TripBooking savedBooking = TripBooking.builder()
+                .id(2L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.ACCEPTED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.save(any(TripBooking.class))).thenReturn(savedBooking);
+        doNothing().when(emailService).sendEmail(anyString(), anyString(), anyString());
+
+        TripBookingResponse response = tripService.createBooking(10L, request, sender);
+
+        assertThat(response.getStatus()).isEqualTo(TripBooking.BookingStatus.ACCEPTED);
+    }
+
+    @Test
+    void acceptBooking_shouldSetAcceptedAndSendEmail() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.PENDING).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+        when(bookingRepository.save(any())).thenReturn(booking);
+        doNothing().when(emailService).sendEmail(anyString(), anyString(), anyString());
+
+        TripBookingResponse response = tripService.acceptBooking(10L, 1L, traveler);
+
+        assertThat(booking.getStatus()).isEqualTo(TripBooking.BookingStatus.ACCEPTED);
+        verify(emailService).sendEmail(eq(sender.getEmail()), anyString(), anyString());
+    }
+
+    @Test
+    void rejectBooking_shouldSetRejectedAndSendEmail() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.PENDING).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+        when(bookingRepository.save(any())).thenReturn(booking);
+        doNothing().when(emailService).sendEmail(anyString(), anyString(), anyString());
+
+        tripService.rejectBooking(10L, 1L, traveler);
+
+        assertThat(booking.getStatus()).isEqualTo(TripBooking.BookingStatus.REJECTED);
+        verify(emailService).sendEmail(eq(sender.getEmail()), anyString(), anyString());
+    }
+
+    @Test
+    void removeBooking_shouldDeleteAndSendEmail() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.PENDING).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+        doNothing().when(emailService).sendEmail(anyString(), anyString(), anyString());
+        doNothing().when(bookingRepository).delete(booking);
+
+        tripService.removeBooking(10L, 1L, traveler);
+
+        verify(emailService).sendEmail(eq(sender.getEmail()), anyString(), anyString());
+        verify(bookingRepository).delete(booking);
+    }
+}


### PR DESCRIPTION
## Résolution de l'issue #3 — Gestion des trajets

> ⚠️ Cette PR dépend de la PR #7 (feat/2-user-management)

### Ce qui a été implémenté

**Entités**
- `Trip` : departureAddress, destination, departureTime, arrivalTime, maxWeight, pricePerKilo, instantAcceptance, status
- `TripBooking` : trip, sender, weight, description, packagePhotoUrl, status (PENDING / ACCEPTED / REJECTED)

**Endpoints**

| Méthode | URL | Description |
|---|---|---|
| `POST` | `/api/trips` | Publier un trajet |
| `GET` | `/api/trips` | Lister les trajets actifs |
| `GET` | `/api/trips/{id}` | Détail d'un trajet |
| `PUT` | `/api/trips/{id}` | Modifier un trajet (propriétaire/admin) |
| `DELETE` | `/api/trips/{id}` | Annuler un trajet (propriétaire/admin) |
| `GET` | `/api/trips/{id}/bookings` | Lister les demandes |
| `POST` | `/api/trips/{id}/bookings` | Soumettre une demande |
| `PUT` | `/api/trips/{id}/bookings/{bookingId}/accept` | Accepter une demande + email |
| `PUT` | `/api/trips/{id}/bookings/{bookingId}/reject` | Refuser une demande + email |
| `DELETE` | `/api/trips/{id}/bookings/{bookingId}` | Retirer un utilisateur + email |

**Logique métier**
- Acceptation instantanée : si `instantAcceptance=true`, le booking passe directement en `ACCEPTED`
- Sécurité : seul le propriétaire du trajet (ou un ADMIN) peut accepter, refuser ou retirer
- Emails : MailHog (port 1025/8025) pour les notifications

**Services**
- `EmailService` : envoi de mails transactionnels via Spring Mail
- `TripServiceImpl` : toute la logique métier testée avec Mockito

**Tests** : 11 tests unitaires `TripServiceImplTest`

### Closes #3