### PR TITLE
fix: hide expired trips from search results

### DIFF
--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
@@ -383,16 +383,23 @@ public class TripServiceImpl implements TripService {
     @Transactional(readOnly = true)
     public List<TripResponse> searchTrips(String departure, String destination) {
         List<Trip> activeTrips = tripRepository.findByStatus(Trip.TripStatus.ACTIVE);
+        LocalDateTime searchReferenceTime = LocalDateTime.now();
 
         Set<String> departureTerms = expandSearchTerm(departure);
         Set<String> destinationTerms = expandSearchTerm(destination);
 
         List<Trip> matchingTrips = activeTrips.stream()
+                .filter(trip -> departsAtOrAfter(trip, searchReferenceTime))
                 .filter(t -> departureTerms == null || matchesAnyTerm(t.getDepartureAddress(), departureTerms))
                 .filter(t -> destinationTerms == null || matchesAnyTerm(t.getDestination(), destinationTerms))
                 .toList();
 
         return mapTrips(matchingTrips, true);
+    }
+
+    private boolean departsAtOrAfter(Trip trip, LocalDateTime referenceTime) {
+        LocalDateTime departureTime = trip.getDepartureTime();
+        return departureTime != null && !departureTime.isBefore(referenceTime);
     }
 
     /**

--- a/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
@@ -866,6 +866,41 @@ class TripServiceImplTest {
     }
 
     @Test
+    void searchTrips_shouldTakeTimeOfDayIntoAccountForSameDate() {
+        LocalDateTime now = LocalDateTime.now();
+
+        Trip sameDayExpiredTrip = Trip.builder()
+                .id(11L).traveler(traveler)
+                .departureAddress("Paris").destination("Abidjan")
+                .departureTime(now.minusMinutes(10))
+                .arrivalTime(now.plusHours(5))
+                .maxWeight(BigDecimal.valueOf(15))
+                .pricePerKilo(BigDecimal.valueOf(8))
+                .status(Trip.TripStatus.ACTIVE).build();
+
+        Trip sameDayUpcomingTrip = Trip.builder()
+                .id(12L).traveler(traveler)
+                .departureAddress("Paris").destination("Abidjan")
+                .departureTime(now.plusMinutes(10))
+                .arrivalTime(now.plusHours(6))
+                .maxWeight(BigDecimal.valueOf(18))
+                .pricePerKilo(BigDecimal.valueOf(9))
+                .status(Trip.TripStatus.ACTIVE).build();
+
+        when(tripRepository.findByStatus(Trip.TripStatus.ACTIVE))
+                .thenReturn(List.of(sameDayExpiredTrip, sameDayUpcomingTrip));
+        when(locationRepository.findNamesByTypeAndCountryContaining(LocationType.CITY, "Paris"))
+                .thenReturn(List.of());
+        when(bookingRepository.findByTripAndStatus(sameDayUpcomingTrip, TripBooking.BookingStatus.ACCEPTED))
+                .thenReturn(List.of());
+
+        List<TripResponse> results = tripService.searchTrips("Paris", null);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getId()).isEqualTo(sameDayUpcomingTrip.getId());
+    }
+
+    @Test
     void searchTrips_shouldReturnMatchingTripsByDestination() {
         when(tripRepository.findByStatus(Trip.TripStatus.ACTIVE)).thenReturn(List.of(sampleTrip));
         when(locationRepository.findNamesByTypeAndCountryContaining(LocationType.CITY, "Abidjan"))

--- a/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
@@ -843,6 +843,29 @@ class TripServiceImplTest {
     }
 
     @Test
+    void searchTrips_shouldExcludeTripsWhoseDepartureTimeHasPassed() {
+        Trip expiredTrip = Trip.builder()
+                .id(11L).traveler(traveler)
+                .departureAddress("Paris").destination("Abidjan")
+                .departureTime(LocalDateTime.now().minusHours(1))
+                .arrivalTime(LocalDateTime.now().plusHours(5))
+                .maxWeight(BigDecimal.valueOf(15))
+                .pricePerKilo(BigDecimal.valueOf(8))
+                .status(Trip.TripStatus.ACTIVE).build();
+
+        when(tripRepository.findByStatus(Trip.TripStatus.ACTIVE)).thenReturn(List.of(sampleTrip, expiredTrip));
+        when(locationRepository.findNamesByTypeAndCountryContaining(LocationType.CITY, "Paris"))
+                .thenReturn(List.of());
+        when(bookingRepository.findByTripAndStatus(sampleTrip, TripBooking.BookingStatus.ACCEPTED))
+                .thenReturn(List.of());
+
+        List<TripResponse> results = tripService.searchTrips("Paris", null);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getId()).isEqualTo(sampleTrip.getId());
+    }
+
+    @Test
     void searchTrips_shouldReturnMatchingTripsByDestination() {
         when(tripRepository.findByStatus(Trip.TripStatus.ACTIVE)).thenReturn(List.of(sampleTrip));
         when(locationRepository.findNamesByTypeAndCountryContaining(LocationType.CITY, "Abidjan"))


### PR DESCRIPTION
## Summary\n- exclude trips whose departure time is already past from the public search endpoint\n- keep existing departure/destination matching and available weight computation unchanged\n- add regression coverage for expired trips in TripServiceImplTest\n\nFixes #64