### PR TITLE
feat: send recipient validation codes

### DIFF
--- a/back-office/pom.xml
+++ b/back-office/pom.xml
@@ -118,6 +118,16 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.google.zxing</groupId>
+			<artifactId>core</artifactId>
+			<version>3.5.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.zxing</groupId>
+			<artifactId>javase</artifactId>
+			<version>3.5.3</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/back-office/src/main/java/com/colick/backoffice/email/EmailService.java
+++ b/back-office/src/main/java/com/colick/backoffice/email/EmailService.java
@@ -180,6 +180,27 @@ public class EmailService {
         );
     }
 
+    public void sendBookingValidationCodeEmail(String to,
+                                               String packageTitle,
+                                               String validationCode,
+                                               String qrCodeDataUri,
+                                               String departureAddress,
+                                               String destination) {
+        sendTemplateEmail(
+            to,
+            "Code de validation destinataire - Colick",
+            "email/booking-validation-code",
+            Map.of(
+                "packageTitle", packageTitle,
+                "validationCode", validationCode,
+                "qrCodeDataUri", qrCodeDataUri,
+                "departureAddress", departureAddress,
+                "destination", destination,
+                "supportEmail", supportEmail
+            )
+        );
+    }
+
     private void sendTemplateEmail(String to, String subject, String templateName, Map<String, Object> variables) {
         Context context = new Context();
         variables.forEach(context::setVariable);

--- a/back-office/src/main/java/com/colick/backoffice/exception/ValidationCodeDeliveryException.java
+++ b/back-office/src/main/java/com/colick/backoffice/exception/ValidationCodeDeliveryException.java
@@ -1,0 +1,26 @@
+package com.colick.backoffice.exception;
+
+import com.colick.backoffice.trip.entity.TripBooking;
+
+public class ValidationCodeDeliveryException extends RuntimeException {
+
+    private final String recipientContact;
+    private final TripBooking.ValidationDeliveryChannel deliveryChannel;
+
+    public ValidationCodeDeliveryException(String message,
+                                           String recipientContact,
+                                           TripBooking.ValidationDeliveryChannel deliveryChannel,
+                                           Throwable cause) {
+        super(message, cause);
+        this.recipientContact = recipientContact;
+        this.deliveryChannel = deliveryChannel;
+    }
+
+    public String getRecipientContact() {
+        return recipientContact;
+    }
+
+    public TripBooking.ValidationDeliveryChannel getDeliveryChannel() {
+        return deliveryChannel;
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/notification/qrcode/QrCodeService.java
+++ b/back-office/src/main/java/com/colick/backoffice/notification/qrcode/QrCodeService.java
@@ -1,0 +1,27 @@
+package com.colick.backoffice.notification.qrcode;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.MultiFormatWriter;
+import com.google.zxing.WriterException;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+@Service
+public class QrCodeService {
+
+    public String generateDataUri(String content) {
+        try {
+            BitMatrix matrix = new MultiFormatWriter().encode(content, BarcodeFormat.QR_CODE, 240, 240);
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            MatrixToImageWriter.writeToStream(matrix, "PNG", outputStream);
+            return "data:image/png;base64," + Base64.getEncoder().encodeToString(outputStream.toByteArray());
+        } catch (WriterException | IOException ex) {
+            throw new IllegalStateException("Unable to generate QR code", ex);
+        }
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/notification/sms/SmsService.java
+++ b/back-office/src/main/java/com/colick/backoffice/notification/sms/SmsService.java
@@ -1,0 +1,6 @@
+package com.colick.backoffice.notification.sms;
+
+public interface SmsService {
+
+    void sendValidationCode(String to, String validationCode, String departureAddress, String destination);
+}

--- a/back-office/src/main/java/com/colick/backoffice/notification/sms/TwilioSmsService.java
+++ b/back-office/src/main/java/com/colick/backoffice/notification/sms/TwilioSmsService.java
@@ -1,0 +1,51 @@
+package com.colick.backoffice.notification.sms;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class TwilioSmsService implements SmsService {
+
+    private final RestClient restClient;
+    private final boolean enabled;
+    private final String accountSid;
+    private final String authToken;
+    private final String fromNumber;
+
+    public TwilioSmsService(RestClient.Builder restClientBuilder,
+                            @Value("${app.sms.enabled:false}") boolean enabled,
+                            @Value("${app.sms.twilio.account-sid:}") String accountSid,
+                            @Value("${app.sms.twilio.auth-token:}") String authToken,
+                            @Value("${app.sms.twilio.from-number:}") String fromNumber) {
+        this.restClient = restClientBuilder.build();
+        this.enabled = enabled;
+        this.accountSid = accountSid;
+        this.authToken = authToken;
+        this.fromNumber = fromNumber;
+    }
+
+    @Override
+    public void sendValidationCode(String to, String validationCode, String departureAddress, String destination) {
+        if (!enabled || accountSid.isBlank() || authToken.isBlank() || fromNumber.isBlank()) {
+            throw new IllegalStateException("SMS delivery is not configured");
+        }
+
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("To", to);
+        form.add("From", fromNumber);
+        form.add("Body", "Colick: votre code de validation pour le trajet %s -> %s est %s."
+                .formatted(departureAddress, destination, validationCode));
+
+        restClient.post()
+                .uri("https://api.twilio.com/2010-04-01/Accounts/{accountSid}/Messages.json", accountSid)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .headers(headers -> headers.setBasicAuth(accountSid, authToken))
+                .body(form)
+                .retrieve()
+                .toBodilessEntity();
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/controller/TripController.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/controller/TripController.java
@@ -88,8 +88,10 @@ public class TripController {
     /** List all booking requests for a trip. */
     @GetMapping("/{id}/bookings")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<List<TripBookingResponse>> getBookings(@PathVariable Long id) {
-        return ResponseEntity.ok(tripService.getBookings(id));
+    public ResponseEntity<List<TripBookingResponse>> getBookings(
+            @PathVariable Long id,
+            @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(tripService.getBookings(id, currentUser));
     }
 
     /** Submit a booking request on a trip. */

--- a/back-office/src/main/java/com/colick/backoffice/trip/dto/TripBookingResponse.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/dto/TripBookingResponse.java
@@ -25,8 +25,10 @@ public class TripBookingResponse {
     private String recipientContact;
     private TripBooking.BookingStatus status;
     private TripBooking.ValidationDeliveryChannel validationDeliveryChannel;
+    private TripBooking.ValidationDeliveryStatus validationDeliveryStatus;
     private LocalDateTime validationCodeSentAt;
     private LocalDateTime validationCodeInvalidatedAt;
+    private LocalDateTime validationCodeDeliveryFailedAt;
     private boolean validationCodeActive;
 
     /**
@@ -45,8 +47,10 @@ public class TripBookingResponse {
                 .recipientContact(booking.getRecipientContact())
                 .status(booking.getStatus())
                 .validationDeliveryChannel(booking.getValidationDeliveryChannel())
+                .validationDeliveryStatus(booking.getValidationDeliveryStatus())
                 .validationCodeSentAt(booking.getValidationCodeSentAt())
                 .validationCodeInvalidatedAt(booking.getValidationCodeInvalidatedAt())
+                .validationCodeDeliveryFailedAt(booking.getValidationCodeDeliveryFailedAt())
                 .validationCodeActive(booking.hasActiveValidationCode())
                 .build();
     }

--- a/back-office/src/main/java/com/colick/backoffice/trip/dto/TripBookingResponse.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/dto/TripBookingResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 /**
  * Read-only view of a trip booking returned by the API.
@@ -23,6 +24,10 @@ public class TripBookingResponse {
     private String packagePhotoUrl;
     private String recipientContact;
     private TripBooking.BookingStatus status;
+    private TripBooking.ValidationDeliveryChannel validationDeliveryChannel;
+    private LocalDateTime validationCodeSentAt;
+    private LocalDateTime validationCodeInvalidatedAt;
+    private boolean validationCodeActive;
 
     /**
      * Maps a {@link TripBooking} entity to a {@link TripBookingResponse} DTO.
@@ -39,6 +44,10 @@ public class TripBookingResponse {
                 .packagePhotoUrl(booking.getPackagePhotoUrl())
                 .recipientContact(booking.getRecipientContact())
                 .status(booking.getStatus())
+                .validationDeliveryChannel(booking.getValidationDeliveryChannel())
+                .validationCodeSentAt(booking.getValidationCodeSentAt())
+                .validationCodeInvalidatedAt(booking.getValidationCodeInvalidatedAt())
+                .validationCodeActive(booking.hasActiveValidationCode())
                 .build();
     }
 }

--- a/back-office/src/main/java/com/colick/backoffice/trip/entity/TripBooking.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/entity/TripBooking.java
@@ -62,21 +62,34 @@ public class TripBooking {
     @Column
     private ValidationDeliveryChannel validationDeliveryChannel;
 
+    @Enumerated(EnumType.STRING)
+    @Column
+    private ValidationDeliveryStatus validationDeliveryStatus;
+
     @Column
     private LocalDateTime validationCodeSentAt;
 
     @Column
     private LocalDateTime validationCodeInvalidatedAt;
 
+    @Column
+    private LocalDateTime validationCodeDeliveryFailedAt;
+
     public boolean hasActiveValidationCode() {
-        return validationCode != null && validationCodeInvalidatedAt == null;
+        return validationCode != null
+                && validationDeliveryStatus == ValidationDeliveryStatus.DELIVERED
+                && validationCodeInvalidatedAt == null;
     }
 
     public enum BookingStatus {
-        PENDING, ACCEPTED, REJECTED, CANCELLED
+        PENDING, ACCEPTED, REJECTED, CANCELLED, REMOVED
     }
 
     public enum ValidationDeliveryChannel {
         EMAIL, SMS
+    }
+
+    public enum ValidationDeliveryStatus {
+        DELIVERED, FAILED, INVALIDATED
     }
 }

--- a/back-office/src/main/java/com/colick/backoffice/trip/entity/TripBooking.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/entity/TripBooking.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 /**
  * Represents a booking request made by a sender for a specific trip.
@@ -54,7 +55,28 @@ public class TripBooking {
     @Builder.Default
     private BookingStatus status = BookingStatus.PENDING;
 
+    @Column(length = 6)
+    private String validationCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private ValidationDeliveryChannel validationDeliveryChannel;
+
+    @Column
+    private LocalDateTime validationCodeSentAt;
+
+    @Column
+    private LocalDateTime validationCodeInvalidatedAt;
+
+    public boolean hasActiveValidationCode() {
+        return validationCode != null && validationCodeInvalidatedAt == null;
+    }
+
     public enum BookingStatus {
         PENDING, ACCEPTED, REJECTED, CANCELLED
+    }
+
+    public enum ValidationDeliveryChannel {
+        EMAIL, SMS
     }
 }

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/BookingValidationService.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/BookingValidationService.java
@@ -1,0 +1,115 @@
+package com.colick.backoffice.trip.service;
+
+import com.colick.backoffice.email.EmailService;
+import com.colick.backoffice.notification.qrcode.QrCodeService;
+import com.colick.backoffice.notification.sms.SmsService;
+import com.colick.backoffice.trip.entity.TripBooking;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+@Service
+public class BookingValidationService {
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(
+            "^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern PHONE_ALLOWED_PATTERN = Pattern.compile("^\\+?[0-9\\s().-]{6,}$");
+
+    private final EmailService emailService;
+    private final SmsService smsService;
+    private final QrCodeService qrCodeService;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public BookingValidationService(EmailService emailService,
+                                    SmsService smsService,
+                                    QrCodeService qrCodeService) {
+        this.emailService = emailService;
+        this.smsService = smsService;
+        this.qrCodeService = qrCodeService;
+    }
+
+    public String normalizeRecipientContact(String rawContact) {
+        if (rawContact == null) {
+            throw new IllegalArgumentException("Recipient contact must be a valid email address or phone number");
+        }
+
+        String contact = rawContact.trim();
+        if (contact.isEmpty()) {
+            throw new IllegalArgumentException("Recipient contact must be a valid email address or phone number");
+        }
+
+        if (isEmail(contact)) {
+            return contact.toLowerCase(Locale.ROOT);
+        }
+
+        if (!PHONE_ALLOWED_PATTERN.matcher(contact).matches()) {
+            throw new IllegalArgumentException("Recipient contact must be a valid email address or phone number");
+        }
+
+        String normalizedPhone = contact.replaceAll("[\\s().-]", "");
+        if (!normalizedPhone.matches("^\\+?[0-9]{6,15}$")) {
+            throw new IllegalArgumentException("Recipient contact must be a valid email address or phone number");
+        }
+        return normalizedPhone;
+    }
+
+    public void sendValidationCode(TripBooking booking) {
+        if (booking.hasActiveValidationCode()) {
+            return;
+        }
+
+        String normalizedContact = normalizeRecipientContact(booking.getRecipientContact());
+        String validationCode = "%06d".formatted(secureRandom.nextInt(1_000_000));
+        TripBooking.ValidationDeliveryChannel channel = isEmail(normalizedContact)
+                ? TripBooking.ValidationDeliveryChannel.EMAIL
+                : TripBooking.ValidationDeliveryChannel.SMS;
+
+        booking.setRecipientContact(normalizedContact);
+        booking.setValidationCode(validationCode);
+        booking.setValidationDeliveryChannel(channel);
+        booking.setValidationCodeSentAt(LocalDateTime.now());
+        booking.setValidationCodeInvalidatedAt(null);
+
+        if (channel == TripBooking.ValidationDeliveryChannel.EMAIL) {
+            emailService.sendBookingValidationCodeEmail(
+                    normalizedContact,
+                    booking.getTitle(),
+                    validationCode,
+                    qrCodeService.generateDataUri(buildQrPayload(booking, validationCode)),
+                    booking.getTrip().getDepartureAddress(),
+                    booking.getTrip().getDestination()
+            );
+            return;
+        }
+
+        smsService.sendValidationCode(
+                normalizedContact,
+                validationCode,
+                booking.getTrip().getDepartureAddress(),
+                booking.getTrip().getDestination()
+        );
+    }
+
+    public void invalidateValidationCode(TripBooking booking) {
+        if (!booking.hasActiveValidationCode()) {
+            return;
+        }
+        booking.setValidationCodeInvalidatedAt(LocalDateTime.now());
+    }
+
+    private boolean isEmail(String contact) {
+        return EMAIL_PATTERN.matcher(contact).matches();
+    }
+
+    private String buildQrPayload(TripBooking booking, String validationCode) {
+        return "COLICK|BOOKING:%d|TRIP:%d|CODE:%s".formatted(
+                booking.getId(),
+                booking.getTrip().getId(),
+                validationCode
+        );
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/BookingValidationService.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/BookingValidationService.java
@@ -1,6 +1,7 @@
 package com.colick.backoffice.trip.service;
 
 import com.colick.backoffice.email.EmailService;
+import com.colick.backoffice.exception.ValidationCodeDeliveryException;
 import com.colick.backoffice.notification.qrcode.QrCodeService;
 import com.colick.backoffice.notification.sms.SmsService;
 import com.colick.backoffice.trip.entity.TripBooking;
@@ -63,42 +64,69 @@ public class BookingValidationService {
         }
 
         String normalizedContact = normalizeRecipientContact(booking.getRecipientContact());
+        TripBooking.ValidationDeliveryChannel channel = resolveDeliveryChannel(normalizedContact);
         String validationCode = "%06d".formatted(secureRandom.nextInt(1_000_000));
-        TripBooking.ValidationDeliveryChannel channel = isEmail(normalizedContact)
-                ? TripBooking.ValidationDeliveryChannel.EMAIL
-                : TripBooking.ValidationDeliveryChannel.SMS;
+
+        try {
+            if (channel == TripBooking.ValidationDeliveryChannel.EMAIL) {
+                emailService.sendBookingValidationCodeEmail(
+                        normalizedContact,
+                        booking.getTitle(),
+                        validationCode,
+                        qrCodeService.generateDataUri(buildQrPayload(booking, validationCode)),
+                        booking.getTrip().getDepartureAddress(),
+                        booking.getTrip().getDestination()
+                );
+            } else {
+                smsService.sendValidationCode(
+                        normalizedContact,
+                        validationCode,
+                        booking.getTrip().getDepartureAddress(),
+                        booking.getTrip().getDestination()
+                );
+            }
+        } catch (RuntimeException ex) {
+            throw new ValidationCodeDeliveryException(
+                    "Unable to deliver validation code",
+                    normalizedContact,
+                    channel,
+                    ex
+            );
+        }
 
         booking.setRecipientContact(normalizedContact);
         booking.setValidationCode(validationCode);
         booking.setValidationDeliveryChannel(channel);
+        booking.setValidationDeliveryStatus(TripBooking.ValidationDeliveryStatus.DELIVERED);
         booking.setValidationCodeSentAt(LocalDateTime.now());
         booking.setValidationCodeInvalidatedAt(null);
+        booking.setValidationCodeDeliveryFailedAt(null);
+    }
 
-        if (channel == TripBooking.ValidationDeliveryChannel.EMAIL) {
-            emailService.sendBookingValidationCodeEmail(
-                    normalizedContact,
-                    booking.getTitle(),
-                    validationCode,
-                    qrCodeService.generateDataUri(buildQrPayload(booking, validationCode)),
-                    booking.getTrip().getDepartureAddress(),
-                    booking.getTrip().getDestination()
-            );
-            return;
-        }
-
-        smsService.sendValidationCode(
-                normalizedContact,
-                validationCode,
-                booking.getTrip().getDepartureAddress(),
-                booking.getTrip().getDestination()
-        );
+    public void markValidationCodeDeliveryFailed(TripBooking booking,
+                                                 String normalizedContact,
+                                                 TripBooking.ValidationDeliveryChannel channel) {
+        booking.setRecipientContact(normalizedContact);
+        booking.setValidationCode(null);
+        booking.setValidationDeliveryChannel(channel);
+        booking.setValidationDeliveryStatus(TripBooking.ValidationDeliveryStatus.FAILED);
+        booking.setValidationCodeSentAt(null);
+        booking.setValidationCodeInvalidatedAt(null);
+        booking.setValidationCodeDeliveryFailedAt(LocalDateTime.now());
     }
 
     public void invalidateValidationCode(TripBooking booking) {
         if (!booking.hasActiveValidationCode()) {
             return;
         }
+        booking.setValidationDeliveryStatus(TripBooking.ValidationDeliveryStatus.INVALIDATED);
         booking.setValidationCodeInvalidatedAt(LocalDateTime.now());
+    }
+
+    private TripBooking.ValidationDeliveryChannel resolveDeliveryChannel(String normalizedContact) {
+        return isEmail(normalizedContact)
+                ? TripBooking.ValidationDeliveryChannel.EMAIL
+                : TripBooking.ValidationDeliveryChannel.SMS;
     }
 
     private boolean isEmail(String contact) {

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripService.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripService.java
@@ -26,7 +26,7 @@ public interface TripService {
     void deleteTrip(Long id, User requester);
 
     /** Returns all booking requests for a trip. */
-    List<TripBookingResponse> getBookings(Long tripId);
+    List<TripBookingResponse> getBookings(Long tripId, User requester);
 
     /** Submits a booking request on a trip. */
     TripBookingResponse createBooking(Long tripId, CreateBookingRequest request, User sender);

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
@@ -3,6 +3,7 @@ package com.colick.backoffice.trip.service;
 import com.colick.backoffice.email.EmailService;
 import com.colick.backoffice.exception.TripBookingConflictException;
 import com.colick.backoffice.exception.ResourceNotFoundException;
+import com.colick.backoffice.exception.ValidationCodeDeliveryException;
 import com.colick.backoffice.location.entity.LocationType;
 import com.colick.backoffice.location.repository.LocationRepository;
 import com.colick.backoffice.trip.dto.*;
@@ -111,9 +112,11 @@ public class TripServiceImpl implements TripService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<TripBookingResponse> getBookings(Long tripId) {
+    public List<TripBookingResponse> getBookings(Long tripId, User requester) {
         Trip trip = findTripOrThrow(tripId);
+        assertTripOwner(trip, requester);
         return bookingRepository.findByTrip(trip).stream()
+                .filter(booking -> booking.getStatus() != TripBooking.BookingStatus.REMOVED)
                 .map(TripBookingResponse::from)
                 .toList();
     }
@@ -157,8 +160,7 @@ public class TripServiceImpl implements TripService {
         TripBooking saved = bookingRepository.save(booking);
 
         if (initialStatus == TripBooking.BookingStatus.ACCEPTED) {
-            bookingValidationService.sendValidationCode(saved);
-            saved = bookingRepository.save(saved);
+            saved = deliverValidationCodeWithoutBlockingAcceptance(saved);
         }
 
         emailService.sendTripBookingCreatedEmail(
@@ -177,9 +179,16 @@ public class TripServiceImpl implements TripService {
         TripBooking booking = findBookingOrThrow(tripId, bookingId);
         assertTripOwner(booking.getTrip(), requester);
 
+        if (booking.getStatus() == TripBooking.BookingStatus.ACCEPTED) {
+            return TripBookingResponse.from(booking);
+        }
+        if (booking.getStatus() != TripBooking.BookingStatus.PENDING) {
+            throw new IllegalStateException("Only PENDING bookings can be accepted");
+        }
+
         booking.setStatus(TripBooking.BookingStatus.ACCEPTED);
-        bookingValidationService.sendValidationCode(booking);
         TripBooking saved = bookingRepository.save(booking);
+        saved = deliverValidationCodeWithoutBlockingAcceptance(saved);
 
         emailService.sendTripBookingAcceptedEmail(
             booking.getSender().getEmail(),
@@ -195,6 +204,13 @@ public class TripServiceImpl implements TripService {
     public TripBookingResponse rejectBooking(Long tripId, Long bookingId, User requester) {
         TripBooking booking = findBookingOrThrow(tripId, bookingId);
         assertTripOwner(booking.getTrip(), requester);
+
+        if (booking.getStatus() == TripBooking.BookingStatus.REJECTED) {
+            return TripBookingResponse.from(booking);
+        }
+        if (booking.getStatus() != TripBooking.BookingStatus.PENDING) {
+            throw new IllegalStateException("Only PENDING bookings can be rejected");
+        }
 
         booking.setStatus(TripBooking.BookingStatus.REJECTED);
         bookingValidationService.invalidateValidationCode(booking);
@@ -215,14 +231,23 @@ public class TripServiceImpl implements TripService {
         TripBooking booking = findBookingOrThrow(tripId, bookingId);
         assertTripOwner(booking.getTrip(), requester);
 
+        if (booking.getStatus() == TripBooking.BookingStatus.REMOVED) {
+            return;
+        }
+        if (booking.getStatus() != TripBooking.BookingStatus.ACCEPTED) {
+            throw new IllegalStateException("Only ACCEPTED bookings can be removed");
+        }
+
+        booking.setStatus(TripBooking.BookingStatus.REMOVED);
+        bookingValidationService.invalidateValidationCode(booking);
+        bookingRepository.save(booking);
+
         emailService.sendTripBookingRemovedEmail(
             booking.getSender().getEmail(),
             booking.getSender().getFirstName(),
             booking.getTrip().getDepartureAddress(),
             booking.getTrip().getDestination()
         );
-
-        bookingRepository.delete(booking);
     }
 
     @Override
@@ -269,6 +294,19 @@ public class TripServiceImpl implements TripService {
                 && requester.getRole() != User.Role.ADMIN) {
             throw new AccessDeniedException("You are not the owner of this trip");
         }
+    }
+
+    private TripBooking deliverValidationCodeWithoutBlockingAcceptance(TripBooking booking) {
+        try {
+            bookingValidationService.sendValidationCode(booking);
+        } catch (ValidationCodeDeliveryException ex) {
+            bookingValidationService.markValidationCodeDeliveryFailed(
+                    booking,
+                    ex.getRecipientContact(),
+                    ex.getDeliveryChannel()
+            );
+        }
+        return bookingRepository.save(booking);
     }
 
     // ---- Trip search -------------------------------------------------------

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
@@ -29,15 +29,18 @@ public class TripServiceImpl implements TripService {
     private final TripBookingRepository bookingRepository;
     private final EmailService emailService;
     private final LocationRepository locationRepository;
+    private final BookingValidationService bookingValidationService;
 
     public TripServiceImpl(TripRepository tripRepository,
                            TripBookingRepository bookingRepository,
                            EmailService emailService,
-                           LocationRepository locationRepository) {
+                           LocationRepository locationRepository,
+                           BookingValidationService bookingValidationService) {
         this.tripRepository = tripRepository;
         this.bookingRepository = bookingRepository;
         this.emailService = emailService;
         this.locationRepository = locationRepository;
+        this.bookingValidationService = bookingValidationService;
     }
 
     @Override
@@ -96,12 +99,14 @@ public class TripServiceImpl implements TripService {
         List<TripBooking.BookingStatus> activeStatuses = List.of(
                 TripBooking.BookingStatus.PENDING,
                 TripBooking.BookingStatus.ACCEPTED);
-        bookingRepository.findByTripAndStatusIn(trip, activeStatuses)
-                .forEach(b -> emailService.sendTripCancelledEmail(
-                        b.getSender().getEmail(),
-                        b.getSender().getFirstName(),
-                        trip.getDepartureAddress(),
-                        trip.getDestination()));
+        List<TripBooking> activeBookings = bookingRepository.findByTripAndStatusIn(trip, activeStatuses);
+        activeBookings.forEach(bookingValidationService::invalidateValidationCode);
+        bookingRepository.saveAll(activeBookings);
+        activeBookings.forEach(b -> emailService.sendTripCancelledEmail(
+                b.getSender().getEmail(),
+                b.getSender().getFirstName(),
+                trip.getDepartureAddress(),
+                trip.getDestination()));
     }
 
     @Override
@@ -145,11 +150,16 @@ public class TripServiceImpl implements TripService {
                 .weight(request.getWeight())
                 .description(request.getDescription())
                 .packagePhotoUrl(request.getPackagePhotoUrl())
-                .recipientContact(request.getRecipientContact())
+                .recipientContact(bookingValidationService.normalizeRecipientContact(request.getRecipientContact()))
                 .status(initialStatus)
                 .build();
 
         TripBooking saved = bookingRepository.save(booking);
+
+        if (initialStatus == TripBooking.BookingStatus.ACCEPTED) {
+            bookingValidationService.sendValidationCode(saved);
+            saved = bookingRepository.save(saved);
+        }
 
         emailService.sendTripBookingCreatedEmail(
             trip.getTraveler().getEmail(),
@@ -168,6 +178,7 @@ public class TripServiceImpl implements TripService {
         assertTripOwner(booking.getTrip(), requester);
 
         booking.setStatus(TripBooking.BookingStatus.ACCEPTED);
+        bookingValidationService.sendValidationCode(booking);
         TripBooking saved = bookingRepository.save(booking);
 
         emailService.sendTripBookingAcceptedEmail(
@@ -186,6 +197,7 @@ public class TripServiceImpl implements TripService {
         assertTripOwner(booking.getTrip(), requester);
 
         booking.setStatus(TripBooking.BookingStatus.REJECTED);
+        bookingValidationService.invalidateValidationCode(booking);
         TripBooking saved = bookingRepository.save(booking);
 
         emailService.sendTripBookingRejectedEmail(
@@ -227,6 +239,7 @@ public class TripServiceImpl implements TripService {
         }
 
         booking.setStatus(TripBooking.BookingStatus.CANCELLED);
+        bookingValidationService.invalidateValidationCode(booking);
         TripBooking saved = bookingRepository.save(booking);
 
         emailService.sendBookingCancelledBySenderEmail(

--- a/back-office/src/main/resources/application.yml
+++ b/back-office/src/main/resources/application.yml
@@ -77,6 +77,12 @@ app:
   mail:
     from-address: ${MAIL_FROM_ADDRESS:noreply@colick.app}
     support-email: ${MAIL_SUPPORT_EMAIL:support@colick.app}
+  sms:
+    enabled: ${SMS_ENABLED:false}
+    twilio:
+      account-sid: ${TWILIO_ACCOUNT_SID:}
+      auth-token: ${TWILIO_AUTH_TOKEN:}
+      from-number: ${TWILIO_FROM_NUMBER:}
   auth:
     password-reset:
       base-url: ${PASSWORD_RESET_BASE_URL:http://localhost:4200/reset-password}

--- a/back-office/src/main/resources/templates/email/booking-validation-code.html
+++ b/back-office/src/main/resources/templates/email/booking-validation-code.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Code de validation destinataire - Colick</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f5f5f5;font-family:Poppins,Arial,sans-serif;color:#111827;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5;padding:24px 0;">
+    <tr>
+        <td align="center">
+            <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:16px;overflow:hidden;">
+                <tr>
+                    <td style="background:#023047;padding:20px 24px;color:#ffffff;font-size:20px;font-weight:700;">
+                        Colick
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:28px 24px;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Bonjour,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            Votre colis <strong th:text="${packageTitle}">Colis</strong> pour le trajet
+                            <strong th:text="${departureAddress}">Paris</strong> vers
+                            <strong th:text="${destination}">Abidjan</strong> a ete valide.
+                        </p>
+                        <p style="margin:0 0 16px 0;line-height:1.6;">
+                            Remettez ce code au voyageur lorsqu'il arrivera a destination:
+                        </p>
+                        <div style="margin:0 0 20px 0;padding:16px;border-radius:14px;background:#F9FAFB;border:1px solid #e5e7eb;text-align:center;">
+                            <p style="margin:0 0 12px 0;font-size:12px;letter-spacing:0.14em;text-transform:uppercase;color:#6B7280;">Code de validation</p>
+                            <p style="margin:0;font-size:32px;font-weight:700;letter-spacing:0.2em;color:#023047;" th:text="${validationCode}">123456</p>
+                        </div>
+                        <div style="text-align:center;margin:0 0 20px 0;">
+                            <img th:src="${qrCodeDataUri}" alt="QR code de validation Colick" width="220" height="220" style="display:inline-block;border-radius:16px;border:1px solid #e5e7eb;background:#ffffff;padding:12px;" />
+                        </div>
+                        <p style="margin:0 0 20px 0;line-height:1.6;background:#F9FAFB;border-left:4px solid #219ebc;padding:12px 16px;border-radius:10px;">
+                            Conservez cet e-mail jusqu'a la remise du colis. Si la reservation est annulee, ce code ne sera plus valable.
+                        </p>
+                        <hr style="border:none;border-top:1px solid #e5e7eb;margin:20px 0;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Hello,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            Your parcel <strong th:text="${packageTitle}">Parcel</strong> for the trip
+                            <strong th:text="${departureAddress}">Paris</strong> to
+                            <strong th:text="${destination}">Abidjan</strong> is now validated.
+                        </p>
+                        <p style="margin:0;line-height:1.6;color:#6B7280;">
+                            Share this code or QR code with the traveler upon arrival. If the booking is cancelled, the code will no longer be valid.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="background:#F9FAFB;padding:16px 24px;font-size:12px;color:#6B7280;">
+                        Besoin d'aide / Need help? <span style="color:#219ebc;" th:text="${supportEmail}">support@colick.app</span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/back-office/src/test/java/com/colick/backoffice/trip/BookingValidationServiceTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/BookingValidationServiceTest.java
@@ -1,6 +1,7 @@
 package com.colick.backoffice.trip;
 
 import com.colick.backoffice.email.EmailService;
+import com.colick.backoffice.exception.ValidationCodeDeliveryException;
 import com.colick.backoffice.notification.qrcode.QrCodeService;
 import com.colick.backoffice.notification.sms.SmsService;
 import com.colick.backoffice.trip.entity.Trip;
@@ -96,8 +97,10 @@ class BookingValidationServiceTest {
 
         assertThat(booking.getRecipientContact()).isEqualTo("recipient@example.com");
         assertThat(booking.getValidationDeliveryChannel()).isEqualTo(TripBooking.ValidationDeliveryChannel.EMAIL);
+        assertThat(booking.getValidationDeliveryStatus()).isEqualTo(TripBooking.ValidationDeliveryStatus.DELIVERED);
         assertThat(booking.getValidationCode()).matches("\\d{6}");
         assertThat(booking.getValidationCodeSentAt()).isNotNull();
+        assertThat(booking.getValidationCodeDeliveryFailedAt()).isNull();
         assertThat(booking.getValidationCodeInvalidatedAt()).isNull();
 
         ArgumentCaptor<String> qrPayloadCaptor = ArgumentCaptor.forClass(String.class);
@@ -130,6 +133,7 @@ class BookingValidationServiceTest {
 
         assertThat(booking.getRecipientContact()).isEqualTo("+22507000000");
         assertThat(booking.getValidationDeliveryChannel()).isEqualTo(TripBooking.ValidationDeliveryChannel.SMS);
+        assertThat(booking.getValidationDeliveryStatus()).isEqualTo(TripBooking.ValidationDeliveryStatus.DELIVERED);
         assertThat(booking.getValidationCode()).matches("\\d{6}");
         assertThat(booking.getValidationCodeSentAt()).isNotNull();
         verify(smsService).sendValidationCode(
@@ -142,16 +146,60 @@ class BookingValidationServiceTest {
     }
 
     @Test
+    void sendValidationCode_shouldThrowDeliveryException_whenSmsSendFails() {
+        TripBooking booking = TripBooking.builder()
+                .id(21L)
+                .trip(trip)
+                .title("Valise")
+                .recipientContact("+225 07 00 00 00")
+                .status(TripBooking.BookingStatus.ACCEPTED)
+                .build();
+
+        doThrow(new IllegalStateException("SMS delivery is not configured"))
+                .when(smsService).sendValidationCode(anyString(), anyString(), anyString(), anyString());
+
+        assertThatThrownBy(() -> bookingValidationService.sendValidationCode(booking))
+                .isInstanceOf(ValidationCodeDeliveryException.class)
+                .hasMessage("Unable to deliver validation code");
+
+        assertThat(booking.getValidationCode()).isNull();
+        assertThat(booking.getValidationDeliveryStatus()).isNull();
+        assertThat(booking.getValidationCodeSentAt()).isNull();
+    }
+
+    @Test
+    void markValidationCodeDeliveryFailed_shouldPersistFailureMetadata() {
+        TripBooking booking = TripBooking.builder()
+                .trip(trip)
+                .recipientContact("+22507000000")
+                .build();
+
+        bookingValidationService.markValidationCodeDeliveryFailed(
+                booking,
+                "+22507000000",
+                TripBooking.ValidationDeliveryChannel.SMS
+        );
+
+        assertThat(booking.getRecipientContact()).isEqualTo("+22507000000");
+        assertThat(booking.getValidationCode()).isNull();
+        assertThat(booking.getValidationDeliveryChannel()).isEqualTo(TripBooking.ValidationDeliveryChannel.SMS);
+        assertThat(booking.getValidationDeliveryStatus()).isEqualTo(TripBooking.ValidationDeliveryStatus.FAILED);
+        assertThat(booking.getValidationCodeDeliveryFailedAt()).isNotNull();
+    }
+
+    @Test
     void invalidateValidationCode_shouldSetInvalidatedAt_whenCodeIsActive() {
         TripBooking booking = TripBooking.builder()
                 .trip(trip)
                 .recipientContact("recipient@example.com")
                 .validationCode("123456")
+                .validationDeliveryStatus(TripBooking.ValidationDeliveryStatus.DELIVERED)
                 .validationCodeSentAt(LocalDateTime.now())
                 .build();
 
         bookingValidationService.invalidateValidationCode(booking);
 
+        assertThat(booking.getValidationDeliveryStatus()).isEqualTo(TripBooking.ValidationDeliveryStatus.INVALIDATED);
         assertThat(booking.getValidationCodeInvalidatedAt()).isNotNull();
     }
 }

--- a/back-office/src/test/java/com/colick/backoffice/trip/BookingValidationServiceTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/BookingValidationServiceTest.java
@@ -1,0 +1,157 @@
+package com.colick.backoffice.trip;
+
+import com.colick.backoffice.email.EmailService;
+import com.colick.backoffice.notification.qrcode.QrCodeService;
+import com.colick.backoffice.notification.sms.SmsService;
+import com.colick.backoffice.trip.entity.Trip;
+import com.colick.backoffice.trip.entity.TripBooking;
+import com.colick.backoffice.trip.service.BookingValidationService;
+import com.colick.backoffice.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BookingValidationServiceTest {
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private SmsService smsService;
+
+    @Mock
+    private QrCodeService qrCodeService;
+
+    @InjectMocks
+    private BookingValidationService bookingValidationService;
+
+    private Trip trip;
+
+    @BeforeEach
+    void setUp() {
+        User traveler = User.builder()
+                .id(1L)
+                .firstName("Alice")
+                .lastName("Dupont")
+                .email("alice@example.com")
+                .role(User.Role.USER)
+                .build();
+
+        trip = Trip.builder()
+                .id(10L)
+                .traveler(traveler)
+                .departureAddress("Paris")
+                .destination("Abidjan")
+                .departureTime(LocalDateTime.now().plusDays(5))
+                .arrivalTime(LocalDateTime.now().plusDays(6))
+                .build();
+    }
+
+    @Test
+    void normalizeRecipientContact_shouldLowercaseEmail() {
+        String normalized = bookingValidationService.normalizeRecipientContact(" Recipient@Example.COM ");
+
+        assertThat(normalized).isEqualTo("recipient@example.com");
+    }
+
+    @Test
+    void normalizeRecipientContact_shouldNormalizePhone() {
+        String normalized = bookingValidationService.normalizeRecipientContact("+225 07 00-00-00");
+
+        assertThat(normalized).isEqualTo("+22507000000");
+    }
+
+    @Test
+    void normalizeRecipientContact_shouldThrow_whenInvalid() {
+        assertThatThrownBy(() -> bookingValidationService.normalizeRecipientContact("John Doe"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Recipient contact must be a valid email address or phone number");
+    }
+
+    @Test
+    void sendValidationCode_shouldSendEmailAndStoreMetadata_forEmailContact() {
+        TripBooking booking = TripBooking.builder()
+                .id(20L)
+                .trip(trip)
+                .title("Documents")
+                .recipientContact("Recipient@Example.com")
+                .status(TripBooking.BookingStatus.ACCEPTED)
+                .build();
+
+        when(qrCodeService.generateDataUri(anyString())).thenReturn("data:image/png;base64,qr");
+
+        bookingValidationService.sendValidationCode(booking);
+
+        assertThat(booking.getRecipientContact()).isEqualTo("recipient@example.com");
+        assertThat(booking.getValidationDeliveryChannel()).isEqualTo(TripBooking.ValidationDeliveryChannel.EMAIL);
+        assertThat(booking.getValidationCode()).matches("\\d{6}");
+        assertThat(booking.getValidationCodeSentAt()).isNotNull();
+        assertThat(booking.getValidationCodeInvalidatedAt()).isNull();
+
+        ArgumentCaptor<String> qrPayloadCaptor = ArgumentCaptor.forClass(String.class);
+        verify(qrCodeService).generateDataUri(qrPayloadCaptor.capture());
+        assertThat(qrPayloadCaptor.getValue())
+                .contains("BOOKING:20")
+                .contains("TRIP:10")
+                .contains("CODE:" + booking.getValidationCode());
+        verify(emailService).sendBookingValidationCodeEmail(
+                eq("recipient@example.com"),
+                eq("Documents"),
+                eq(booking.getValidationCode()),
+                eq("data:image/png;base64,qr"),
+                eq("Paris"),
+                eq("Abidjan"));
+        verifyNoInteractions(smsService);
+    }
+
+    @Test
+    void sendValidationCode_shouldSendSmsAndStoreMetadata_forPhoneContact() {
+        TripBooking booking = TripBooking.builder()
+                .id(21L)
+                .trip(trip)
+                .title("Valise")
+                .recipientContact("+225 07 00 00 00")
+                .status(TripBooking.BookingStatus.ACCEPTED)
+                .build();
+
+        bookingValidationService.sendValidationCode(booking);
+
+        assertThat(booking.getRecipientContact()).isEqualTo("+22507000000");
+        assertThat(booking.getValidationDeliveryChannel()).isEqualTo(TripBooking.ValidationDeliveryChannel.SMS);
+        assertThat(booking.getValidationCode()).matches("\\d{6}");
+        assertThat(booking.getValidationCodeSentAt()).isNotNull();
+        verify(smsService).sendValidationCode(
+                eq("+22507000000"),
+                eq(booking.getValidationCode()),
+                eq("Paris"),
+                eq("Abidjan"));
+        verifyNoInteractions(emailService);
+        verifyNoInteractions(qrCodeService);
+    }
+
+    @Test
+    void invalidateValidationCode_shouldSetInvalidatedAt_whenCodeIsActive() {
+        TripBooking booking = TripBooking.builder()
+                .trip(trip)
+                .recipientContact("recipient@example.com")
+                .validationCode("123456")
+                .validationCodeSentAt(LocalDateTime.now())
+                .build();
+
+        bookingValidationService.invalidateValidationCode(booking);
+
+        assertThat(booking.getValidationCodeInvalidatedAt()).isNotNull();
+    }
+}

--- a/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
@@ -10,6 +10,7 @@ import com.colick.backoffice.trip.entity.Trip;
 import com.colick.backoffice.trip.entity.TripBooking;
 import com.colick.backoffice.trip.repository.TripBookingRepository;
 import com.colick.backoffice.trip.repository.TripRepository;
+import com.colick.backoffice.trip.service.BookingValidationService;
 import com.colick.backoffice.trip.service.TripServiceImpl;
 import com.colick.backoffice.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +46,9 @@ class TripServiceImplTest {
 
     @Mock
     private LocationRepository locationRepository;
+
+    @Mock
+    private BookingValidationService bookingValidationService;
 
     @InjectMocks
     private TripServiceImpl tripService;
@@ -83,6 +87,9 @@ class TripServiceImplTest {
                 .instantAcceptance(false)
                 .status(Trip.TripStatus.ACTIVE)
                 .build();
+
+        lenient().when(bookingValidationService.normalizeRecipientContact(anyString()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test
@@ -169,6 +176,8 @@ class TripServiceImplTest {
         verify(emailService).sendTripCancelledEmail(
                 eq(anotherSender.getEmail()), eq(anotherSender.getFirstName()),
                 eq(sampleTrip.getDepartureAddress()), eq(sampleTrip.getDestination()));
+        verify(bookingValidationService).invalidateValidationCode(pending);
+        verify(bookingValidationService).invalidateValidationCode(accepted);
     }
 
     @Test
@@ -187,6 +196,7 @@ class TripServiceImplTest {
         TripBookingResponse response = tripService.cancelBooking(10L, 1L, sender);
 
         assertThat(booking.getStatus()).isEqualTo(TripBooking.BookingStatus.CANCELLED);
+        verify(bookingValidationService).invalidateValidationCode(booking);
         verify(emailService).sendBookingCancelledBySenderEmail(
                 eq(traveler.getEmail()), eq(traveler.getFirstName()), eq(sender.getFirstName()),
                 eq(sampleTrip.getDepartureAddress()), eq(sampleTrip.getDestination()));
@@ -208,6 +218,7 @@ class TripServiceImplTest {
         tripService.cancelBooking(10L, 2L, sender);
 
         assertThat(booking.getStatus()).isEqualTo(TripBooking.BookingStatus.CANCELLED);
+        verify(bookingValidationService).invalidateValidationCode(booking);
     }
 
     @Test
@@ -291,6 +302,8 @@ class TripServiceImplTest {
         assertThat(response.getStatus()).isEqualTo(TripBooking.BookingStatus.PENDING);
         assertThat(response.getTitle()).isEqualTo("Electronics");
         assertThat(response.getRecipientContact()).isEqualTo("+225 07 00 00 00");
+        verify(bookingValidationService).normalizeRecipientContact("+225 07 00 00 00");
+        verify(bookingValidationService, never()).sendValidationCode(any());
         verify(emailService).sendTripBookingCreatedEmail(
                 eq(traveler.getEmail()),
                 eq(traveler.getFirstName()),
@@ -321,10 +334,12 @@ class TripServiceImplTest {
                 .thenReturn(List.of());
         when(bookingRepository.save(any(TripBooking.class))).thenReturn(savedBooking);
         doNothing().when(emailService).sendTripBookingCreatedEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+        doNothing().when(bookingValidationService).sendValidationCode(any());
 
         TripBookingResponse response = tripService.createBooking(10L, request, sender);
 
         assertThat(response.getStatus()).isEqualTo(TripBooking.BookingStatus.ACCEPTED);
+        verify(bookingValidationService).sendValidationCode(savedBooking);
     }
 
     @Test
@@ -413,6 +428,7 @@ class TripServiceImplTest {
         tripService.acceptBooking(10L, 1L, traveler);
 
         assertThat(booking.getStatus()).isEqualTo(TripBooking.BookingStatus.ACCEPTED);
+        verify(bookingValidationService).sendValidationCode(booking);
         verify(emailService).sendTripBookingAcceptedEmail(
                 eq(sender.getEmail()),
                 eq(sender.getFirstName()),
@@ -435,6 +451,7 @@ class TripServiceImplTest {
         tripService.rejectBooking(10L, 1L, traveler);
 
         assertThat(booking.getStatus()).isEqualTo(TripBooking.BookingStatus.REJECTED);
+        verify(bookingValidationService).invalidateValidationCode(booking);
         verify(emailService).sendTripBookingRejectedEmail(
                 eq(sender.getEmail()),
                 eq(sender.getFirstName()),

--- a/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
@@ -3,6 +3,7 @@ package com.colick.backoffice.trip;
 import com.colick.backoffice.email.EmailService;
 import com.colick.backoffice.exception.ResourceNotFoundException;
 import com.colick.backoffice.exception.TripBookingConflictException;
+import com.colick.backoffice.exception.ValidationCodeDeliveryException;
 import com.colick.backoffice.location.entity.LocationType;
 import com.colick.backoffice.location.repository.LocationRepository;
 import com.colick.backoffice.trip.dto.*;
@@ -181,6 +182,33 @@ class TripServiceImplTest {
     }
 
     @Test
+    void getBookings_shouldReturnVisibleBookings_whenRequesterOwnsTrip() {
+        TripBooking pending = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.PENDING).build();
+        TripBooking removed = TripBooking.builder()
+                .id(2L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.REMOVED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findByTrip(sampleTrip)).thenReturn(List.of(pending, removed));
+
+        List<TripBookingResponse> bookings = tripService.getBookings(10L, traveler);
+
+        assertThat(bookings).hasSize(1);
+        assertThat(bookings.get(0).getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void getBookings_shouldThrow_whenRequesterIsNotTripOwner() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+
+        assertThatThrownBy(() -> tripService.getBookings(10L, sender))
+                .isInstanceOf(AccessDeniedException.class);
+        verify(bookingRepository, never()).findByTrip(any());
+    }
+
+    @Test
     void cancelBooking_shouldSetCancelledAndNotifyTraveler_whenStatusIsAccepted() {
         TripBooking booking = TripBooking.builder()
                 .id(1L).trip(sampleTrip).sender(sender)
@@ -343,6 +371,49 @@ class TripServiceImplTest {
     }
 
     @Test
+    void createBooking_shouldKeepAcceptedStatusAndMarkDeliveryFailed_whenValidationSendFails() {
+        sampleTrip.setInstantAcceptance(true);
+
+        CreateBookingRequest request = new CreateBookingRequest();
+        request.setTitle("Clothes");
+        request.setWeight(BigDecimal.valueOf(3));
+        request.setRecipientContact("+225 01 00 00 00");
+
+        TripBooking savedBooking = TripBooking.builder()
+                .id(2L).trip(sampleTrip).sender(sender)
+                .title("Clothes")
+                .weight(BigDecimal.valueOf(3))
+                .recipientContact("+22501000000")
+                .status(TripBooking.BookingStatus.ACCEPTED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findByTripAndStatus(sampleTrip, TripBooking.BookingStatus.ACCEPTED))
+                .thenReturn(List.of());
+        when(bookingRepository.save(any(TripBooking.class))).thenReturn(savedBooking);
+        doThrow(new ValidationCodeDeliveryException(
+                "Unable to deliver validation code",
+                "+22501000000",
+                TripBooking.ValidationDeliveryChannel.SMS,
+                new IllegalStateException("SMS delivery is not configured")
+        )).when(bookingValidationService).sendValidationCode(savedBooking);
+        doNothing().when(bookingValidationService).markValidationCodeDeliveryFailed(
+                savedBooking,
+                "+22501000000",
+                TripBooking.ValidationDeliveryChannel.SMS
+        );
+        doNothing().when(emailService).sendTripBookingCreatedEmail(anyString(), anyString(), anyString(), anyString(), anyString());
+
+        TripBookingResponse response = tripService.createBooking(10L, request, sender);
+
+        assertThat(response.getStatus()).isEqualTo(TripBooking.BookingStatus.ACCEPTED);
+        verify(bookingValidationService).markValidationCodeDeliveryFailed(
+                savedBooking,
+                "+22501000000",
+                TripBooking.ValidationDeliveryChannel.SMS
+        );
+    }
+
+    @Test
     void createBooking_shouldThrow_whenSenderAlreadyHasActiveBookingForTrip() {
         CreateBookingRequest request = new CreateBookingRequest();
         request.setTitle("Electronics");
@@ -438,6 +509,64 @@ class TripServiceImplTest {
     }
 
     @Test
+    void acceptBooking_shouldKeepAcceptedStatusAndMarkDeliveryFailed_whenValidationSendFails() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.PENDING).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+        when(bookingRepository.save(any())).thenReturn(booking);
+        doThrow(new ValidationCodeDeliveryException(
+                "Unable to deliver validation code",
+                "+22507000000",
+                TripBooking.ValidationDeliveryChannel.SMS,
+                new IllegalStateException("SMS delivery is not configured")
+        )).when(bookingValidationService).sendValidationCode(booking);
+        doNothing().when(emailService).sendTripBookingAcceptedEmail(anyString(), anyString(), anyString(), anyString());
+
+        TripBookingResponse response = tripService.acceptBooking(10L, 1L, traveler);
+
+        assertThat(response.getStatus()).isEqualTo(TripBooking.BookingStatus.ACCEPTED);
+        verify(bookingValidationService).markValidationCodeDeliveryFailed(
+                booking,
+                "+22507000000",
+                TripBooking.ValidationDeliveryChannel.SMS
+        );
+    }
+
+    @Test
+    void acceptBooking_shouldBeIdempotent_whenAlreadyAccepted() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.ACCEPTED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+
+        TripBookingResponse response = tripService.acceptBooking(10L, 1L, traveler);
+
+        assertThat(response.getStatus()).isEqualTo(TripBooking.BookingStatus.ACCEPTED);
+        verify(bookingRepository, never()).save(any());
+        verify(bookingValidationService, never()).sendValidationCode(any());
+        verify(emailService, never()).sendTripBookingAcceptedEmail(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void acceptBooking_shouldThrow_whenBookingIsCancelled() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.CANCELLED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+
+        assertThatThrownBy(() -> tripService.acceptBooking(10L, 1L, traveler))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Only PENDING bookings can be accepted");
+    }
+
+    @Test
     void rejectBooking_shouldSetRejectedAndSendEmail() {
         TripBooking booking = TripBooking.builder()
                 .id(1L).trip(sampleTrip).sender(sender)
@@ -461,25 +590,72 @@ class TripServiceImplTest {
     }
 
     @Test
-    void removeBooking_shouldDeleteAndSendEmail() {
+    void rejectBooking_shouldBeIdempotent_whenAlreadyRejected() {
         TripBooking booking = TripBooking.builder()
                 .id(1L).trip(sampleTrip).sender(sender)
-                .status(TripBooking.BookingStatus.PENDING).build();
+                .status(TripBooking.BookingStatus.REJECTED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+
+        TripBookingResponse response = tripService.rejectBooking(10L, 1L, traveler);
+
+        assertThat(response.getStatus()).isEqualTo(TripBooking.BookingStatus.REJECTED);
+        verify(bookingRepository, never()).save(any());
+        verify(emailService, never()).sendTripBookingRejectedEmail(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void rejectBooking_shouldThrow_whenBookingIsAccepted() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.ACCEPTED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+
+        assertThatThrownBy(() -> tripService.rejectBooking(10L, 1L, traveler))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Only PENDING bookings can be rejected");
+    }
+
+    @Test
+    void removeBooking_shouldMarkRemovedInvalidateCodeAndSendEmail() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.ACCEPTED).build();
 
         when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
         when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
         doNothing().when(emailService).sendTripBookingRemovedEmail(anyString(), anyString(), anyString(), anyString());
-        doNothing().when(bookingRepository).delete(booking);
+        when(bookingRepository.save(booking)).thenReturn(booking);
 
         tripService.removeBooking(10L, 1L, traveler);
 
+        assertThat(booking.getStatus()).isEqualTo(TripBooking.BookingStatus.REMOVED);
+        verify(bookingValidationService).invalidateValidationCode(booking);
         verify(emailService).sendTripBookingRemovedEmail(
                 eq(sender.getEmail()),
                 eq(sender.getFirstName()),
                 eq(sampleTrip.getDepartureAddress()),
                 eq(sampleTrip.getDestination())
         );
-        verify(bookingRepository).delete(booking);
+        verify(bookingRepository).save(booking);
+    }
+
+    @Test
+    void removeBooking_shouldThrow_whenBookingIsPending() {
+        TripBooking booking = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.PENDING).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
+
+        assertThatThrownBy(() -> tripService.removeBooking(10L, 1L, traveler))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Only ACCEPTED bookings can be removed");
+        verify(bookingRepository, never()).save(any());
     }
 
     @Test

--- a/front-office/src/app/models/booking.model.ts
+++ b/front-office/src/app/models/booking.model.ts
@@ -17,4 +17,8 @@ export interface BookingResponse {
   packagePhotoUrl?: string;
   recipientContact: string;
   status: 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'CANCELLED';
+  validationDeliveryChannel?: 'EMAIL' | 'SMS';
+  validationCodeSentAt?: string;
+  validationCodeInvalidatedAt?: string;
+  validationCodeActive: boolean;
 }

--- a/front-office/src/app/models/booking.model.ts
+++ b/front-office/src/app/models/booking.model.ts
@@ -16,9 +16,11 @@ export interface BookingResponse {
   description?: string;
   packagePhotoUrl?: string;
   recipientContact: string;
-  status: 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'CANCELLED';
+  status: 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'CANCELLED' | 'REMOVED';
   validationDeliveryChannel?: 'EMAIL' | 'SMS';
+  validationDeliveryStatus?: 'DELIVERED' | 'FAILED' | 'INVALIDATED';
   validationCodeSentAt?: string;
   validationCodeInvalidatedAt?: string;
+  validationCodeDeliveryFailedAt?: string;
   validationCodeActive: boolean;
 }

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.html
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.html
@@ -293,8 +293,19 @@
                           <div>
                             <p class="font-medium text-text-primary text-sm">{{ booking.senderName }}</p>
                             <p class="text-text-secondary text-xs">{{ booking.title }} · {{ booking.weight }} kg</p>
+                            <p class="text-text-muted text-xs mt-1">Contact destinataire : {{ booking.recipientContact }}</p>
                             @if (booking.description) {
                               <p class="text-text-muted text-xs mt-1">{{ booking.description }}</p>
+                            }
+                            @if (booking.validationCodeActive && booking.validationDeliveryChannel && booking.validationCodeSentAt) {
+                              <p class="text-success text-xs mt-1">
+                                Code actif envoyé par {{ validationChannelLabel(booking.validationDeliveryChannel) }}
+                                le {{ booking.validationCodeSentAt | date:'dd/MM/yyyy HH:mm' }}
+                              </p>
+                            } @else if (booking.validationCodeInvalidatedAt) {
+                              <p class="text-warning text-xs mt-1">
+                                Code invalidé le {{ booking.validationCodeInvalidatedAt | date:'dd/MM/yyyy HH:mm' }}
+                              </p>
                             }
                           </div>
                           <div class="flex items-center gap-2 shrink-0">
@@ -361,6 +372,20 @@
                       </p>
                       @if (booking.description) {
                         <p class="text-text-muted text-xs mt-1">{{ booking.description }}</p>
+                      }
+                      @if (booking.validationCodeActive && booking.validationDeliveryChannel && booking.validationCodeSentAt) {
+                        <p class="text-success text-xs mt-1">
+                          Code actif envoyé par {{ validationChannelLabel(booking.validationDeliveryChannel) }}
+                          le {{ booking.validationCodeSentAt | date:'dd/MM/yyyy HH:mm' }}
+                        </p>
+                      } @else if (booking.validationCodeInvalidatedAt) {
+                        <p class="text-warning text-xs mt-1">
+                          Code invalidé le {{ booking.validationCodeInvalidatedAt | date:'dd/MM/yyyy HH:mm' }}
+                        </p>
+                      } @else if (booking.status === 'ACCEPTED') {
+                        <p class="text-text-muted text-xs mt-1">
+                          Le code de validation est en cours d’envoi au destinataire.
+                        </p>
                       }
                     </div>
                     <!-- Status badge + cancel button -->

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.html
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.html
@@ -302,6 +302,10 @@
                                 Code actif envoyé par {{ validationChannelLabel(booking.validationDeliveryChannel) }}
                                 le {{ booking.validationCodeSentAt | date:'dd/MM/yyyy HH:mm' }}
                               </p>
+                            } @else if (booking.validationDeliveryStatus === 'FAILED' && booking.validationCodeDeliveryFailedAt) {
+                              <p class="text-warning text-xs mt-1">
+                                L'envoi du code a échoué le {{ booking.validationCodeDeliveryFailedAt | date:'dd/MM/yyyy HH:mm' }}.
+                              </p>
                             } @else if (booking.validationCodeInvalidatedAt) {
                               <p class="text-warning text-xs mt-1">
                                 Code invalidé le {{ booking.validationCodeInvalidatedAt | date:'dd/MM/yyyy HH:mm' }}
@@ -377,6 +381,10 @@
                         <p class="text-success text-xs mt-1">
                           Code actif envoyé par {{ validationChannelLabel(booking.validationDeliveryChannel) }}
                           le {{ booking.validationCodeSentAt | date:'dd/MM/yyyy HH:mm' }}
+                        </p>
+                      } @else if (booking.validationDeliveryStatus === 'FAILED' && booking.validationCodeDeliveryFailedAt) {
+                        <p class="text-warning text-xs mt-1">
+                          L'envoi du code a échoué le {{ booking.validationCodeDeliveryFailedAt | date:'dd/MM/yyyy HH:mm' }}.
                         </p>
                       } @else if (booking.validationCodeInvalidatedAt) {
                         <p class="text-warning text-xs mt-1">

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.ts
@@ -335,4 +335,8 @@ export class DashboardPageComponent implements OnInit {
   statusClass(status: string): string {
     return ({ PENDING: 'bg-yellow-100 text-yellow-800', ACCEPTED: 'bg-green-100 text-green-800', REJECTED: 'bg-red-100 text-red-800', CANCELLED: 'bg-gray-100 text-gray-500' } as Record<string, string>)[status] ?? 'bg-gray-100 text-gray-800';
   }
+
+  validationChannelLabel(channel?: string): string {
+    return channel === 'SMS' ? 'SMS' : 'e-mail';
+  }
 }

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.ts
@@ -329,11 +329,11 @@ export class DashboardPageComponent implements OnInit {
   }
 
   statusLabel(status: string): string {
-    return ({ PENDING: 'En attente', ACCEPTED: 'Acceptée', REJECTED: 'Refusée', CANCELLED: 'Annulée' } as Record<string, string>)[status] ?? status;
+    return ({ PENDING: 'En attente', ACCEPTED: 'Acceptée', REJECTED: 'Refusée', CANCELLED: 'Annulée', REMOVED: 'Retirée' } as Record<string, string>)[status] ?? status;
   }
 
   statusClass(status: string): string {
-    return ({ PENDING: 'bg-yellow-100 text-yellow-800', ACCEPTED: 'bg-green-100 text-green-800', REJECTED: 'bg-red-100 text-red-800', CANCELLED: 'bg-gray-100 text-gray-500' } as Record<string, string>)[status] ?? 'bg-gray-100 text-gray-800';
+    return ({ PENDING: 'bg-yellow-100 text-yellow-800', ACCEPTED: 'bg-green-100 text-green-800', REJECTED: 'bg-red-100 text-red-800', CANCELLED: 'bg-gray-100 text-gray-500', REMOVED: 'bg-slate-100 text-slate-600' } as Record<string, string>)[status] ?? 'bg-gray-100 text-gray-800';
   }
 
   validationChannelLabel(channel?: string): string {

--- a/front-office/src/app/pages/search/search-page.component.spec.ts
+++ b/front-office/src/app/pages/search/search-page.component.spec.ts
@@ -117,4 +117,22 @@ describe('SearchPageComponent', () => {
 
     expect(messagingServiceMock.startConversation).not.toHaveBeenCalled();
   });
+
+  it('treats only pending and accepted bookings as active', () => {
+    component.myBookings = [
+      { id: 1, tripId: 10, senderId: 1, senderName: 'Bob', title: 'A', weight: 1, recipientContact: 'a@example.com', status: 'CANCELLED', validationCodeActive: false },
+      { id: 2, tripId: 10, senderId: 1, senderName: 'Bob', title: 'B', weight: 1, recipientContact: 'b@example.com', status: 'REMOVED', validationCodeActive: false },
+      { id: 3, tripId: 10, senderId: 1, senderName: 'Bob', title: 'C', weight: 1, recipientContact: 'c@example.com', status: 'PENDING', validationCodeActive: false },
+    ];
+
+    expect(component.hasActiveBookingForTrip(10)).toBeTrue();
+
+    component.myBookings = [
+      { id: 4, tripId: 11, senderId: 1, senderName: 'Bob', title: 'D', weight: 1, recipientContact: 'd@example.com', status: 'CANCELLED', validationCodeActive: false },
+      { id: 5, tripId: 11, senderId: 1, senderName: 'Bob', title: 'E', weight: 1, recipientContact: 'e@example.com', status: 'REMOVED', validationCodeActive: false },
+      { id: 6, tripId: 11, senderId: 1, senderName: 'Bob', title: 'F', weight: 1, recipientContact: 'f@example.com', status: 'REJECTED', validationCodeActive: false },
+    ];
+
+    expect(component.hasActiveBookingForTrip(11)).toBeFalse();
+  });
 });

--- a/front-office/src/app/pages/search/search-page.component.spec.ts
+++ b/front-office/src/app/pages/search/search-page.component.spec.ts
@@ -16,6 +16,7 @@ describe('SearchPageComponent', () => {
   const tripServiceMock = {
     searchTrips: jasmine.createSpy('searchTrips').and.returnValue(of([])),
     createBooking: jasmine.createSpy('createBooking'),
+    getMyBookings: jasmine.createSpy('getMyBookings').and.returnValue(of([])),
   };
 
   const authServiceMock = {

--- a/front-office/src/app/pages/search/search-page.component.ts
+++ b/front-office/src/app/pages/search/search-page.component.ts
@@ -247,7 +247,10 @@ export class SearchPageComponent implements OnInit, OnDestroy {
   }
 
   hasActiveBookingForTrip(tripId: number): boolean {
-    return this.myBookings.some((booking) => booking.tripId === tripId && booking.status !== 'REJECTED');
+    return this.myBookings.some(
+      (booking) => booking.tripId === tripId
+        && (booking.status === 'PENDING' || booking.status === 'ACCEPTED')
+    );
   }
 
   private loadSentBookings(): void {

--- a/front-office/src/app/shared/components/booking-modal/booking-modal.component.html
+++ b/front-office/src/app/shared/components/booking-modal/booking-modal.component.html
@@ -84,9 +84,9 @@
             <h3 class="text-lg font-semibold text-success mb-1">
               Demande envoyée avec succès !
             </h3>
-            <p class="text-sm text-text-secondary">
-              Le voyageur sera notifié de votre demande.
-            </p>
+             <p class="text-sm text-text-secondary">
+               Le destinataire recevra son code dès que la demande sera acceptée.
+             </p>
           </div>
         }
 
@@ -207,20 +207,31 @@
                 id="booking-recipient"
                 type="text"
                 formControlName="recipientContact"
-                placeholder="Nom, téléphone ou email du destinataire"
+                placeholder="Ex : +22507000000 ou destinataire@email.com"
                 autocomplete="off"
                 [attr.aria-invalid]="bookingForm.get('recipientContact')?.touched && bookingForm.get('recipientContact')?.invalid"
-                aria-describedby="recipient-error"
+                aria-describedby="recipient-hint recipient-error"
                 class="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm text-text-primary
                        placeholder:text-text-muted bg-white
                        focus:outline-none focus:ring-2 focus:ring-secondary focus:border-secondary
                        transition-shadow" />
+              <p id="recipient-hint" class="mt-1.5 text-xs text-text-muted">
+                Renseignez un numéro de téléphone ou une adresse e-mail. Le code de validation partira après acceptation.
+              </p>
               @if (bookingForm.get('recipientContact')?.touched && bookingForm.get('recipientContact')?.hasError('required')) {
                 <p id="recipient-error" class="mt-1.5 text-xs text-error flex items-center gap-1" role="alert">
                   <svg class="w-3.5 h-3.5 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                     <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
                   </svg>
                   Le contact du destinataire est requis
+                </p>
+              }
+              @if (bookingForm.get('recipientContact')?.touched && bookingForm.get('recipientContact')?.hasError('recipientContact')) {
+                <p id="recipient-error" class="mt-1.5 text-xs text-error flex items-center gap-1" role="alert">
+                  <svg class="w-3.5 h-3.5 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
+                  </svg>
+                  Saisissez un numéro de téléphone ou une adresse e-mail valide
                 </p>
               }
             </div>

--- a/front-office/src/app/shared/components/booking-modal/booking-modal.component.spec.ts
+++ b/front-office/src/app/shared/components/booking-modal/booking-modal.component.spec.ts
@@ -1,0 +1,74 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { BookingModalComponent } from './booking-modal.component';
+import { TripService } from '../../../services/trip.service';
+
+describe('BookingModalComponent', () => {
+  let fixture: ComponentFixture<BookingModalComponent>;
+  let component: BookingModalComponent;
+
+  const tripServiceMock = {
+    createBooking: jasmine.createSpy('createBooking').and.returnValue(of({
+      id: 1,
+      tripId: 10,
+      senderId: 2,
+      senderName: 'Bob Martin',
+      title: 'Documents',
+      weight: 1,
+      recipientContact: 'recipient@example.com',
+      status: 'PENDING',
+      validationCodeActive: false,
+    })),
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BookingModalComponent],
+      providers: [{ provide: TripService, useValue: tripServiceMock }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BookingModalComponent);
+    component = fixture.componentInstance;
+    component.trip = {
+      id: 10,
+      travelerId: 99,
+      travelerName: 'Alice Dupont',
+      departureAddress: 'Paris',
+      destination: 'Abidjan',
+      departureTime: '2026-05-01T08:00:00Z',
+      arrivalTime: '2026-05-02T08:00:00Z',
+      maxWeight: 10,
+      availableWeight: 10,
+      pricePerKilo: 5,
+      instantAcceptance: false,
+      status: 'ACTIVE',
+    };
+    component.isOpen = true;
+    fixture.detectChanges();
+  });
+
+  it('marks recipient contact invalid when it is neither phone nor email', () => {
+    component.bookingForm.patchValue({
+      title: 'Documents',
+      weight: 1,
+      recipientContact: 'John Doe',
+    });
+    component.bookingForm.get('recipientContact')?.markAsTouched();
+
+    expect(component.bookingForm.get('recipientContact')?.hasError('recipientContact')).toBeTrue();
+  });
+
+  it('trims recipient contact before sending the booking request', () => {
+    component.bookingForm.patchValue({
+      title: 'Documents',
+      weight: 1,
+      recipientContact: ' recipient@example.com ',
+    });
+
+    component.onSubmit();
+
+    expect(tripServiceMock.createBooking).toHaveBeenCalledWith(10, jasmine.objectContaining({
+      recipientContact: 'recipient@example.com',
+    }));
+  });
+});

--- a/front-office/src/app/shared/components/booking-modal/booking-modal.component.ts
+++ b/front-office/src/app/shared/components/booking-modal/booking-modal.component.ts
@@ -1,9 +1,25 @@
 import { Component, Input, Output, EventEmitter, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { AbstractControl, ReactiveFormsModule, FormBuilder, ValidationErrors, Validators } from '@angular/forms';
 import { Trip } from '../../../models/trip.model';
 import { BookingResponse } from '../../../models/booking.model';
 import { TripService } from '../../../services/trip.service';
+
+const EMAIL_PATTERN = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
+
+function recipientContactValidator(control: AbstractControl): ValidationErrors | null {
+  const value = `${control.value ?? ''}`.trim();
+  if (!value) {
+    return null;
+  }
+
+  const normalizedPhone = value.replace(/[\s().-]/g, '');
+  if (EMAIL_PATTERN.test(value) || /^\+?[0-9]{6,15}$/.test(normalizedPhone)) {
+    return null;
+  }
+
+  return { recipientContact: true };
+}
 
 /**
  * BookingModalComponent - Modal overlay for submitting a parcel booking request.
@@ -27,7 +43,7 @@ export class BookingModalComponent {
     title: ['', [Validators.required]],
     weight: [null as number | null, [Validators.required, Validators.min(0.1)]],
     description: [''],
-    recipientContact: ['', [Validators.required]],
+    recipientContact: ['', [Validators.required, recipientContactValidator]],
   });
 
   isLoading = false;
@@ -57,7 +73,7 @@ export class BookingModalComponent {
       title: this.bookingForm.value.title!,
       weight,
       description: this.bookingForm.value.description || undefined,
-      recipientContact: this.bookingForm.value.recipientContact!,
+      recipientContact: this.bookingForm.value.recipientContact!.trim(),
     }).subscribe({
       next: (booking: BookingResponse) => {
         this.isLoading = false;


### PR DESCRIPTION
## Summary\n- generate and persist recipient validation metadata on accepted bookings\n- send six-digit SMS codes or email codes with QR payloads depending on the recipient contact\n- invalidate issued codes when bookings or trips are cancelled, and surface validation delivery status in the front-office\n\nCloses #49