### PR TITLE
fix: prevent duplicate trip booking requests

### DIFF
--- a/back-office/src/main/java/com/colick/backoffice/exception/GlobalExceptionHandler.java
+++ b/back-office/src/main/java/com/colick/backoffice/exception/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.colick.backoffice.exception;
 
-import com.colick.backoffice.exception.UserAlreadyExistsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -35,8 +34,8 @@ public class GlobalExceptionHandler {
                 .body(new ApiError(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
     }
 
-    @ExceptionHandler(UserAlreadyExistsException.class)
-    public ResponseEntity<ApiError> handleConflict(UserAlreadyExistsException ex) {
+    @ExceptionHandler({UserAlreadyExistsException.class, TripBookingConflictException.class})
+    public ResponseEntity<ApiError> handleConflict(RuntimeException ex) {
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
                 .body(new ApiError(HttpStatus.CONFLICT.value(), ex.getMessage()));

--- a/back-office/src/main/java/com/colick/backoffice/exception/TripBookingConflictException.java
+++ b/back-office/src/main/java/com/colick/backoffice/exception/TripBookingConflictException.java
@@ -1,0 +1,11 @@
+package com.colick.backoffice.exception;
+
+/**
+ * Thrown when a sender tries to create more than one active booking for the same trip.
+ */
+public class TripBookingConflictException extends RuntimeException {
+
+    public TripBookingConflictException(String message) {
+        super(message);
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/repository/TripBookingRepository.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/repository/TripBookingRepository.java
@@ -18,6 +18,8 @@ public interface TripBookingRepository extends JpaRepository<TripBooking, Long> 
 
     List<TripBooking> findByTripAndStatus(Trip trip, TripBooking.BookingStatus status);
 
+    boolean existsByTripAndSenderAndStatusNot(Trip trip, User sender, TripBooking.BookingStatus status);
+
     /** Returns all booking requests submitted by the given user. */
     List<TripBooking> findBySender(User sender);
 }

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
@@ -1,6 +1,7 @@
 package com.colick.backoffice.trip.service;
 
 import com.colick.backoffice.email.EmailService;
+import com.colick.backoffice.exception.TripBookingConflictException;
 import com.colick.backoffice.exception.ResourceNotFoundException;
 import com.colick.backoffice.location.entity.LocationType;
 import com.colick.backoffice.location.repository.LocationRepository;
@@ -107,6 +108,14 @@ public class TripServiceImpl implements TripService {
 
         if (trip.getTraveler().getId().equals(sender.getId())) {
             throw new IllegalArgumentException("You cannot create a booking request for your own trip");
+        }
+
+        if (bookingRepository.existsByTripAndSenderAndStatusNot(
+                trip,
+                sender,
+                TripBooking.BookingStatus.REJECTED
+        )) {
+            throw new TripBookingConflictException("Vous avez deja une demande en cours pour ce trajet");
         }
 
         // Validate that the requested weight does not exceed the available weight

--- a/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
@@ -2,6 +2,7 @@ package com.colick.backoffice.trip;
 
 import com.colick.backoffice.email.EmailService;
 import com.colick.backoffice.exception.ResourceNotFoundException;
+import com.colick.backoffice.exception.TripBookingConflictException;
 import com.colick.backoffice.location.entity.LocationType;
 import com.colick.backoffice.location.repository.LocationRepository;
 import com.colick.backoffice.trip.dto.*;
@@ -214,6 +215,63 @@ class TripServiceImplTest {
         TripBookingResponse response = tripService.createBooking(10L, request, sender);
 
         assertThat(response.getStatus()).isEqualTo(TripBooking.BookingStatus.ACCEPTED);
+    }
+
+    @Test
+    void createBooking_shouldThrow_whenSenderAlreadyHasActiveBookingForTrip() {
+        CreateBookingRequest request = new CreateBookingRequest();
+        request.setTitle("Electronics");
+        request.setWeight(BigDecimal.valueOf(5));
+        request.setRecipientContact("+225 07 00 00 00");
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.existsByTripAndSenderAndStatusNot(
+                sampleTrip,
+                sender,
+                TripBooking.BookingStatus.REJECTED
+        )).thenReturn(true);
+
+        assertThatThrownBy(() -> tripService.createBooking(10L, request, sender))
+                .isInstanceOf(TripBookingConflictException.class)
+                .hasMessage("Vous avez deja une demande en cours pour ce trajet");
+
+        verify(bookingRepository, never()).save(any(TripBooking.class));
+        verify(emailService, never()).sendTripBookingCreatedEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void createBooking_shouldAllowNewRequest_whenPreviousBookingWasRejected() {
+        CreateBookingRequest request = new CreateBookingRequest();
+        request.setTitle("Electronics");
+        request.setWeight(BigDecimal.valueOf(5));
+        request.setRecipientContact("+225 07 00 00 00");
+
+        TripBooking savedBooking = TripBooking.builder()
+                .id(3L)
+                .trip(sampleTrip)
+                .sender(sender)
+                .title("Electronics")
+                .weight(BigDecimal.valueOf(5))
+                .recipientContact("+225 07 00 00 00")
+                .status(TripBooking.BookingStatus.PENDING)
+                .build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.existsByTripAndSenderAndStatusNot(
+                sampleTrip,
+                sender,
+                TripBooking.BookingStatus.REJECTED
+        )).thenReturn(false);
+        when(bookingRepository.findByTripAndStatus(sampleTrip, TripBooking.BookingStatus.ACCEPTED))
+                .thenReturn(List.of());
+        when(bookingRepository.save(any(TripBooking.class))).thenReturn(savedBooking);
+        doNothing().when(emailService).sendTripBookingCreatedEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+
+        TripBookingResponse response = tripService.createBooking(10L, request, sender);
+
+        assertThat(response.getId()).isEqualTo(3L);
+        assertThat(response.getStatus()).isEqualTo(TripBooking.BookingStatus.PENDING);
+        verify(bookingRepository).save(any(TripBooking.class));
     }
 
         @Test

--- a/front-office/src/app/pages/search/search-page.component.html
+++ b/front-office/src/app/pages/search/search-page.component.html
@@ -343,7 +343,7 @@
                       <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
                       </svg>
-                      Demande envoyee
+                      Demande envoyée
                     </span>
                   } @else {
                     <button

--- a/front-office/src/app/pages/search/search-page.component.html
+++ b/front-office/src/app/pages/search/search-page.component.html
@@ -338,17 +338,26 @@
               @if (!isOwnTrip(trip)) {
                 <div class="flex items-center gap-2">
                   <button type="button" class="inline-flex items-center gap-1.5 bg-secondary text-white font-semibold px-4 py-2.5 rounded-full text-sm hover:bg-secondary/90 transition-colors whitespace-nowrap" (click)="contactTraveler(trip)"><svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg>Contacter</button>
-                  <button
-                    type="button"
-                    (click)="openBookingModal(trip)"
-                    class="btn-primary !px-5 !py-2.5 !rounded-full !text-sm whitespace-nowrap"
-                    [attr.aria-label]="'Envoyer une demande pour le voyage vers ' + trip.destination"
-                  >
-                    <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                    </svg>
-                    Demande
-                  </button>
+                  @if (hasActiveBookingForTrip(trip.id)) {
+                    <span class="inline-flex items-center gap-1.5 bg-primary/10 text-primary font-semibold px-4 py-2.5 rounded-full text-sm whitespace-nowrap">
+                      <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                      </svg>
+                      Demande envoyee
+                    </span>
+                  } @else {
+                    <button
+                      type="button"
+                      (click)="openBookingModal(trip)"
+                      class="btn-primary !px-5 !py-2.5 !rounded-full !text-sm whitespace-nowrap"
+                      [attr.aria-label]="'Envoyer une demande pour le voyage vers ' + trip.destination"
+                    >
+                      <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                      </svg>
+                      Demande
+                    </button>
+                  }
                 </div>
               } @else {
                 <span class="inline-flex items-center gap-1 bg-primary/10 text-primary text-xs font-semibold px-3 py-1 rounded-full">

--- a/front-office/src/app/pages/search/search-page.component.ts
+++ b/front-office/src/app/pages/search/search-page.component.ts
@@ -45,6 +45,9 @@ export class SearchPageComponent implements OnInit, OnDestroy {
   /** Search results */
   trips: Trip[] = [];
 
+  /** Booking requests already sent by the current user */
+  myBookings: BookingResponse[] = [];
+
   /** Whether a search has been performed */
   hasSearched = false;
 
@@ -88,6 +91,10 @@ export class SearchPageComponent implements OnInit, OnDestroy {
    * Execute trip search with selected departure and destination
    */
   ngOnInit(): void {
+    if (this.authService.isLoggedIn()) {
+      this.loadSentBookings();
+    }
+
     this.queryParamsSubscription = this.route.queryParamMap.subscribe((params) => {
       const from = params.get('from')?.trim() ?? '';
       const to = params.get('to')?.trim() ?? '';
@@ -191,6 +198,7 @@ export class SearchPageComponent implements OnInit, OnDestroy {
    * Handle successful booking creation — show a success toast.
    */
   onBookingCreated(booking: BookingResponse): void {
+    this.myBookings = [...this.myBookings, booking];
     this.bookingSuccessMessage = `Demande envoyée avec succès pour "${booking.title}" !`;
     // Auto-close modal and clear message after delay
     setTimeout(() => {
@@ -235,6 +243,21 @@ export class SearchPageComponent implements OnInit, OnDestroy {
     }).subscribe({
       next: () => this.router.navigate(['/messages']),
       error: () => { this.errorMessage = 'Impossible de demarrer la conversation.'; },
+    });
+  }
+
+  hasActiveBookingForTrip(tripId: number): boolean {
+    return this.myBookings.some((booking) => booking.tripId === tripId && booking.status !== 'REJECTED');
+  }
+
+  private loadSentBookings(): void {
+    this.tripService.getMyBookings().subscribe({
+      next: (bookings) => {
+        this.myBookings = bookings;
+      },
+      error: () => {
+        this.myBookings = [];
+      },
     });
   }
 


### PR DESCRIPTION
## Summary
- block duplicate booking requests for the same trip while a previous request is still active
- allow a sender to submit a new request again after the previous one was rejected
- update the search results UI to show that a request was already sent for a trip

## Backend
- add a repository check for an existing non-rejected booking by the same sender on the same trip
- raise a dedicated conflict exception mapped to HTTP 409 when a duplicate active request is attempted
- add focused service tests for duplicate rejection and retry-after-rejection behavior

## Frontend
- load the current user's sent bookings on the search page
- replace the booking CTA with a sent state when an active request already exists for a trip
- update local page state immediately after a booking is created successfully

## Validation
- ran the focused backend test file for trip booking rules successfully

Closes #42