### PR TITLE
feat: add Swagger UI / OpenAPI documentation

### DIFF
--- a/back-office/pom.xml
+++ b/back-office/pom.xml
@@ -83,6 +83,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- SpringDoc OpenAPI / Swagger UI -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.6</version>
+		</dependency>
+
 		<!-- JWT -->
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>

--- a/back-office/src/main/java/com/colick/backoffice/config/OpenApiConfig.java
+++ b/back-office/src/main/java/com/colick/backoffice/config/OpenApiConfig.java
@@ -1,0 +1,36 @@
+package com.colick.backoffice.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * OpenAPI / Swagger UI configuration.
+ * Accessible at: http://localhost:8080/api/swagger-ui.html
+ */
+@Configuration
+public class OpenApiConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI colickOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Colick API")
+                        .description("REST API for the Colick parcel transport platform")
+                        .version("1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .name(SECURITY_SCHEME_NAME)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/config/SecurityConfig.java
+++ b/back-office/src/main/java/com/colick/backoffice/config/SecurityConfig.java
@@ -31,10 +31,13 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                 .requestMatchers("/auth/**").permitAll()
-                .requestMatchers("/users").permitAll()  // registration is public
+                .requestMatchers("/users").permitAll()
                 .requestMatchers(
-                    "/swagger-ui.html", "/swagger-ui/**",
-                    "/v3/api-docs", "/v3/api-docs/**"
+                    "/swagger-ui.html",
+                    "/swagger-ui/**",
+                    "/v3/api-docs",
+                    "/v3/api-docs/**",
+                    "/v3/api-docs.yaml"
                 ).permitAll()
                 .anyRequest().authenticated()
             )

--- a/back-office/src/main/java/com/colick/backoffice/config/SecurityConfig.java
+++ b/back-office/src/main/java/com/colick/backoffice/config/SecurityConfig.java
@@ -32,6 +32,10 @@ public class SecurityConfig {
                 .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                 .requestMatchers("/auth/**").permitAll()
                 .requestMatchers("/users").permitAll()  // registration is public
+                .requestMatchers(
+                    "/swagger-ui.html", "/swagger-ui/**",
+                    "/v3/api-docs", "/v3/api-docs/**"
+                ).permitAll()
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);

--- a/back-office/src/main/java/com/colick/backoffice/exception/GlobalExceptionHandler.java
+++ b/back-office/src/main/java/com/colick/backoffice/exception/GlobalExceptionHandler.java
@@ -1,17 +1,22 @@
 package com.colick.backoffice.exception;
 
 import com.colick.backoffice.exception.UserAlreadyExistsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex) {
@@ -44,8 +49,22 @@ public class GlobalExceptionHandler {
                 .body(new ApiError(HttpStatus.FORBIDDEN.value(), ex.getMessage()));
     }
 
+    /**
+     * Handles Spring MVC exceptions (NoResourceFoundException, MethodNotAllowedException, etc.)
+     * and returns the correct HTTP status code instead of masking them as 500.
+     */
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ApiError> handleResponseStatus(ResponseStatusException ex) {
+        int code = ex.getStatusCode().value();
+        String message = ex.getReason() != null ? ex.getReason() : ex.getMessage();
+        return ResponseEntity
+                .status(ex.getStatusCode())
+                .body(new ApiError(code, message));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiError> handleGeneric(Exception ex) {
+        log.error("Unexpected error: {}", ex.getMessage(), ex);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ApiError(HttpStatus.INTERNAL_SERVER_ERROR.value(), "An unexpected error occurred"));

--- a/back-office/src/main/resources/application.yml
+++ b/back-office/src/main/resources/application.yml
@@ -50,5 +50,7 @@ jwt:
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
+    disable-swagger-default-url: true
   api-docs:
     path: /v3/api-docs
+  show-actuator: false

--- a/back-office/src/main/resources/application.yml
+++ b/back-office/src/main/resources/application.yml
@@ -46,3 +46,9 @@ management:
 jwt:
   secret: ${JWT_SECRET:colick-super-secret-key-must-be-at-least-32-chars}
   expiration-ms: ${JWT_EXPIRATION_MS:86400000}
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs


### PR DESCRIPTION
## Swagger UI

Ajoute la documentation interactive OpenAPI/Swagger à l'API Colick.

### Dépendance ajoutée
- `springdoc-openapi-starter-webmvc-ui` v2.8.6

### Accès
| URL | Description |
|---|---|
| `http://localhost:8080/api/swagger-ui.html` | Interface Swagger UI |
| `http://localhost:8080/api/v3/api-docs` | Spec OpenAPI JSON |

### Authentification dans Swagger UI
1. Appeler `POST /api/auth/login` pour obtenir un token JWT
2. Cliquer sur **Authorize** 🔒 en haut à droite
3. Saisir le token (sans `Bearer `) et valider

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>