### PR TITLE
feat: annulation de trajet et de réservation (#45)

### DIFF
--- a/back-office/src/main/java/com/colick/backoffice/email/EmailService.java
+++ b/back-office/src/main/java/com/colick/backoffice/email/EmailService.java
@@ -144,6 +144,42 @@ public class EmailService {
             );
             }
 
+    public void sendTripCancelledEmail(String to,
+                                       String senderFirstName,
+                                       String departureAddress,
+                                       String destination) {
+        sendTemplateEmail(
+            to,
+            "Trajet annulé - Colick",
+            "email/trip-cancelled",
+            Map.of(
+                "firstName", senderFirstName,
+                "departureAddress", departureAddress,
+                "destination", destination,
+                "supportEmail", supportEmail
+            )
+        );
+    }
+
+    public void sendBookingCancelledBySenderEmail(String to,
+                                                  String travelerFirstName,
+                                                  String senderFirstName,
+                                                  String departureAddress,
+                                                  String destination) {
+        sendTemplateEmail(
+            to,
+            "Réservation annulée - Colick",
+            "email/booking-cancelled-by-sender",
+            Map.of(
+                "firstName", travelerFirstName,
+                "senderFirstName", senderFirstName,
+                "departureAddress", departureAddress,
+                "destination", destination,
+                "supportEmail", supportEmail
+            )
+        );
+    }
+
     private void sendTemplateEmail(String to, String subject, String templateName, Map<String, Object> variables) {
         Context context = new Context();
         variables.forEach(context::setVariable);

--- a/back-office/src/main/java/com/colick/backoffice/trip/controller/TripController.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/controller/TripController.java
@@ -134,6 +134,16 @@ public class TripController {
         return ResponseEntity.noContent().build();
     }
 
+    /** Cancel a booking. Only the sender of the booking can do this. */
+    @PutMapping("/{id}/bookings/{bookingId}/cancel")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<TripBookingResponse> cancelBooking(
+            @PathVariable Long id,
+            @PathVariable Long bookingId,
+            @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(tripService.cancelBooking(id, bookingId, currentUser));
+    }
+
     /** Get trips published by the current user (all statuses). */
     @GetMapping("/mine")
     @PreAuthorize("isAuthenticated()")

--- a/back-office/src/main/java/com/colick/backoffice/trip/entity/TripBooking.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/entity/TripBooking.java
@@ -55,6 +55,6 @@ public class TripBooking {
     private BookingStatus status = BookingStatus.PENDING;
 
     public enum BookingStatus {
-        PENDING, ACCEPTED, REJECTED
+        PENDING, ACCEPTED, REJECTED, CANCELLED
     }
 }

--- a/back-office/src/main/java/com/colick/backoffice/trip/repository/TripBookingRepository.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/repository/TripBookingRepository.java
@@ -18,7 +18,9 @@ public interface TripBookingRepository extends JpaRepository<TripBooking, Long> 
 
     List<TripBooking> findByTripAndStatus(Trip trip, TripBooking.BookingStatus status);
 
-    boolean existsByTripAndSenderAndStatusNot(Trip trip, User sender, TripBooking.BookingStatus status);
+    List<TripBooking> findByTripAndStatusIn(Trip trip, List<TripBooking.BookingStatus> statuses);
+
+    boolean existsByTripAndSenderAndStatusIn(Trip trip, User sender, List<TripBooking.BookingStatus> statuses);
 
     /** Returns all booking requests submitted by the given user. */
     List<TripBooking> findBySender(User sender);

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripService.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripService.java
@@ -41,6 +41,12 @@ public interface TripService {
     void removeBooking(Long tripId, Long bookingId, User requester);
 
     /**
+     * Cancels a booking. Only the sender of the booking can cancel.
+     * Booking must be in PENDING or ACCEPTED status.
+     */
+    TripBookingResponse cancelBooking(Long tripId, Long bookingId, User requester);
+
+    /**
      * Searches active trips by departure and/or destination.
      * <p>If a search term matches a country name, all cities in that country are included
      * in the matching set (country-expansion).</p>

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
@@ -91,6 +91,17 @@ public class TripServiceImpl implements TripService {
         assertTripOwner(trip, requester);
         trip.setStatus(Trip.TripStatus.CANCELLED);
         tripRepository.save(trip);
+
+        // Notify all senders with PENDING or ACCEPTED bookings
+        List<TripBooking.BookingStatus> activeStatuses = List.of(
+                TripBooking.BookingStatus.PENDING,
+                TripBooking.BookingStatus.ACCEPTED);
+        bookingRepository.findByTripAndStatusIn(trip, activeStatuses)
+                .forEach(b -> emailService.sendTripCancelledEmail(
+                        b.getSender().getEmail(),
+                        b.getSender().getFirstName(),
+                        trip.getDepartureAddress(),
+                        trip.getDestination()));
     }
 
     @Override
@@ -110,11 +121,10 @@ public class TripServiceImpl implements TripService {
             throw new IllegalArgumentException("You cannot create a booking request for your own trip");
         }
 
-        if (bookingRepository.existsByTripAndSenderAndStatusNot(
-                trip,
-                sender,
-                TripBooking.BookingStatus.REJECTED
-        )) {
+        List<TripBooking.BookingStatus> activeStatuses = List.of(
+                TripBooking.BookingStatus.PENDING,
+                TripBooking.BookingStatus.ACCEPTED);
+        if (bookingRepository.existsByTripAndSenderAndStatusIn(trip, sender, activeStatuses)) {
             throw new TripBookingConflictException("Vous avez deja une demande en cours pour ce trajet");
         }
 
@@ -201,6 +211,32 @@ public class TripServiceImpl implements TripService {
         );
 
         bookingRepository.delete(booking);
+    }
+
+    @Override
+    public TripBookingResponse cancelBooking(Long tripId, Long bookingId, User requester) {
+        TripBooking booking = findBookingOrThrow(tripId, bookingId);
+
+        if (!booking.getSender().getId().equals(requester.getId())) {
+            throw new AccessDeniedException("You are not the sender of this booking");
+        }
+
+        if (booking.getStatus() != TripBooking.BookingStatus.PENDING
+                && booking.getStatus() != TripBooking.BookingStatus.ACCEPTED) {
+            throw new IllegalStateException("Only PENDING or ACCEPTED bookings can be cancelled");
+        }
+
+        booking.setStatus(TripBooking.BookingStatus.CANCELLED);
+        TripBooking saved = bookingRepository.save(booking);
+
+        emailService.sendBookingCancelledBySenderEmail(
+                booking.getTrip().getTraveler().getEmail(),
+                booking.getTrip().getTraveler().getFirstName(),
+                requester.getFirstName(),
+                booking.getTrip().getDepartureAddress(),
+                booking.getTrip().getDestination());
+
+        return TripBookingResponse.from(saved);
     }
 
     private Trip findTripOrThrow(Long id) {

--- a/back-office/src/main/resources/templates/email/booking-cancelled-by-sender.html
+++ b/back-office/src/main/resources/templates/email/booking-cancelled-by-sender.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Réservation annulée - Colick</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f5f5f5;font-family:Poppins,Arial,sans-serif;color:#111827;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5;padding:24px 0;">
+    <tr>
+        <td align="center">
+            <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:16px;overflow:hidden;">
+                <tr>
+                    <td style="background:#023047;padding:20px 24px;color:#ffffff;font-size:20px;font-weight:700;">
+                        Colick
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:28px 24px;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Bonjour <span th:text="${firstName}">Voyageur</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            <strong th:text="${senderFirstName}">Expéditeur</strong> a annulé sa réservation pour votre trajet
+                            <strong th:text="${departureAddress}">Paris</strong> → <strong th:text="${destination}">Abidjan</strong>.
+                        </p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;background:#F9FAFB;border-left:4px solid #fb8500;padding:12px 16px;border-radius:10px;">
+                            Le poids correspondant est de nouveau disponible sur votre trajet.
+                        </p>
+                        <hr style="border:none;border-top:1px solid #e5e7eb;margin:20px 0;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Hello <span th:text="${firstName}">Traveler</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            <strong th:text="${senderFirstName}">Sender</strong> has cancelled their booking for your trip
+                            <strong th:text="${departureAddress}">Paris</strong> → <strong th:text="${destination}">Abidjan</strong>.
+                        </p>
+                        <p style="margin:0;line-height:1.6;color:#6B7280;">
+                            The corresponding weight is now available again on your trip.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="background:#F9FAFB;padding:16px 24px;font-size:12px;color:#6B7280;">
+                        Besoin d'aide / Need help? <span style="color:#219ebc;" th:text="${supportEmail}">support@colick.app</span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/back-office/src/main/resources/templates/email/trip-cancelled.html
+++ b/back-office/src/main/resources/templates/email/trip-cancelled.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trajet annulé - Colick</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f5f5f5;font-family:Poppins,Arial,sans-serif;color:#111827;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5;padding:24px 0;">
+    <tr>
+        <td align="center">
+            <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:16px;overflow:hidden;">
+                <tr>
+                    <td style="background:#023047;padding:20px 24px;color:#ffffff;font-size:20px;font-weight:700;">
+                        Colick
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:28px 24px;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Bonjour <span th:text="${firstName}">Utilisateur</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            Nous vous informons que le trajet <strong th:text="${departureAddress}">Paris</strong> →
+                            <strong th:text="${destination}">Abidjan</strong> a été <strong>annulé</strong> par le voyageur.
+                        </p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;background:#F9FAFB;border-left:4px solid #fb8500;padding:12px 16px;border-radius:10px;">
+                            Votre réservation est automatiquement annulée. Vous pouvez relancer votre recherche directement depuis Colick.
+                        </p>
+                        <hr style="border:none;border-top:1px solid #e5e7eb;margin:20px 0;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Hello <span th:text="${firstName}">User</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            We inform you that the trip <strong th:text="${departureAddress}">Paris</strong> →
+                            <strong th:text="${destination}">Abidjan</strong> has been <strong>cancelled</strong> by the traveler.
+                        </p>
+                        <p style="margin:0;line-height:1.6;color:#6B7280;">
+                            Your booking has been automatically cancelled. You can launch a new search directly from Colick.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="background:#F9FAFB;padding:16px 24px;font-size:12px;color:#6B7280;">
+                        Besoin d'aide / Need help? <span style="color:#219ebc;" th:text="${supportEmail}">support@colick.app</span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
@@ -136,11 +136,121 @@ class TripServiceImplTest {
     void deleteTrip_shouldCancelTrip_whenOwner() {
         when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
         when(tripRepository.save(any(Trip.class))).thenReturn(sampleTrip);
+        when(bookingRepository.findByTripAndStatusIn(eq(sampleTrip), anyList())).thenReturn(List.of());
 
         tripService.deleteTrip(10L, traveler);
 
         assertThat(sampleTrip.getStatus()).isEqualTo(Trip.TripStatus.CANCELLED);
         verify(tripRepository).save(sampleTrip);
+    }
+
+    @Test
+    void deleteTrip_shouldNotifyAllActiveBookingSenders() {
+        TripBooking pending = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.PENDING).build();
+        User anotherSender = User.builder().id(3L).firstName("Claire")
+                .email("claire@example.com").role(User.Role.USER).build();
+        TripBooking accepted = TripBooking.builder()
+                .id(2L).trip(sampleTrip).sender(anotherSender)
+                .status(TripBooking.BookingStatus.ACCEPTED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(tripRepository.save(any(Trip.class))).thenReturn(sampleTrip);
+        when(bookingRepository.findByTripAndStatusIn(eq(sampleTrip), anyList()))
+                .thenReturn(List.of(pending, accepted));
+        doNothing().when(emailService).sendTripCancelledEmail(anyString(), anyString(), anyString(), anyString());
+
+        tripService.deleteTrip(10L, traveler);
+
+        verify(emailService).sendTripCancelledEmail(
+                eq(sender.getEmail()), eq(sender.getFirstName()),
+                eq(sampleTrip.getDepartureAddress()), eq(sampleTrip.getDestination()));
+        verify(emailService).sendTripCancelledEmail(
+                eq(anotherSender.getEmail()), eq(anotherSender.getFirstName()),
+                eq(sampleTrip.getDepartureAddress()), eq(sampleTrip.getDestination()));
+    }
+
+    @Test
+    void cancelBooking_shouldSetCancelledAndNotifyTraveler_whenStatusIsAccepted() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .title("Box").recipientContact("+225 00").weight(BigDecimal.valueOf(2))
+                .status(TripBooking.BookingStatus.ACCEPTED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+        when(bookingRepository.save(any())).thenReturn(booking);
+        doNothing().when(emailService).sendBookingCancelledBySenderEmail(
+                anyString(), anyString(), anyString(), anyString(), anyString());
+
+        TripBookingResponse response = tripService.cancelBooking(10L, 1L, sender);
+
+        assertThat(booking.getStatus()).isEqualTo(TripBooking.BookingStatus.CANCELLED);
+        verify(emailService).sendBookingCancelledBySenderEmail(
+                eq(traveler.getEmail()), eq(traveler.getFirstName()), eq(sender.getFirstName()),
+                eq(sampleTrip.getDepartureAddress()), eq(sampleTrip.getDestination()));
+    }
+
+    @Test
+    void cancelBooking_shouldSetCancelledAndNotifyTraveler_whenStatusIsPending() {
+        TripBooking booking = TripBooking.builder()
+                .id(2L).trip(sampleTrip).sender(sender)
+                .title("Box").recipientContact("+225 00").weight(BigDecimal.valueOf(2))
+                .status(TripBooking.BookingStatus.PENDING).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(2L)).thenReturn(Optional.of(booking));
+        when(bookingRepository.save(any())).thenReturn(booking);
+        doNothing().when(emailService).sendBookingCancelledBySenderEmail(
+                anyString(), anyString(), anyString(), anyString(), anyString());
+
+        tripService.cancelBooking(10L, 2L, sender);
+
+        assertThat(booking.getStatus()).isEqualTo(TripBooking.BookingStatus.CANCELLED);
+    }
+
+    @Test
+    void cancelBooking_shouldThrow_whenRequesterIsNotSender() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.ACCEPTED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+
+        assertThatThrownBy(() -> tripService.cancelBooking(10L, 1L, traveler))
+                .isInstanceOf(AccessDeniedException.class);
+        verify(bookingRepository, never()).save(any());
+    }
+
+    @Test
+    void cancelBooking_shouldThrow_whenBookingIsAlreadyCancelled() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.CANCELLED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+
+        assertThatThrownBy(() -> tripService.cancelBooking(10L, 1L, sender))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("PENDING or ACCEPTED");
+        verify(bookingRepository, never()).save(any());
+    }
+
+    @Test
+    void cancelBooking_shouldThrow_whenBookingIsRejected() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.REJECTED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+
+        assertThatThrownBy(() -> tripService.cancelBooking(10L, 1L, sender))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("PENDING or ACCEPTED");
     }
 
     @Test
@@ -224,12 +334,11 @@ class TripServiceImplTest {
         request.setWeight(BigDecimal.valueOf(5));
         request.setRecipientContact("+225 07 00 00 00");
 
+        List<TripBooking.BookingStatus> activeStatuses = List.of(
+                TripBooking.BookingStatus.PENDING, TripBooking.BookingStatus.ACCEPTED);
         when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
-        when(bookingRepository.existsByTripAndSenderAndStatusNot(
-                sampleTrip,
-                sender,
-                TripBooking.BookingStatus.REJECTED
-        )).thenReturn(true);
+        when(bookingRepository.existsByTripAndSenderAndStatusIn(
+                sampleTrip, sender, activeStatuses)).thenReturn(true);
 
         assertThatThrownBy(() -> tripService.createBooking(10L, request, sender))
                 .isInstanceOf(TripBookingConflictException.class)
@@ -240,7 +349,7 @@ class TripServiceImplTest {
     }
 
     @Test
-    void createBooking_shouldAllowNewRequest_whenPreviousBookingWasRejected() {
+    void createBooking_shouldAllowNewRequest_whenPreviousBookingWasCancelledOrRejected() {
         CreateBookingRequest request = new CreateBookingRequest();
         request.setTitle("Electronics");
         request.setWeight(BigDecimal.valueOf(5));
@@ -256,12 +365,11 @@ class TripServiceImplTest {
                 .status(TripBooking.BookingStatus.PENDING)
                 .build();
 
+        List<TripBooking.BookingStatus> activeStatuses = List.of(
+                TripBooking.BookingStatus.PENDING, TripBooking.BookingStatus.ACCEPTED);
         when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
-        when(bookingRepository.existsByTripAndSenderAndStatusNot(
-                sampleTrip,
-                sender,
-                TripBooking.BookingStatus.REJECTED
-        )).thenReturn(false);
+        when(bookingRepository.existsByTripAndSenderAndStatusIn(
+                sampleTrip, sender, activeStatuses)).thenReturn(false);
         when(bookingRepository.findByTripAndStatus(sampleTrip, TripBooking.BookingStatus.ACCEPTED))
                 .thenReturn(List.of());
         when(bookingRepository.save(any(TripBooking.class))).thenReturn(savedBooking);

--- a/front-office/src/app/models/booking.model.ts
+++ b/front-office/src/app/models/booking.model.ts
@@ -16,5 +16,5 @@ export interface BookingResponse {
   description?: string;
   packagePhotoUrl?: string;
   recipientContact: string;
-  status: string;
+  status: 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'CANCELLED';
 }

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.html
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.html
@@ -255,6 +255,16 @@
                     <p class="text-text-muted text-xs mt-1">
                       Poids max : {{ trip.maxWeight }} kg · {{ trip.pricePerKilo }} €/kg
                     </p>
+                    <!-- Cancel trip button -->
+                    <div class="mt-3 flex justify-end" (click)="$event.stopPropagation()">
+                      <button
+                        (click)="cancelTrip(trip.id)"
+                        [disabled]="isCancellingTrip"
+                        class="text-xs font-semibold text-error hover:underline disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        Annuler le trajet
+                      </button>
+                    </div>
                   </button>
                 }
               </div>
@@ -344,10 +354,20 @@
                         <p class="text-text-muted text-xs mt-1">{{ booking.description }}</p>
                       }
                     </div>
-                    <!-- Status badge -->
-                    <span [class]="statusClass(booking.status) + ' text-xs font-medium px-2.5 py-1 rounded-full shrink-0'">
-                      {{ statusLabel(booking.status) }}
-                    </span>
+                    <!-- Status badge + cancel button -->
+                    <div class="flex items-center gap-2 shrink-0">
+                      <span [class]="statusClass(booking.status) + ' text-xs font-medium px-2.5 py-1 rounded-full'">
+                        {{ statusLabel(booking.status) }}
+                      </span>
+                      @if (booking.status === 'PENDING' || booking.status === 'ACCEPTED') {
+                        <button
+                          (click)="cancelMyBooking(booking)"
+                          class="text-xs font-semibold text-error hover:underline"
+                        >
+                          Annuler
+                        </button>
+                      }
+                    </div>
                   </div>
                 }
               </div>

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.html
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.html
@@ -317,6 +317,15 @@
                                 Refuser
                               </button>
                             }
+                            <!-- Remove action (only for accepted bookings) -->
+                            @if (booking.status === 'ACCEPTED') {
+                              <button
+                                (click)="removeBooking(booking.id)"
+                                class="bg-gray-500 text-white text-xs font-semibold px-3 py-1.5 rounded-lg hover:bg-opacity-90 transition-colors"
+                              >
+                                Retirer
+                              </button>
+                            }
                           </div>
                         </div>
                       }

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.html
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.html
@@ -389,3 +389,15 @@
 
   </div>
 </div>
+
+<!-- ── Confirm remove booking modal ──────────────────────────────────────── -->
+<app-confirm-modal
+  [isOpen]="isRemoveModalOpen"
+  title="Retirer ce demandeur ?"
+  message="Cette action retirera définitivement ce demandeur de votre trajet. Il recevra une notification par email."
+  confirmLabel="Retirer"
+  variant="danger"
+  [isLoading]="isRemoving"
+  (confirmed)="confirmRemoveBooking()"
+  (cancelled)="cancelRemoveBooking()"
+/>

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.ts
@@ -77,6 +77,7 @@ export class DashboardPageComponent implements OnInit {
   isLoadingTrips = false;
   isLoadingBookings = false;
   bookingActionError = '';
+  isCancellingTrip = false;
 
   // ── Sent requests ─────────────────────────────────────────────────────────
   myBookings: BookingResponse[] = [];
@@ -241,6 +242,23 @@ export class DashboardPageComponent implements OnInit {
     });
   }
 
+  cancelTrip(tripId: number): void {
+    if (!confirm('Êtes-vous sûr de vouloir annuler ce trajet ? Tous les demandeurs seront notifiés.')) return;
+    this.isCancellingTrip = true;
+    this.bookingActionError = '';
+    this.tripService.cancelTrip(tripId).subscribe({
+      next: () => {
+        this.myTrips = this.myTrips.filter((t) => t.id !== tripId);
+        if (this.selectedTripId === tripId) {
+          this.selectedTripId = null;
+          this.selectedTripBookings = [];
+        }
+        this.isCancellingTrip = false;
+      },
+      error: () => { this.bookingActionError = "Erreur lors de l'annulation du trajet."; this.isCancellingTrip = false; },
+    });
+  }
+
   loadSentBookings(): void {
     this.isLoadingSentBookings = true;
     this.tripService.getMyBookings().subscribe({
@@ -249,11 +267,22 @@ export class DashboardPageComponent implements OnInit {
     });
   }
 
+  cancelMyBooking(booking: BookingResponse): void {
+    if (!confirm('Êtes-vous sûr de vouloir annuler cette réservation ?')) return;
+    this.tripService.cancelBooking(booking.tripId, booking.id).subscribe({
+      next: (updated) => {
+        const idx = this.myBookings.findIndex((b) => b.id === updated.id);
+        if (idx >= 0) { this.myBookings[idx] = updated; }
+      },
+      error: () => { /* no-op: UX handled by status staying unchanged */ },
+    });
+  }
+
   statusLabel(status: string): string {
-    return ({ PENDING: 'En attente', ACCEPTED: 'Acceptée', REJECTED: 'Refusée' } as Record<string, string>)[status] ?? status;
+    return ({ PENDING: 'En attente', ACCEPTED: 'Acceptée', REJECTED: 'Refusée', CANCELLED: 'Annulée' } as Record<string, string>)[status] ?? status;
   }
 
   statusClass(status: string): string {
-    return ({ PENDING: 'bg-yellow-100 text-yellow-800', ACCEPTED: 'bg-green-100 text-green-800', REJECTED: 'bg-red-100 text-red-800' } as Record<string, string>)[status] ?? 'bg-gray-100 text-gray-800';
+    return ({ PENDING: 'bg-yellow-100 text-yellow-800', ACCEPTED: 'bg-green-100 text-green-800', REJECTED: 'bg-red-100 text-red-800', CANCELLED: 'bg-gray-100 text-gray-500' } as Record<string, string>)[status] ?? 'bg-gray-100 text-gray-800';
   }
 }

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.ts
@@ -242,6 +242,19 @@ export class DashboardPageComponent implements OnInit {
     });
   }
 
