### PR TITLE
feat: add templated trip booking emails

### DIFF
--- a/back-office/src/main/java/com/colick/backoffice/email/EmailService.java
+++ b/back-office/src/main/java/com/colick/backoffice/email/EmailService.java
@@ -74,6 +74,76 @@ public class EmailService {
         );
     }
 
+            public void sendTripBookingCreatedEmail(String to,
+                                String travelerFirstName,
+                                String senderFirstName,
+                                String departureAddress,
+                                String destination) {
+            sendTemplateEmail(
+                to,
+                "Nouvelle demande de transport - Colick",
+                "email/trip-booking-created",
+                Map.of(
+                    "firstName", travelerFirstName,
+                    "senderFirstName", senderFirstName,
+                    "departureAddress", departureAddress,
+                    "destination", destination,
+                    "supportEmail", supportEmail
+                )
+            );
+            }
+
+            public void sendTripBookingAcceptedEmail(String to,
+                                 String senderFirstName,
+                                 String departureAddress,
+                                 String destination) {
+            sendTemplateEmail(
+                to,
+                "Votre demande a ete acceptee - Colick",
+                "email/trip-booking-accepted",
+                Map.of(
+                    "firstName", senderFirstName,
+                    "departureAddress", departureAddress,
+                    "destination", destination,
+                    "supportEmail", supportEmail
+                )
+            );
+            }
+
+            public void sendTripBookingRejectedEmail(String to,
+                                 String senderFirstName,
+                                 String departureAddress,
+                                 String destination) {
+            sendTemplateEmail(
+                to,
+                "Votre demande a ete refusee - Colick",
+                "email/trip-booking-rejected",
+                Map.of(
+                    "firstName", senderFirstName,
+                    "departureAddress", departureAddress,
+                    "destination", destination,
+                    "supportEmail", supportEmail
+                )
+            );
+            }
+
+            public void sendTripBookingRemovedEmail(String to,
+                                String senderFirstName,
+                                String departureAddress,
+                                String destination) {
+            sendTemplateEmail(
+                to,
+                "Vous avez ete retire d'un trajet - Colick",
+                "email/trip-booking-removed",
+                Map.of(
+                    "firstName", senderFirstName,
+                    "departureAddress", departureAddress,
+                    "destination", destination,
+                    "supportEmail", supportEmail
+                )
+            );
+            }
+
     private void sendTemplateEmail(String to, String subject, String templateName, Map<String, Object> variables) {
         Context context = new Context();
         variables.forEach(context::setVariable);

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
@@ -132,16 +132,12 @@ public class TripServiceImpl implements TripService {
 
         TripBooking saved = bookingRepository.save(booking);
 
-        // Notify the traveler about the new booking request
-        emailService.sendEmail(
-                trip.getTraveler().getEmail(),
-                "Nouvelle demande de transport — Colick",
-                String.format(
-                        "Bonjour %s,%n%nUne nouvelle demande a été soumise pour votre trajet %s → %s.%n%nConnectez-vous à Colick pour la traiter.%n%nCordialement,%nL'équipe Colick",
-                        trip.getTraveler().getFirstName(),
-                        trip.getDepartureAddress(),
-                        trip.getDestination()
-                )
+        emailService.sendTripBookingCreatedEmail(
+            trip.getTraveler().getEmail(),
+            trip.getTraveler().getFirstName(),
+            sender.getFirstName(),
+            trip.getDepartureAddress(),
+            trip.getDestination()
         );
 
         return TripBookingResponse.from(saved);
@@ -155,15 +151,11 @@ public class TripServiceImpl implements TripService {
         booking.setStatus(TripBooking.BookingStatus.ACCEPTED);
         TripBooking saved = bookingRepository.save(booking);
 
-        emailService.sendEmail(
-                booking.getSender().getEmail(),
-                "Votre demande a été acceptée — Colick",
-                String.format(
-                        "Bonjour %s,%n%nVotre demande pour le trajet %s → %s a été acceptée.%n%nCordialement,%nL'équipe Colick",
-                        booking.getSender().getFirstName(),
-                        booking.getTrip().getDepartureAddress(),
-                        booking.getTrip().getDestination()
-                )
+        emailService.sendTripBookingAcceptedEmail(
+            booking.getSender().getEmail(),
+            booking.getSender().getFirstName(),
+            booking.getTrip().getDepartureAddress(),
+            booking.getTrip().getDestination()
         );
 
         return TripBookingResponse.from(saved);
@@ -177,15 +169,11 @@ public class TripServiceImpl implements TripService {
         booking.setStatus(TripBooking.BookingStatus.REJECTED);
         TripBooking saved = bookingRepository.save(booking);
 
-        emailService.sendEmail(
-                booking.getSender().getEmail(),
-                "Votre demande a été refusée — Colick",
-                String.format(
-                        "Bonjour %s,%n%nNous sommes désolés, votre demande pour le trajet %s → %s a été refusée.%n%nCordialement,%nL'équipe Colick",
-                        booking.getSender().getFirstName(),
-                        booking.getTrip().getDepartureAddress(),
-                        booking.getTrip().getDestination()
-                )
+        emailService.sendTripBookingRejectedEmail(
+            booking.getSender().getEmail(),
+            booking.getSender().getFirstName(),
+            booking.getTrip().getDepartureAddress(),
+            booking.getTrip().getDestination()
         );
 
         return TripBookingResponse.from(saved);
@@ -196,15 +184,11 @@ public class TripServiceImpl implements TripService {
         TripBooking booking = findBookingOrThrow(tripId, bookingId);
         assertTripOwner(booking.getTrip(), requester);
 
-        emailService.sendEmail(
-                booking.getSender().getEmail(),
-                "Vous avez été retiré d'un trajet — Colick",
-                String.format(
-                        "Bonjour %s,%n%nVous avez été retiré de la liste pour le trajet %s → %s.%n%nCordialement,%nL'équipe Colick",
-                        booking.getSender().getFirstName(),
-                        booking.getTrip().getDepartureAddress(),
-                        booking.getTrip().getDestination()
-                )
+        emailService.sendTripBookingRemovedEmail(
+            booking.getSender().getEmail(),
+            booking.getSender().getFirstName(),
+            booking.getTrip().getDepartureAddress(),
+            booking.getTrip().getDestination()
         );
 
         bookingRepository.delete(booking);

--- a/back-office/src/main/resources/templates/email/trip-booking-accepted.html
+++ b/back-office/src/main/resources/templates/email/trip-booking-accepted.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Demande acceptee Colick</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f5f5f5;font-family:Poppins,Arial,sans-serif;color:#111827;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5;padding:24px 0;">
+    <tr>
+        <td align="center">
+            <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:16px;overflow:hidden;">
+                <tr>
+                    <td style="background:#023047;padding:20px 24px;color:#ffffff;font-size:20px;font-weight:700;">
+                        Colick
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:28px 24px;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Bonjour <span th:text="${firstName}">Utilisateur</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            Votre demande pour le trajet <strong th:text="${departureAddress}">Paris</strong> vers
+                            <strong th:text="${destination}">Abidjan</strong> a ete acceptee.
+                        </p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;background:#F9FAFB;border-left:4px solid #fb8500;padding:12px 16px;border-radius:10px;">
+                            Vous pouvez maintenant poursuivre les echanges avec le voyageur depuis Colick.
+                        </p>
+                        <hr style="border:none;border-top:1px solid #e5e7eb;margin:20px 0;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Hello <span th:text="${firstName}">User</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            Your request for the trip <strong th:text="${departureAddress}">Paris</strong> to
+                            <strong th:text="${destination}">Abidjan</strong> has been accepted.
+                        </p>
+                        <p style="margin:0;line-height:1.6;color:#6B7280;">
+                            You can now continue the discussion with the traveler on Colick.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="background:#F9FAFB;padding:16px 24px;font-size:12px;color:#6B7280;">
+                        Besoin d'aide / Need help? <span style="color:#219ebc;" th:text="${supportEmail}">support@colick.app</span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/back-office/src/main/resources/templates/email/trip-booking-created.html
+++ b/back-office/src/main/resources/templates/email/trip-booking-created.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nouvelle demande de transport Colick</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f5f5f5;font-family:Poppins,Arial,sans-serif;color:#111827;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5;padding:24px 0;">
+    <tr>
+        <td align="center">
+            <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:16px;overflow:hidden;">
+                <tr>
+                    <td style="background:#023047;padding:20px 24px;color:#ffffff;font-size:20px;font-weight:700;">
+                        Colick
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:28px 24px;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Bonjour <span th:text="${firstName}">Utilisateur</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            <span th:text="${senderFirstName}">Un utilisateur</span> vous a envoye une nouvelle demande de transport pour le trajet
+                            <strong th:text="${departureAddress}">Paris</strong> vers <strong th:text="${destination}">Abidjan</strong>.
+                        </p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;background:#F9FAFB;border-left:4px solid #219ebc;padding:12px 16px;border-radius:10px;">
+                            Connectez-vous a Colick pour consulter cette demande et y repondre rapidement.
+                        </p>
+                        <hr style="border:none;border-top:1px solid #e5e7eb;margin:20px 0;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Hello <span th:text="${firstName}">User</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            <span th:text="${senderFirstName}">A user</span> sent you a new booking request for the trip
+                            <strong th:text="${departureAddress}">Paris</strong> to <strong th:text="${destination}">Abidjan</strong>.
+                        </p>
+                        <p style="margin:0;line-height:1.6;color:#6B7280;">
+                            Sign in to Colick to review the request and answer quickly.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="background:#F9FAFB;padding:16px 24px;font-size:12px;color:#6B7280;">
+                        Besoin d'aide / Need help? <span style="color:#219ebc;" th:text="${supportEmail}">support@colick.app</span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/back-office/src/main/resources/templates/email/trip-booking-rejected.html
+++ b/back-office/src/main/resources/templates/email/trip-booking-rejected.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Demande refusee Colick</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f5f5f5;font-family:Poppins,Arial,sans-serif;color:#111827;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5;padding:24px 0;">
+    <tr>
+        <td align="center">
+            <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:16px;overflow:hidden;">
+                <tr>
+                    <td style="background:#023047;padding:20px 24px;color:#ffffff;font-size:20px;font-weight:700;">
+                        Colick
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:28px 24px;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Bonjour <span th:text="${firstName}">Utilisateur</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            Nous sommes desoles, votre demande pour le trajet <strong th:text="${departureAddress}">Paris</strong> vers
+                            <strong th:text="${destination}">Abidjan</strong> a ete refusee.
+                        </p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;background:#F9FAFB;border-left:4px solid #219ebc;padding:12px 16px;border-radius:10px;">
+                            Vous pouvez relancer une recherche pour trouver un autre voyage correspondant a votre besoin.
+                        </p>
+                        <hr style="border:none;border-top:1px solid #e5e7eb;margin:20px 0;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Hello <span th:text="${firstName}">User</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            We are sorry, your request for the trip <strong th:text="${departureAddress}">Paris</strong> to
+                            <strong th:text="${destination}">Abidjan</strong> has been rejected.
+                        </p>
+                        <p style="margin:0;line-height:1.6;color:#6B7280;">
+                            You can search again to find another available traveler.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="background:#F9FAFB;padding:16px 24px;font-size:12px;color:#6B7280;">
+                        Besoin d'aide / Need help? <span style="color:#219ebc;" th:text="${supportEmail}">support@colick.app</span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/back-office/src/main/resources/templates/email/trip-booking-removed.html
+++ b/back-office/src/main/resources/templates/email/trip-booking-removed.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Retrait d'un trajet Colick</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f5f5f5;font-family:Poppins,Arial,sans-serif;color:#111827;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5;padding:24px 0;">
+    <tr>
+        <td align="center">
+            <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:16px;overflow:hidden;">
+                <tr>
+                    <td style="background:#023047;padding:20px 24px;color:#ffffff;font-size:20px;font-weight:700;">
+                        Colick
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:28px 24px;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Bonjour <span th:text="${firstName}">Utilisateur</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            Vous avez ete retire de la liste pour le trajet <strong th:text="${departureAddress}">Paris</strong> vers
+                            <strong th:text="${destination}">Abidjan</strong>.
+                        </p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;background:#F9FAFB;border-left:4px solid #fb8500;padding:12px 16px;border-radius:10px;">
+                            Si besoin, vous pouvez relancer votre recherche directement depuis Colick.
+                        </p>
+                        <hr style="border:none;border-top:1px solid #e5e7eb;margin:20px 0;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Hello <span th:text="${firstName}">User</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            You have been removed from the list for the trip <strong th:text="${departureAddress}">Paris</strong> to
+                            <strong th:text="${destination}">Abidjan</strong>.
+                        </p>
+                        <p style="margin:0;line-height:1.6;color:#6B7280;">
+                            If needed, you can launch a new search directly from Colick.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="background:#F9FAFB;padding:16px 24px;font-size:12px;color:#6B7280;">
+                        Besoin d'aide / Need help? <span style="color:#219ebc;" th:text="${supportEmail}">support@colick.app</span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
@@ -173,14 +173,20 @@ class TripServiceImplTest {
         when(bookingRepository.findByTripAndStatus(sampleTrip, TripBooking.BookingStatus.ACCEPTED))
                 .thenReturn(List.of());
         when(bookingRepository.save(any(TripBooking.class))).thenReturn(savedBooking);
-        doNothing().when(emailService).sendEmail(anyString(), anyString(), anyString());
+        doNothing().when(emailService).sendTripBookingCreatedEmail(anyString(), anyString(), anyString(), anyString(), anyString());
 
         TripBookingResponse response = tripService.createBooking(10L, request, sender);
 
         assertThat(response.getStatus()).isEqualTo(TripBooking.BookingStatus.PENDING);
         assertThat(response.getTitle()).isEqualTo("Electronics");
         assertThat(response.getRecipientContact()).isEqualTo("+225 07 00 00 00");
-        verify(emailService).sendEmail(eq(traveler.getEmail()), anyString(), anyString());
+        verify(emailService).sendTripBookingCreatedEmail(
+                eq(traveler.getEmail()),
+                eq(traveler.getFirstName()),
+                eq(sender.getFirstName()),
+                eq(sampleTrip.getDepartureAddress()),
+                eq(sampleTrip.getDestination())
+        );
     }
 
     @Test
@@ -203,7 +209,7 @@ class TripServiceImplTest {
         when(bookingRepository.findByTripAndStatus(sampleTrip, TripBooking.BookingStatus.ACCEPTED))
                 .thenReturn(List.of());
         when(bookingRepository.save(any(TripBooking.class))).thenReturn(savedBooking);
-        doNothing().when(emailService).sendEmail(anyString(), anyString(), anyString());
+        doNothing().when(emailService).sendTripBookingCreatedEmail(anyString(), anyString(), anyString(), anyString(), anyString());
 
         TripBookingResponse response = tripService.createBooking(10L, request, sender);
 
@@ -224,7 +230,7 @@ class TripServiceImplTest {
                                 .hasMessage("You cannot create a booking request for your own trip");
 
                 verify(bookingRepository, never()).save(any(TripBooking.class));
-                verify(emailService, never()).sendEmail(anyString(), anyString(), anyString());
+                verify(emailService, never()).sendTripBookingCreatedEmail(anyString(), anyString(), anyString(), anyString(), anyString());
         }
 
     @Test
@@ -236,12 +242,17 @@ class TripServiceImplTest {
         when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
         when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
         when(bookingRepository.save(any())).thenReturn(booking);
-        doNothing().when(emailService).sendEmail(anyString(), anyString(), anyString());
+        doNothing().when(emailService).sendTripBookingAcceptedEmail(anyString(), anyString(), anyString(), anyString());
 
         tripService.acceptBooking(10L, 1L, traveler);
 
         assertThat(booking.getStatus()).isEqualTo(TripBooking.BookingStatus.ACCEPTED);
-        verify(emailService).sendEmail(eq(sender.getEmail()), anyString(), anyString());
+        verify(emailService).sendTripBookingAcceptedEmail(
+                eq(sender.getEmail()),
+                eq(sender.getFirstName()),
+                eq(sampleTrip.getDepartureAddress()),
+                eq(sampleTrip.getDestination())
+        );
     }
 
     @Test
@@ -253,12 +264,17 @@ class TripServiceImplTest {
         when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
         when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
         when(bookingRepository.save(any())).thenReturn(booking);
-        doNothing().when(emailService).sendEmail(anyString(), anyString(), anyString());
+        doNothing().when(emailService).sendTripBookingRejectedEmail(anyString(), anyString(), anyString(), anyString());
 
         tripService.rejectBooking(10L, 1L, traveler);
 
         assertThat(booking.getStatus()).isEqualTo(TripBooking.BookingStatus.REJECTED);
-        verify(emailService).sendEmail(eq(sender.getEmail()), anyString(), anyString());
+        verify(emailService).sendTripBookingRejectedEmail(
+                eq(sender.getEmail()),
+                eq(sender.getFirstName()),
+                eq(sampleTrip.getDepartureAddress()),
+                eq(sampleTrip.getDestination())
+        );
     }
 
     @Test
@@ -269,12 +285,17 @@ class TripServiceImplTest {
 
         when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
         when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
-        doNothing().when(emailService).sendEmail(anyString(), anyString(), anyString());
+        doNothing().when(emailService).sendTripBookingRemovedEmail(anyString(), anyString(), anyString(), anyString());
         doNothing().when(bookingRepository).delete(booking);
 
         tripService.removeBooking(10L, 1L, traveler);
 
-        verify(emailService).sendEmail(eq(sender.getEmail()), anyString(), anyString());
+        verify(emailService).sendTripBookingRemovedEmail(
+                eq(sender.getEmail()),
+                eq(sender.getFirstName()),
+                eq(sampleTrip.getDepartureAddress()),
+                eq(sampleTrip.getDestination())
+        );
         verify(bookingRepository).delete(booking);
     }
 


### PR DESCRIPTION
## Summary
- replace plain text booking emails in TripServiceImpl with Thymeleaf templated emails
- add four branded Colick email templates for booking lifecycle notifications
- update TripServiceImplTest to verify dedicated EmailService template methods

## Testing
- ./mvnw -Dtest=TripServiceImplTest test

Closes #38