+  removeBooking(bookingId: number): void {
+    if (!this.selectedTripId) return;
+    if (!confirm('Retirer ce demandeur ? Il sera notifié par email.')) return;
+    this.bookingActionError = '';
+    this.tripService.removeBooking(this.selectedTripId, bookingId).subscribe({
+      next: () => {
+        this.selectedTripBookings = this.selectedTripBookings.filter((b) => b.id !== bookingId);
+        this.tripBookingsMap[this.selectedTripId!] = this.selectedTripBookings;
+      },
+      error: () => { this.bookingActionError = 'Erreur lors du retrait du demandeur.'; },
+    });
+  }
+
   cancelTrip(tripId: number): void {
     if (!confirm('Êtes-vous sûr de vouloir annuler ce trajet ? Tous les demandeurs seront notifiés.')) return;
     this.isCancellingTrip = true;

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.ts
@@ -9,13 +9,14 @@ import { TripService } from '../../services/trip.service';
 import { Trip } from '../../models/trip.model';
 import { BookingResponse } from '../../models/booking.model';
 import { UpdateProfileRequest } from '../../models/auth.model';
+import { ConfirmModalComponent } from '../../shared/components/confirm-modal/confirm-modal.component';
 
 type Tab = 'profile' | 'chats' | 'received' | 'sent';
 
 @Component({
   selector: 'app-dashboard-page',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterLink],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterLink, ConfirmModalComponent],
   templateUrl: './dashboard-page.component.html',
 })
 export class DashboardPageComponent implements OnInit {
@@ -78,6 +79,11 @@ export class DashboardPageComponent implements OnInit {
   isLoadingBookings = false;
   bookingActionError = '';
   isCancellingTrip = false;
+
+  // ── Remove booking confirmation modal ─────────────────────────────────────
+  isRemoveModalOpen = false;
+  pendingRemoveBookingId: number | null = null;
+  isRemoving = false;
 
   // ── Sent requests ─────────────────────────────────────────────────────────
   myBookings: BookingResponse[] = [];
@@ -244,15 +250,36 @@ export class DashboardPageComponent implements OnInit {
 
   removeBooking(bookingId: number): void {
     if (!this.selectedTripId) return;
-    if (!confirm('Retirer ce demandeur ? Il sera notifié par email.')) return;
+    this.pendingRemoveBookingId = bookingId;
+    this.isRemoveModalOpen = true;
+  }
+
+  confirmRemoveBooking(): void {
+    if (!this.selectedTripId || this.pendingRemoveBookingId === null) return;
+    this.isRemoving = true;
     this.bookingActionError = '';
-    this.tripService.removeBooking(this.selectedTripId, bookingId).subscribe({
+    this.tripService.removeBooking(this.selectedTripId, this.pendingRemoveBookingId).subscribe({
       next: () => {
-        this.selectedTripBookings = this.selectedTripBookings.filter((b) => b.id !== bookingId);
+        this.selectedTripBookings = this.selectedTripBookings.filter(
+          (b) => b.id !== this.pendingRemoveBookingId
+        );
         this.tripBookingsMap[this.selectedTripId!] = this.selectedTripBookings;
+        this.isRemoveModalOpen = false;
+        this.pendingRemoveBookingId = null;
+        this.isRemoving = false;
       },
-      error: () => { this.bookingActionError = 'Erreur lors du retrait du demandeur.'; },
+      error: () => {
+        this.bookingActionError = 'Erreur lors du retrait du demandeur.';
+        this.isRemoveModalOpen = false;
+        this.pendingRemoveBookingId = null;
+        this.isRemoving = false;
+      },
     });
+  }
+
+  cancelRemoveBooking(): void {
+    this.isRemoveModalOpen = false;
+    this.pendingRemoveBookingId = null;
   }
 
   cancelTrip(tripId: number): void {

--- a/front-office/src/app/services/trip.service.ts
+++ b/front-office/src/app/services/trip.service.ts
@@ -57,6 +57,11 @@ export class TripService {
     return this.http.put<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/reject`, {});
   }
 
+  /** Remove an accepted booking (traveler only). Sends notification to sender. */
+  removeBooking(tripId: number, bookingId: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${tripId}/bookings/${bookingId}`);
+  }
+
   /** Cancel a trip (traveler only). */
   cancelTrip(tripId: number): Observable<void> {
     return this.http.delete<void>(`${this.baseUrl}/${tripId}`);

--- a/front-office/src/app/services/trip.service.ts
+++ b/front-office/src/app/services/trip.service.ts
@@ -56,4 +56,14 @@ export class TripService {
   rejectBooking(tripId: number, bookingId: number): Observable<BookingResponse> {
     return this.http.put<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/reject`, {});
   }
+
+  /** Cancel a trip (traveler only). */
+  cancelTrip(tripId: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${tripId}`);
+  }
+
+  /** Cancel a booking (sender only). */
+  cancelBooking(tripId: number, bookingId: number): Observable<BookingResponse> {
+    return this.http.put<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/cancel`, {});
+  }
 }

--- a/front-office/src/app/shared/components/confirm-modal/confirm-modal.component.html
+++ b/front-office/src/app/shared/components/confirm-modal/confirm-modal.component.html
@@ -1,0 +1,69 @@
+@if (isOpen) {
+  <!-- Backdrop -->
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-[fadeIn_200ms_ease-out]"
+    role="dialog"
+    aria-modal="true"
+    [attr.aria-labelledby]="'confirm-modal-title'"
+    (click)="onCancel()"
+    (keydown.escape)="onCancel()"
+  >
+    <!-- Card -->
+    <div
+      class="bg-white rounded-2xl shadow-2xl w-full max-w-sm mx-4 animate-[slideUp_300ms_ease-out]"
+      (click)="$event.stopPropagation()"
+    >
+      <!-- Header -->
+      <div class="px-6 pt-6 pb-4 border-b border-gray-100">
+        <!-- Icon -->
+        <div class="flex items-center gap-3">
+          @if (variant === 'danger') {
+            <div class="flex items-center justify-center w-10 h-10 rounded-full bg-red-50 shrink-0">
+              <svg class="w-5 h-5 text-error" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+              </svg>
+            </div>
+          } @else {
+            <div class="flex items-center justify-center w-10 h-10 rounded-full bg-secondary/10 shrink-0">
+              <svg class="w-5 h-5 text-secondary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+          }
+          <h2 id="confirm-modal-title" class="text-base font-bold text-text-primary">
+            {{ title }}
+          </h2>
+        </div>
+      </div>
+
+      <!-- Body -->
+      <div class="px-6 py-5">
+        <p class="text-sm text-text-secondary leading-relaxed">{{ message }}</p>
+      </div>
+
+      <!-- Footer -->
+      <div class="px-6 pb-6 flex justify-end gap-3">
+        <button
+          type="button"
+          (click)="onCancel()"
+          [disabled]="isLoading"
+          class="px-5 py-2.5 rounded-lg border border-gray-200 text-sm font-semibold text-text-primary
+                 hover:bg-background-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Annuler
+        </button>
+        <button
+          type="button"
+          (click)="onConfirm()"
+          [disabled]="isLoading"
+          [class]="confirmButtonClass + ' px-5 py-2.5 rounded-lg text-sm font-semibold text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2'"
+        >
+          @if (isLoading) {
+            <span class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" aria-hidden="true"></span>
+          }
+          {{ confirmLabel }}
+        </button>
+      </div>
+    </div>
+  </div>
+}

--- a/front-office/src/app/shared/components/confirm-modal/confirm-modal.component.ts
+++ b/front-office/src/app/shared/components/confirm-modal/confirm-modal.component.ts
@@ -1,0 +1,40 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+/**
+ * Generic confirmation modal.
+ * Emits `confirmed` when the user clicks the confirm button,
+ * `cancelled` when they dismiss or click cancel.
+ */
+@Component({
+  selector: 'app-confirm-modal',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './confirm-modal.component.html',
+})
+export class ConfirmModalComponent {
+  @Input() isOpen = false;
+  @Input() title = 'Confirmer l\'action';
+  @Input() message = 'Êtes-vous sûr de vouloir effectuer cette action ?';
+  @Input() confirmLabel = 'Confirmer';
+  /** 'danger' renders the confirm button in error red, 'primary' in navy */
+  @Input() variant: 'danger' | 'primary' = 'danger';
+  @Input() isLoading = false;
+
+  @Output() confirmed = new EventEmitter<void>();
+  @Output() cancelled = new EventEmitter<void>();
+
+  get confirmButtonClass(): string {
+    return this.variant === 'danger'
+      ? 'bg-error hover:bg-red-600'
+      : 'bg-primary hover:bg-opacity-90';
+  }
+
+  onConfirm(): void {
+    this.confirmed.emit();
+  }
+
+  onCancel(): void {
+    this.cancelled.emit();
+  }
+}


### PR DESCRIPTION
## Résumé

Closes #45

Les deux parties peuvent désormais annuler les trajets/réservations acceptés, avec notification par email dans chaque cas.

## Changements

### Backend
- **`TripBooking.BookingStatus`** — Ajout de `CANCELLED`
- **`TripBookingRepository`** — Remplacement de `existsByTripAndSenderAndStatusNot` par `existsByTripAndSenderAndStatusIn` + ajout de `findByTripAndStatusIn` (permet la re-réservation après annulation)
- **`TripServiceImpl.deleteTrip`** — Notify tous les demandeurs PENDING et ACCEPTED lors de l'annulation d'un trajet
- **`TripServiceImpl.cancelBooking`** — Nouvelle méthode : vérifie que le requester est le sender, que le statut est PENDING ou ACCEPTED, puis passe à CANCELLED et notifie le voyageur
- **`TripController`** — Nouvel endpoint `PUT /trips/{id}/bookings/{bookingId}/cancel`
- **`EmailService`** — 2 nouvelles méthodes : `sendTripCancelledEmail` et `sendBookingCancelledBySenderEmail`
- **Templates Thymeleaf** — 2 nouveaux templates bilingues FR/EN : `trip-cancelled.html` et `booking-cancelled-by-sender.html`

### Frontend
- **`booking.model.ts`** — Ajout de `'CANCELLED'` au type union `BookingStatus`
- **`trip.service.ts`** — Ajout de `cancelTrip()` et `cancelBooking()`
- **`dashboard-page.component`** — Bouton "Annuler le trajet" (voyageur, tab Réservations reçues) + bouton "Annuler" pour les réservations PENDING/ACCEPTED (demandeur, tab Mes demandes) + label/style pour le statut CANCELLED

### Tests
- `deleteTrip_shouldNotifyAllActiveBookingSenders`
- `cancelBooking_shouldSetCancelledAndNotifyTraveler_whenStatusIsAccepted`
- `cancelBooking_shouldSetCancelledAndNotifyTraveler_whenStatusIsPending`
- `cancelBooking_shouldThrow_whenRequesterIsNotSender`
- `cancelBooking_shouldThrow_whenBookingIsAlreadyCancelled`
- `cancelBooking_shouldThrow_whenBookingIsRejected`
- Mise à jour des tests existants pour `existsByTripAndSenderAndStatusIn`

**73 tests passent, 0 échec.**