### PR TITLE
feat: permettre la modification d'un voyage

### DIFF
--- a/back-office/src/main/java/com/colick/backoffice/email/EmailService.java
+++ b/back-office/src/main/java/com/colick/backoffice/email/EmailService.java
@@ -161,6 +161,23 @@ public class EmailService {
         );
     }
 
+    public void sendTripUpdatedEmail(String to,
+                                     String senderFirstName,
+                                     String departureAddress,
+                                     String destination) {
+        sendTemplateEmail(
+            to,
+            "Trajet modifié - Colick",
+            "email/trip-updated",
+            Map.of(
+                "firstName", senderFirstName,
+                "departureAddress", departureAddress,
+                "destination", destination,
+                "supportEmail", supportEmail
+            )
+        );
+    }
+
     public void sendBookingCancelledBySenderEmail(String to,
                                                   String travelerFirstName,
                                                   String senderFirstName,

--- a/back-office/src/main/java/com/colick/backoffice/exception/GlobalExceptionHandler.java
+++ b/back-office/src/main/java/com/colick/backoffice/exception/GlobalExceptionHandler.java
@@ -38,7 +38,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({
             UserAlreadyExistsException.class,
             TripBookingConflictException.class,
-            ReviewSubmissionConflictException.class
+            ReviewSubmissionConflictException.class,
+            TripUpdateNotAllowedException.class
     })
     public ResponseEntity<ApiError> handleConflict(RuntimeException ex) {
         return ResponseEntity

--- a/back-office/src/main/java/com/colick/backoffice/exception/TripUpdateNotAllowedException.java
+++ b/back-office/src/main/java/com/colick/backoffice/exception/TripUpdateNotAllowedException.java
@@ -1,0 +1,11 @@
+package com.colick.backoffice.exception;
+
+/**
+ * Thrown when a trip cannot be updated because of its current status.
+ */
+public class TripUpdateNotAllowedException extends RuntimeException {
+
+    public TripUpdateNotAllowedException(String message) {
+        super(message);
+    }
+}

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
@@ -2,6 +2,7 @@ package com.colick.backoffice.trip.service;
 
 import com.colick.backoffice.email.EmailService;
 import com.colick.backoffice.exception.TripBookingConflictException;
+import com.colick.backoffice.exception.TripUpdateNotAllowedException;
 import com.colick.backoffice.exception.ResourceNotFoundException;
 import com.colick.backoffice.exception.ValidationCodeDeliveryException;
 import com.colick.backoffice.location.entity.LocationType;
@@ -81,6 +82,9 @@ public class TripServiceImpl implements TripService {
     public TripResponse updateTrip(Long id, UpdateTripRequest request, User requester) {
         Trip trip = findTripOrThrow(id);
         assertTripOwner(trip, requester);
+        if (trip.getStatus() != Trip.TripStatus.ACTIVE) {
+            throw new TripUpdateNotAllowedException("Only ACTIVE trips can be updated");
+        }
 
         if (request.getDepartureAddress() != null) trip.setDepartureAddress(request.getDepartureAddress());
         if (request.getDestination() != null) trip.setDestination(request.getDestination());
@@ -90,7 +94,9 @@ public class TripServiceImpl implements TripService {
         if (request.getPricePerKilo() != null) trip.setPricePerKilo(request.getPricePerKilo());
         if (request.getInstantAcceptance() != null) trip.setInstantAcceptance(request.getInstantAcceptance());
 
-        return toTripResponse(tripRepository.save(trip));
+        Trip savedTrip = tripRepository.save(trip);
+        notifyAcceptedBookingSendersAboutTripUpdate(savedTrip);
+        return toTripResponse(savedTrip);
     }
 
     @Override
@@ -375,6 +381,16 @@ public class TripServiceImpl implements TripService {
             );
         }
         return bookingRepository.save(booking);
+    }
+
+    private void notifyAcceptedBookingSendersAboutTripUpdate(Trip trip) {
+        bookingRepository.findByTripAndStatus(trip, TripBooking.BookingStatus.ACCEPTED)
+                .forEach(booking -> emailService.sendTripUpdatedEmail(
+                        booking.getSender().getEmail(),
+                        booking.getSender().getFirstName(),
+                        trip.getDepartureAddress(),
+                        trip.getDestination()
+                ));
     }
 
     // ---- Trip search -------------------------------------------------------

--- a/back-office/src/main/resources/templates/email/trip-updated.html
+++ b/back-office/src/main/resources/templates/email/trip-updated.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trajet modifié - Colick</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f5f5f5;font-family:Poppins,Arial,sans-serif;color:#111827;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5;padding:24px 0;">
+    <tr>
+        <td align="center">
+            <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:16px;overflow:hidden;">
+                <tr>
+                    <td style="background:#023047;padding:20px 24px;color:#ffffff;font-size:20px;font-weight:700;">
+                        Colick
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:28px 24px;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Bonjour <span th:text="${firstName}">Utilisateur</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            Le trajet <strong th:text="${departureAddress}">Paris</strong> →
+                            <strong th:text="${destination}">Abidjan</strong> que vous avez réservé a été modifié par le voyageur.
+                        </p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;background:#F9FAFB;border-left:4px solid #fb8500;padding:12px 16px;border-radius:10px;">
+                            Merci de vérifier les nouvelles informations dans votre espace Colick.
+                        </p>
+                        <hr style="border:none;border-top:1px solid #e5e7eb;margin:20px 0;">
+                        <p style="margin:0 0 12px 0;font-size:16px;">Hello <span th:text="${firstName}">User</span>,</p>
+                        <p style="margin:0 0 20px 0;line-height:1.6;">
+                            The trip <strong th:text="${departureAddress}">Paris</strong> →
+                            <strong th:text="${destination}">Abidjan</strong> you booked has been updated by the traveler.
+                        </p>
+                        <p style="margin:0;line-height:1.6;color:#6B7280;">
+                            Please review the updated details in your Colick account.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="background:#F9FAFB;padding:16px 24px;font-size:12px;color:#6B7280;">
+                        Besoin d'aide / Need help? <span style="color:#219ebc;" th:text="${supportEmail}">support@colick.app</span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
@@ -3,6 +3,7 @@ package com.colick.backoffice.trip;
 import com.colick.backoffice.email.EmailService;
 import com.colick.backoffice.exception.ResourceNotFoundException;
 import com.colick.backoffice.exception.TripBookingConflictException;
+import com.colick.backoffice.exception.TripUpdateNotAllowedException;
 import com.colick.backoffice.exception.ValidationCodeDeliveryException;
 import com.colick.backoffice.location.entity.LocationType;
 import com.colick.backoffice.location.repository.LocationRepository;
@@ -147,6 +148,88 @@ class TripServiceImplTest {
         assertThatThrownBy(() -> tripService.getTripById(99L))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("99");
+    }
+
+    @Test
+    void updateTrip_shouldUpdateActiveTripAndNotifyAcceptedBookingSenders() {
+        UpdateTripRequest request = new UpdateTripRequest();
+        request.setDepartureAddress("Lyon");
+        request.setDestination("Dakar");
+        request.setInstantAcceptance(true);
+
+        TripBooking acceptedBooking = TripBooking.builder()
+                .id(1L)
+                .trip(sampleTrip)
+                .sender(sender)
+                .status(TripBooking.BookingStatus.ACCEPTED)
+                .build();
+        TripBooking pendingBooking = TripBooking.builder()
+                .id(2L)
+                .trip(sampleTrip)
+                .sender(User.builder()
+                        .id(3L)
+                        .firstName("Claire")
+                        .email("claire@example.com")
+                        .role(User.Role.USER)
+                        .build())
+                .status(TripBooking.BookingStatus.PENDING)
+                .build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(tripRepository.save(any(Trip.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(bookingRepository.findByTripAndStatus(sampleTrip, TripBooking.BookingStatus.ACCEPTED))
+                .thenReturn(List.of(acceptedBooking));
+
+        TripResponse response = tripService.updateTrip(10L, request, traveler);
+
+        assertThat(response.getDepartureAddress()).isEqualTo("Lyon");
+        assertThat(response.getDestination()).isEqualTo("Dakar");
+        assertThat(response.isInstantAcceptance()).isTrue();
+        verify(bookingRepository).findByTripAndStatus(sampleTrip, TripBooking.BookingStatus.ACCEPTED);
+        verify(emailService).sendTripUpdatedEmail(
+                eq(sender.getEmail()),
+                eq(sender.getFirstName()),
+                eq("Lyon"),
+                eq("Dakar")
+        );
+        verify(emailService, never()).sendTripUpdatedEmail(
+                eq(pendingBooking.getSender().getEmail()),
+                anyString(),
+                anyString(),
+                anyString()
+        );
+    }
+
+    @Test
+    void updateTrip_shouldThrow_whenTripIsCompleted() {
+        sampleTrip.setStatus(Trip.TripStatus.COMPLETED);
+        UpdateTripRequest request = new UpdateTripRequest();
+        request.setDestination("Dakar");
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+
+        assertThatThrownBy(() -> tripService.updateTrip(10L, request, traveler))
+                .isInstanceOf(TripUpdateNotAllowedException.class)
+                .hasMessage("Only ACTIVE trips can be updated");
+
+        verify(tripRepository, never()).save(any());
+        verify(emailService, never()).sendTripUpdatedEmail(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void updateTrip_shouldThrow_whenTripIsCancelled() {
+        sampleTrip.setStatus(Trip.TripStatus.CANCELLED);
+        UpdateTripRequest request = new UpdateTripRequest();
+        request.setDestination("Dakar");
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+
+        assertThatThrownBy(() -> tripService.updateTrip(10L, request, traveler))
+                .isInstanceOf(TripUpdateNotAllowedException.class)
+                .hasMessage("Only ACTIVE trips can be updated");
+
+        verify(tripRepository, never()).save(any());
+        verify(emailService, never()).sendTripUpdatedEmail(anyString(), anyString(), anyString(), anyString());
     }
 
     @Test

--- a/front-office/src/app/app.routes.ts
+++ b/front-office/src/app/app.routes.ts
@@ -28,6 +28,14 @@ export const routes: Routes = [
       ),
   },
   {
+    path: 'propose/:id',
+    canActivate: [authGuard],
+    loadComponent: () =>
+      import('./pages/propose-trip/propose-trip-page.component').then(
+        (m) => m.ProposeTripPageComponent
+      ),
+  },
+  {
     path: 'propose',
     canActivate: [authGuard],
     loadComponent: () =>

--- a/front-office/src/app/models/trip.model.ts
+++ b/front-office/src/app/models/trip.model.ts
@@ -12,6 +12,12 @@ export interface CreateTripDto {
 }
 
 /**
+ * DTO used when updating an existing trip via PUT /api/trips/:id.
+ * The edit form reuses the exact same payload as creation.
+ */
+export type UpdateTripDto = CreateTripDto;
+
+/**
  * Trip model representing a trip returned by the search API.
  */
 export interface Trip {

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.html
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.html
@@ -245,7 +245,21 @@
               </div>
             } @else if (myTrips.length === 0) {
               <div class="text-center py-10 text-text-secondary text-sm">
-                <p class="mb-6">Vous n'avez aucun trajet proposé pour le moment.</p>
+                <div class="w-14 h-14 bg-accent/10 rounded-full flex items-center justify-center mx-auto mb-4" aria-hidden="true">
+                  <svg class="w-7 h-7 text-accent" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
+                  </svg>
+                </div>
+                <p class="mb-5">Vous n'avez aucun trajet proposé pour le moment.</p>
+                <a
+                  routerLink="/propose"
+                  class="inline-flex items-center gap-2 bg-secondary text-white font-semibold px-6 py-2.5 rounded-lg text-sm hover:bg-opacity-90 transition-all duration-200 shadow-lg shadow-secondary/30"
+                >
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+                  </svg>
+                  Proposer un voyage
+                </a>
               </div>
             } @else {
               <!-- Trip selection grid -->
@@ -285,6 +299,17 @@
                     </p>
                     <div class="mt-3 flex justify-end gap-3" (click)="$event.stopPropagation()">
                       @if (trip.status === 'ACTIVE') {
+                        <!-- Edit action — navigates to the shared propose/edit page -->
+                        <button
+                          (click)="editTrip(trip.id)"
+                          class="inline-flex items-center gap-1 text-xs font-semibold text-secondary hover:underline"
+                          aria-label="Modifier ce trajet"
+                        >
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536M9 13l6.586-6.586a2 2 0 012.828 2.828L11.828 15.828a2 2 0 01-1.414.586H9v-2.414a2 2 0 01.586-1.414z"/>
+                          </svg>
+                          Modifier
+                        </button>
                         <button
                           (click)="completeTrip(trip.id)"
                           [disabled]="isCompletingTrip"

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.spec.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import { BehaviorSubject, of } from 'rxjs';
 import { UserResponse } from '../../models/auth.model';
 import { AuthService } from '../../services/auth.service';
@@ -9,6 +9,7 @@ import { DashboardPageComponent } from './dashboard-page.component';
 describe('DashboardPageComponent', () => {
   let fixture: ComponentFixture<DashboardPageComponent>;
   let component: DashboardPageComponent;
+  let router: Router;
 
   const currentUser$ = new BehaviorSubject<UserResponse>({
     id: 1,
@@ -54,6 +55,8 @@ describe('DashboardPageComponent', () => {
       ],
     }).compileComponents();
 
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate').and.resolveTo(true);
     fixture = TestBed.createComponent(DashboardPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -93,5 +96,52 @@ describe('DashboardPageComponent', () => {
     expect(component.hasLocalPassword()).toBeFalse();
     expect(fixture.nativeElement.textContent).toContain('Ajoutez votre pièce d\'identité');
     expect(fixture.nativeElement.textContent).toContain('Mot de passe oublie');
+  });
+
+  it('shows an edit action for active trips and opens the edit route', () => {
+    component.activeTab = 'received';
+    component.myTrips = [
+      {
+        id: 12,
+        travelerId: 1,
+        travelerName: 'Ada',
+        departureAddress: 'Paris, France',
+        destination: "Abidjan, Côte d'Ivoire",
+        departureTime: '2025-05-10T08:00:00',
+        arrivalTime: '2025-05-10T16:00:00',
+        maxWeight: 20,
+        pricePerKilo: 15,
+        instantAcceptance: true,
+        status: 'ACTIVE',
+        availableWeight: 8,
+      },
+      {
+        id: 13,
+        travelerId: 1,
+        travelerName: 'Ada',
+        departureAddress: 'Lyon, France',
+        destination: 'Dakar, Sénégal',
+        departureTime: '2025-06-10T08:00:00',
+        arrivalTime: '2025-06-10T16:00:00',
+        maxWeight: 10,
+        pricePerKilo: 9,
+        instantAcceptance: false,
+        status: 'COMPLETED',
+        availableWeight: 0,
+      },
+    ];
+    component.tripBookingsMap = { 12: [], 13: [] };
+
+    fixture.detectChanges();
+
+    const editButtons = Array.from(
+      fixture.nativeElement.querySelectorAll('button[aria-label="Modifier ce trajet"]')
+    ) as HTMLButtonElement[];
+
+    expect(editButtons.length).toBe(1);
+
+    editButtons[0].click();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/propose', 12]);
   });
 });

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.ts
@@ -245,6 +245,10 @@ export class DashboardPageComponent implements OnInit {
     this.selectedTripBookings = this.tripBookingsMap[tripId] ?? [];
   }
 
+  editTrip(tripId: number): void {
+    void this.router.navigate(['/propose', tripId]);
+  }
+
   completeTrip(tripId: number): void {
     this.isCompletingTrip = true;
     this.bookingActionError = '';

--- a/front-office/src/app/pages/propose-trip/propose-trip-page.component.html
+++ b/front-office/src/app/pages/propose-trip/propose-trip-page.component.html
@@ -1,8 +1,8 @@
-<!-- Propose Trip Page -->
-<div class="min-h-screen bg-bg-primary" aria-labelledby="propose-title">
+<!-- Propose / Edit Trip Page -->
+<div class="min-h-screen bg-bg-primary font-['Poppins']" aria-labelledby="propose-title">
 
   <!-- ============================================================
-       PAGE HEADER — gradient banner with title and back link
+       PAGE HEADER — gradient banner with dynamic title and back link
        ============================================================ -->
   <section class="hero-gradient pt-24 pb-32 md:pb-40 relative overflow-hidden">
     <!-- Decorative background blurs -->
@@ -16,11 +16,12 @@
     ></div>
 
     <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
-      <!-- Back to home link -->
+      <!-- Back link — adapts to create vs edit context -->
       <a
-        routerLink="/"
+        [routerLink]="isEditMode ? '/dashboard' : '/'"
+        [queryParams]="isEditMode ? { tab: 'received' } : {}"
         class="inline-flex items-center gap-2 text-white/80 hover:text-white transition-colors text-sm font-medium mb-6 group"
-        aria-label="Retour à l'accueil"
+        [attr.aria-label]="isEditMode ? 'Retour au tableau de bord' : 'Retour à l\'accueil'"
       >
         <svg
           class="w-4 h-4 transition-transform group-hover:-translate-x-1"
@@ -32,18 +33,18 @@
         >
           <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
         </svg>
-        Retour à l'accueil
+        {{ isEditMode ? 'Retour au tableau de bord' : 'Retour à l\'accueil' }}
       </a>
 
-      <!-- Page title -->
+      <!-- Dynamic page title -->
       <h1
         id="propose-title"
         class="text-3xl sm:text-4xl lg:text-5xl font-extrabold text-white leading-tight mb-3"
       >
-        Proposer un voyage
+        {{ pageTitle }}
       </h1>
       <p class="text-white/80 text-base sm:text-lg max-w-xl">
-        Partagez votre itinéraire et transportez des colis contre rémunération.
+        {{ pageDescription }}
       </p>
     </div>
   </section>
@@ -55,217 +56,248 @@
     <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="bg-white rounded-2xl shadow-lg p-6 sm:p-8">
 
-        <!-- Error message -->
-        @if (errorMessage) {
+        <!-- ── Page loading skeleton (edit mode: fetching trip details) ── -->
+        @if (isPageLoading) {
           <div
-            class="flex items-start gap-3 bg-red-50 border border-red-200 text-red-700 rounded-xl px-4 py-3 mb-6 text-sm"
-            role="alert"
-            aria-live="assertive"
+            class="flex flex-col items-center justify-center py-14 gap-4"
+            role="status"
+            aria-label="Chargement du voyage en cours"
           >
-            <svg class="w-5 h-5 shrink-0 mt-0.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
-            </svg>
-            <span>{{ errorMessage }}</span>
+            <div class="w-9 h-9 border-[3px] border-secondary border-t-transparent rounded-full animate-spin"></div>
+            <p class="text-text-secondary text-sm">Chargement du voyage…</p>
           </div>
-        }
+        } @else {
 
-        <form (ngSubmit)="submit()" novalidate>
-
-          <!-- ── Section: Itinéraire ── -->
-          <fieldset class="mb-6">
-            <legend class="text-lg font-semibold text-primary mb-4 flex items-center gap-2">
-              <svg class="w-5 h-5 text-secondary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-                <path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
-              </svg>
-              Itinéraire
-            </legend>
-
-            <div class="space-y-4">
-              <!-- Departure autocomplete -->
-              <app-autocomplete
-                label="Ville de départ *"
-                placeholder="Ex: Paris, France"
-                (selected)="onDepartureSelected($event)"
-                (cleared)="onDepartureCleared()"
-              />
-
-              <!-- Destination autocomplete -->
-              <app-autocomplete
-                label="Destination *"
-                placeholder="Ex: Abidjan, Côte d'Ivoire"
-                (selected)="onDestinationSelected($event)"
-                (cleared)="onDestinationCleared()"
-              />
+          <!-- ── Error / warning message ── -->
+          @if (errorMessage) {
+            <div
+              class="flex items-start gap-3 rounded-xl px-4 py-3 mb-6 text-sm border"
+              [class]="canEditTrip
+                ? 'bg-red-50 border-red-200 text-red-700'
+                : 'bg-warning/10 border-warning/30 text-text-primary'"
+              role="alert"
+              aria-live="assertive"
+            >
+              <!-- Icon: triangle warning for non-editable, circle error otherwise -->
+              @if (!canEditTrip) {
+                <svg class="w-5 h-5 shrink-0 mt-0.5 text-warning" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                </svg>
+              } @else {
+                <svg class="w-5 h-5 shrink-0 mt-0.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                </svg>
+              }
+              <span>{{ errorMessage }}</span>
             </div>
-          </fieldset>
+          }
 
-          <hr class="border-gray-100 mb-6" aria-hidden="true" />
-
-          <!-- ── Section: Dates ── -->
-          <fieldset class="mb-6">
-            <legend class="text-lg font-semibold text-primary mb-4 flex items-center gap-2">
-              <svg class="w-5 h-5 text-secondary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-              </svg>
-              Dates
-            </legend>
-
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <!-- Departure date -->
-              <div>
-                <label for="departure-time" class="block text-sm font-medium text-text-primary mb-1.5">
-                  Date de départ *
-                </label>
-                <input
-                  id="departure-time"
-                  type="datetime-local"
-                  [(ngModel)]="departureTime"
-                  name="departureTime"
-                  required
-                  [min]="minDateTime"
-                  class="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-secondary/40 focus:border-secondary transition"
-                  aria-required="true"
-                />
-              </div>
-
-              <!-- Arrival date -->
-              <div>
-                <label for="arrival-time" class="block text-sm font-medium text-text-primary mb-1.5">
-                  Date d'arrivée estimée *
-                </label>
-                <input
-                  id="arrival-time"
-                  type="datetime-local"
-                  [(ngModel)]="arrivalTime"
-                  name="arrivalTime"
-                  required
-                  [min]="departureTime || minDateTime"
-                  class="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-secondary/40 focus:border-secondary transition"
-                  aria-required="true"
-                />
-              </div>
-            </div>
-          </fieldset>
-
-          <hr class="border-gray-100 mb-6" aria-hidden="true" />
-
-          <!-- ── Section: Conditions de transport ── -->
-          <fieldset class="mb-8">
-            <legend class="text-lg font-semibold text-primary mb-4 flex items-center gap-2">
-              <svg class="w-5 h-5 text-secondary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M20 7H4a2 2 0 00-2 2v6a2 2 0 002 2h16a2 2 0 002-2V9a2 2 0 00-2-2z"/>
-                <path stroke-linecap="round" stroke-linejoin="round" d="M16 21V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v16"/>
-              </svg>
-              Conditions de transport
-            </legend>
-
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
-              <!-- Max weight -->
-              <div>
-                <label for="max-weight" class="block text-sm font-medium text-text-primary mb-1.5">
-                  Poids max accepté (kg) *
-                </label>
-                <div class="relative">
-                  <input
-                    id="max-weight"
-                    type="number"
-                    [(ngModel)]="maxWeight"
-                    name="maxWeight"
-                    min="1"
-                    step="1"
-                    placeholder="Ex: 10"
-                    required
-                    class="w-full border border-gray-200 rounded-xl px-4 py-3 pr-12 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-secondary/40 focus:border-secondary transition"
-                    aria-required="true"
-                  />
-                  <span class="absolute right-4 top-1/2 -translate-y-1/2 text-text-muted text-sm font-medium pointer-events-none">
-                    kg
-                  </span>
-                </div>
-              </div>
-
-              <!-- Price per kilo -->
-              <div>
-                <label for="price-per-kilo" class="block text-sm font-medium text-text-primary mb-1.5">
-                  Prix par kilo (€) *
-                </label>
-                <div class="relative">
-                  <input
-                    id="price-per-kilo"
-                    type="number"
-                    [(ngModel)]="pricePerKilo"
-                    name="pricePerKilo"
-                    min="0"
-                    step="0.5"
-                    placeholder="Ex: 5.00"
-                    required
-                    class="w-full border border-gray-200 rounded-xl px-4 py-3 pr-10 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-secondary/40 focus:border-secondary transition"
-                    aria-required="true"
-                  />
-                  <span class="absolute right-4 top-1/2 -translate-y-1/2 text-text-muted text-sm font-medium pointer-events-none">
-                    €
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            <!-- Instant acceptance toggle -->
-            <div class="flex items-center justify-between bg-bg-secondary rounded-xl px-4 py-4">
-              <div>
-                <p class="text-sm font-medium text-text-primary">Acceptation instantanée</p>
-                <p class="text-xs text-text-muted mt-0.5">
-                  Les réservations sont confirmées automatiquement sans votre validation manuelle.
-                </p>
-              </div>
-              <button
-                type="button"
-                role="switch"
-                [attr.aria-checked]="instantAcceptance"
-                (click)="instantAcceptance = !instantAcceptance"
-                class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-secondary/40 focus:ring-offset-2"
-                [class.bg-secondary]="instantAcceptance"
-                [class.bg-gray-200]="!instantAcceptance"
-                aria-label="Activer l'acceptation instantanée"
-              >
-                <span
-                  class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                  [class.translate-x-5]="instantAcceptance"
-                  [class.translate-x-0]="!instantAcceptance"
-                ></span>
-              </button>
-            </div>
-          </fieldset>
-
-          <!-- ── Submit button ── -->
-          <button
-            type="submit"
-            [disabled]="isLoading || !isFormValid"
-            class="w-full flex items-center justify-center gap-2 bg-accent text-white font-bold py-4 rounded-xl hover:bg-opacity-90 transition shadow-lg shadow-accent/30 text-base disabled:opacity-50 disabled:cursor-not-allowed"
-            aria-label="Publier le voyage"
+          <!-- ── Form — visually dimmed when the trip cannot be edited ── -->
+          <div
+            [class.opacity-60]="!canEditTrip"
+            [class.pointer-events-none]="!canEditTrip"
           >
-            @if (isLoading) {
-              <!-- Loading spinner -->
-              <svg
-                class="animate-spin w-5 h-5 text-white"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-              </svg>
-              <span>Publication en cours…</span>
-            } @else {
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
-              </svg>
-              <span>Publier le voyage</span>
-            }
-          </button>
+            <form (ngSubmit)="submit()" novalidate>
 
-        </form>
+              <!-- ── Section: Itinéraire ── -->
+              <fieldset class="mb-6">
+                <legend class="text-lg font-semibold text-primary mb-4 flex items-center gap-2">
+                  <svg class="w-5 h-5 text-secondary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
+                  </svg>
+                  Itinéraire
+                </legend>
+
+                <div class="space-y-4">
+                  <!-- Departure autocomplete — pre-filled in edit mode -->
+                  <app-autocomplete
+                    label="Ville de départ *"
+                    placeholder="Ex: Paris, France"
+                    [initialQuery]="departureQuery"
+                    (selected)="onDepartureSelected($event)"
+                    (cleared)="onDepartureCleared()"
+                  />
+
+                  <!-- Destination autocomplete — pre-filled in edit mode -->
+                  <app-autocomplete
+                    label="Destination *"
+                    placeholder="Ex: Abidjan, Côte d'Ivoire"
+                    [initialQuery]="destinationQuery"
+                    (selected)="onDestinationSelected($event)"
+                    (cleared)="onDestinationCleared()"
+                  />
+                </div>
+              </fieldset>
+
+              <hr class="border-gray-100 mb-6" aria-hidden="true" />
+
+              <!-- ── Section: Dates ── -->
+              <fieldset class="mb-6">
+                <legend class="text-lg font-semibold text-primary mb-4 flex items-center gap-2">
+                  <svg class="w-5 h-5 text-secondary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                  </svg>
+                  Dates
+                </legend>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <!-- Departure date -->
+                  <div>
+                    <label for="departure-time" class="block text-sm font-medium text-text-primary mb-1.5">
+                      Date de départ *
+                    </label>
+                    <input
+                      id="departure-time"
+                      type="datetime-local"
+                      [(ngModel)]="departureTime"
+                      name="departureTime"
+                      required
+                      [min]="minDateTime"
+                      class="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-secondary/40 focus:border-secondary transition"
+                      aria-required="true"
+                    />
+                  </div>
+
+                  <!-- Arrival date -->
+                  <div>
+                    <label for="arrival-time" class="block text-sm font-medium text-text-primary mb-1.5">
+                      Date d'arrivée estimée *
+                    </label>
+                    <input
+                      id="arrival-time"
+                      type="datetime-local"
+                      [(ngModel)]="arrivalTime"
+                      name="arrivalTime"
+                      required
+                      [min]="departureTime || minDateTime"
+                      class="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-secondary/40 focus:border-secondary transition"
+                      aria-required="true"
+                    />
+                  </div>
+                </div>
+              </fieldset>
+
+              <hr class="border-gray-100 mb-6" aria-hidden="true" />
+
+              <!-- ── Section: Conditions de transport ── -->
+              <fieldset class="mb-8">
+                <legend class="text-lg font-semibold text-primary mb-4 flex items-center gap-2">
+                  <svg class="w-5 h-5 text-secondary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M20 7H4a2 2 0 00-2 2v6a2 2 0 002 2h16a2 2 0 002-2V9a2 2 0 00-2-2z"/>
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M16 21V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v16"/>
+                  </svg>
+                  Conditions de transport
+                </legend>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
+                  <!-- Max weight -->
+                  <div>
+                    <label for="max-weight" class="block text-sm font-medium text-text-primary mb-1.5">
+                      Poids max accepté (kg) *
+                    </label>
+                    <div class="relative">
+                      <input
+                        id="max-weight"
+                        type="number"
+                        [(ngModel)]="maxWeight"
+                        name="maxWeight"
+                        min="1"
+                        step="1"
+                        placeholder="Ex: 10"
+                        required
+                        class="w-full border border-gray-200 rounded-xl px-4 py-3 pr-12 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-secondary/40 focus:border-secondary transition"
+                        aria-required="true"
+                      />
+                      <span class="absolute right-4 top-1/2 -translate-y-1/2 text-text-muted text-sm font-medium pointer-events-none">
+                        kg
+                      </span>
+                    </div>
+                  </div>
+
+                  <!-- Price per kilo -->
+                  <div>
+                    <label for="price-per-kilo" class="block text-sm font-medium text-text-primary mb-1.5">
+                      Prix par kilo (€) *
+                    </label>
+                    <div class="relative">
+                      <input
+                        id="price-per-kilo"
+                        type="number"
+                        [(ngModel)]="pricePerKilo"
+                        name="pricePerKilo"
+                        min="0"
+                        step="0.5"
+                        placeholder="Ex: 5.00"
+                        required
+                        class="w-full border border-gray-200 rounded-xl px-4 py-3 pr-10 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-secondary/40 focus:border-secondary transition"
+                        aria-required="true"
+                      />
+                      <span class="absolute right-4 top-1/2 -translate-y-1/2 text-text-muted text-sm font-medium pointer-events-none">
+                        €
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Instant acceptance toggle -->
+                <div class="flex items-center justify-between bg-bg-secondary rounded-xl px-4 py-4">
+                  <div>
+                    <p class="text-sm font-medium text-text-primary">Acceptation instantanée</p>
+                    <p class="text-xs text-text-muted mt-0.5">
+                      Les réservations sont confirmées automatiquement sans votre validation manuelle.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    [attr.aria-checked]="instantAcceptance"
+                    (click)="instantAcceptance = !instantAcceptance"
+                    class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-secondary/40 focus:ring-offset-2"
+                    [class.bg-secondary]="instantAcceptance"
+                    [class.bg-gray-200]="!instantAcceptance"
+                    aria-label="Activer l'acceptation instantanée"
+                  >
+                    <span
+                      class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                      [class.translate-x-5]="instantAcceptance"
+                      [class.translate-x-0]="!instantAcceptance"
+                    ></span>
+                  </button>
+                </div>
+              </fieldset>
+
+              <!-- ── Submit button — dynamic label & disabled state ── -->
+              <button
+                type="submit"
+                [disabled]="isSubmitDisabled"
+                class="w-full flex items-center justify-center gap-2 bg-accent text-white font-bold py-4 rounded-xl hover:bg-opacity-90 transition shadow-lg shadow-accent/30 text-base disabled:opacity-50 disabled:cursor-not-allowed"
+                [attr.aria-label]="submitButtonLabel"
+              >
+                @if (isLoading) {
+                  <svg
+                    class="animate-spin w-5 h-5 text-white"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
+                  </svg>
+                  <span>{{ submitLoadingLabel }}</span>
+                } @else {
+                  <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
+                  </svg>
+                  <span>{{ submitButtonLabel }}</span>
+                }
+              </button>
+
+            </form>
+          </div><!-- /form wrapper -->
+
+        }<!-- /isPageLoading @else -->
       </div>
     </div>
   </section>

--- a/front-office/src/app/pages/propose-trip/propose-trip-page.component.spec.ts
+++ b/front-office/src/app/pages/propose-trip/propose-trip-page.component.spec.ts
@@ -1,0 +1,193 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
+import { BehaviorSubject, Observable, of, throwError } from 'rxjs';
+import { AutocompleteComponent } from '../../shared/components/autocomplete/autocomplete.component';
+import { LocationService } from '../../services/location.service';
+import { TripService } from '../../services/trip.service';
+import { ProposeTripPageComponent } from './propose-trip-page.component';
+
+describe('ProposeTripPageComponent', () => {
+  let fixture: ComponentFixture<ProposeTripPageComponent>;
+  let component: ProposeTripPageComponent;
+  let router: Router;
+  let paramMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  let routeMock: {
+    paramMap: Observable<ReturnType<typeof convertToParamMap>>;
+    snapshot: { paramMap: ReturnType<typeof convertToParamMap> };
+  };
+
+  const tripServiceMock = {
+    createTrip: jasmine.createSpy('createTrip').and.returnValue(of({})),
+    getTripById: jasmine.createSpy('getTripById').and.returnValue(of({
+      id: 12,
+      travelerId: 1,
+      travelerName: 'Ada',
+      departureAddress: 'Paris, France',
+      destination: "Abidjan, Côte d'Ivoire",
+      departureTime: '2025-05-10T08:00:00',
+      arrivalTime: '2025-05-10T16:00:00',
+      maxWeight: 20,
+      pricePerKilo: 15,
+      instantAcceptance: true,
+      status: 'ACTIVE',
+      availableWeight: 8,
+    })),
+    updateTrip: jasmine.createSpy('updateTrip').and.returnValue(of({})),
+  };
+
+  const locationServiceMock = {
+    searchLocations: jasmine.createSpy('searchLocations').and.returnValue(of([])),
+  };
+
+  beforeEach(async () => {
+    paramMapSubject = new BehaviorSubject(convertToParamMap({}));
+    routeMock = {
+      paramMap: paramMapSubject.asObservable(),
+      snapshot: { paramMap: convertToParamMap({}) },
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ProposeTripPageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: routeMock },
+        { provide: TripService, useValue: tripServiceMock },
+        { provide: LocationService, useValue: locationServiceMock },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate').and.resolveTo(true);
+
+    tripServiceMock.createTrip.calls.reset();
+    tripServiceMock.getTripById.calls.reset();
+    tripServiceMock.updateTrip.calls.reset();
+    tripServiceMock.createTrip.and.returnValue(of({}));
+    tripServiceMock.getTripById.and.returnValue(of({
+      id: 12,
+      travelerId: 1,
+      travelerName: 'Ada',
+      departureAddress: 'Paris, France',
+      destination: "Abidjan, Côte d'Ivoire",
+      departureTime: '2025-05-10T08:00:00',
+      arrivalTime: '2025-05-10T16:00:00',
+      maxWeight: 20,
+      pricePerKilo: 15,
+      instantAcceptance: true,
+      status: 'ACTIVE',
+      availableWeight: 8,
+    }));
+    tripServiceMock.updateTrip.and.returnValue(of({}));
+
+    fixture = TestBed.createComponent(ProposeTripPageComponent);
+    component = fixture.componentInstance;
+  });
+
+  function setRouteId(id?: string): void {
+    const paramMap = convertToParamMap(id ? { id } : {});
+    routeMock.snapshot.paramMap = paramMap;
+    paramMapSubject.next(paramMap);
+  }
+
+  it('creates a trip in creation mode and redirects to search', () => {
+    setRouteId();
+    fixture.detectChanges();
+
+    component.departure = { id: 1, name: 'Paris', country: 'France', type: 'city' };
+    component.destination = { id: 2, name: 'Abidjan', country: "Côte d'Ivoire", type: 'city' };
+    component.departureTime = '2025-05-10T08:00';
+    component.arrivalTime = '2025-05-10T16:00';
+    component.maxWeight = 20;
+    component.pricePerKilo = 15;
+    component.instantAcceptance = true;
+
+    component.submit();
+
+    expect(tripServiceMock.createTrip).toHaveBeenCalledWith({
+      departureAddress: 'Paris, France',
+      destination: "Abidjan, Côte d'Ivoire",
+      departureTime: '2025-05-10T08:00',
+      arrivalTime: '2025-05-10T16:00',
+      maxWeight: 20,
+      pricePerKilo: 15,
+      instantAcceptance: true,
+    });
+    expect(router.navigate).toHaveBeenCalledWith(['/search']);
+  });
+
+  it('loads an active trip in edit mode, pre-fills the form and updates it', () => {
+    setRouteId('12');
+    fixture.detectChanges();
+
+    expect(tripServiceMock.getTripById).toHaveBeenCalledWith(12);
+    expect(component.isEditMode).toBeTrue();
+    expect(component.departureQuery).toBe('Paris, France');
+    expect(component.destinationQuery).toBe("Abidjan, Côte d'Ivoire");
+    expect(component.departure?.name).toBe('Paris');
+    expect(component.departure?.country).toBe('France');
+
+    fixture.detectChanges();
+
+    const autocompleteComponents = fixture.debugElement.queryAll(
+      By.directive(AutocompleteComponent)
+    );
+    expect(autocompleteComponents[0].componentInstance.initialQuery).toBe('Paris, France');
+    expect(autocompleteComponents[0].componentInstance.query).toBe('Paris, France');
+    expect(autocompleteComponents[1].componentInstance.initialQuery).toBe("Abidjan, Côte d'Ivoire");
+    expect(autocompleteComponents[1].componentInstance.query).toBe("Abidjan, Côte d'Ivoire");
+
+    component.maxWeight = 25;
+    component.submit();
+
+    expect(tripServiceMock.updateTrip).toHaveBeenCalledWith(12, {
+      departureAddress: 'Paris, France',
+      destination: "Abidjan, Côte d'Ivoire",
+      departureTime: component.departureTime,
+      arrivalTime: component.arrivalTime,
+      maxWeight: 25,
+      pricePerKilo: 15,
+      instantAcceptance: true,
+    });
+    expect(router.navigate).toHaveBeenCalledWith(['/dashboard'], {
+      queryParams: { tab: 'received' },
+    });
+  });
+
+  it('blocks editing when the loaded trip is not active', () => {
+    tripServiceMock.getTripById.and.returnValue(of({
+      id: 15,
+      travelerId: 1,
+      travelerName: 'Ada',
+      departureAddress: 'Paris, France',
+      destination: "Abidjan, Côte d'Ivoire",
+      departureTime: '2025-05-10T08:00:00',
+      arrivalTime: '2025-05-10T16:00:00',
+      maxWeight: 20,
+      pricePerKilo: 15,
+      instantAcceptance: true,
+      status: 'COMPLETED',
+      availableWeight: 0,
+    }));
+
+    setRouteId('15');
+    fixture.detectChanges();
+
+    expect(component.canEditTrip).toBeFalse();
+    expect(component.errorMessage).toContain('Seuls les voyages actifs peuvent être modifiés.');
+
+    component.submit();
+
+    expect(tripServiceMock.updateTrip).not.toHaveBeenCalled();
+  });
+
+  it('shows a loading error when the trip cannot be fetched in edit mode', () => {
+    tripServiceMock.getTripById.and.returnValue(throwError(() => new Error('boom')));
+
+    setRouteId('18');
+    fixture.detectChanges();
+
+    expect(component.errorMessage).toContain('Une erreur est survenue lors du chargement du voyage.');
+    expect(component.isPageLoading).toBeFalse();
+  });
+});

--- a/front-office/src/app/pages/propose-trip/propose-trip-page.component.ts
+++ b/front-office/src/app/pages/propose-trip/propose-trip-page.component.ts
@@ -1,16 +1,16 @@
-import { Component, inject } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { AutocompleteComponent } from '../../shared/components/autocomplete/autocomplete.component';
 import { TripService } from '../../services/trip.service';
 import { Location } from '../../models/location.model';
-import { CreateTripDto } from '../../models/trip.model';
+import { CreateTripDto, Trip } from '../../models/trip.model';
 
 /**
- * ProposeTripPageComponent - Page form allowing a traveler to propose a new trip.
+ * ProposeTripPageComponent - Shared form used to create or edit a trip.
  * Collects departure, destination, dates, weight, price and acceptance mode,
- * then POSTs to /api/trips and redirects to /search on success.
+ * then creates or updates the trip depending on the current route.
  */
 @Component({
   selector: 'app-propose-trip-page',
@@ -18,9 +18,16 @@ import { CreateTripDto } from '../../models/trip.model';
   imports: [CommonModule, FormsModule, RouterLink, AutocompleteComponent],
   templateUrl: './propose-trip-page.component.html',
 })
-export class ProposeTripPageComponent {
+export class ProposeTripPageComponent implements OnInit {
   private readonly tripService = inject(TripService);
   private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+
+  /** Trip identifier when editing an existing trip. */
+  tripId: number | null = null;
+
+  /** Whether the page is currently used to edit an existing trip. */
+  isEditMode = false;
 
   // --- Form fields ---
 
@@ -35,6 +42,12 @@ export class ProposeTripPageComponent {
 
   /** Estimated arrival datetime (ISO string from datetime-local input) */
   arrivalTime = '';
+
+  /** Initial query displayed in the departure autocomplete. */
+  departureQuery = '';
+
+  /** Initial query displayed in the destination autocomplete. */
+  destinationQuery = '';
 
   /** Maximum weight accepted in kg */
   maxWeight: number | null = null;
@@ -57,8 +70,32 @@ export class ProposeTripPageComponent {
   /** Whether the form submission is in progress */
   isLoading = false;
 
+  /** Whether the trip details are loading in edit mode */
+  isPageLoading = false;
+
   /** Error message to display on failure */
   errorMessage = '';
+
+  /** Status of the loaded trip when editing. */
+  loadedTripStatus: Trip['status'] | null = null;
+
+  ngOnInit(): void {
+    const tripIdParam = this.route.snapshot.paramMap.get('id');
+    if (!tripIdParam) {
+      return;
+    }
+
+    const parsedTripId = Number(tripIdParam);
+    if (Number.isNaN(parsedTripId)) {
+      this.isEditMode = true;
+      this.errorMessage = 'Voyage introuvable.';
+      return;
+    }
+
+    this.isEditMode = true;
+    this.tripId = parsedTripId;
+    this.loadTrip(parsedTripId);
+  }
 
   /** Whether all required fields are filled */
   get isFormValid(): boolean {
@@ -72,6 +109,38 @@ export class ProposeTripPageComponent {
       this.pricePerKilo !== null &&
       this.pricePerKilo >= 0
     );
+  }
+
+  /** Whether the current trip can be edited according to business rules. */
+  get canEditTrip(): boolean {
+    return !this.isEditMode || this.loadedTripStatus === 'ACTIVE';
+  }
+
+  /** Whether the submit action should be disabled. */
+  get isSubmitDisabled(): boolean {
+    return this.isPageLoading || this.isLoading || !this.isFormValid || !this.canEditTrip;
+  }
+
+  /** Dynamic page title according to mode. */
+  get pageTitle(): string {
+    return this.isEditMode ? 'Modifier un voyage' : 'Proposer un voyage';
+  }
+
+  /** Dynamic introductory text according to mode. */
+  get pageDescription(): string {
+    return this.isEditMode
+      ? 'Mettez à jour votre itinéraire et vos conditions de transport.'
+      : 'Partagez votre itinéraire et transportez des colis contre rémunération.';
+  }
+
+  /** Dynamic submit button text according to mode. */
+  get submitButtonLabel(): string {
+    return this.isEditMode ? 'Enregistrer les modifications' : 'Publier le voyage';
+  }
+
+  /** Dynamic loading text according to mode. */
+  get submitLoadingLabel(): string {
+    return this.isEditMode ? 'Mise à jour en cours…' : 'Publication en cours…';
   }
 
   onDepartureSelected(location: Location): void {
@@ -92,9 +161,14 @@ export class ProposeTripPageComponent {
 
   /**
    * Submit the trip form.
-   * Validates fields, calls TripService.createTrip(), then navigates to /search.
+   * Validates fields, then creates or updates the trip depending on the current mode.
    */
   submit(): void {
+    if (!this.canEditTrip) {
+      this.errorMessage = 'Seuls les voyages actifs peuvent être modifiés.';
+      return;
+    }
+
     if (!this.isFormValid) {
       this.errorMessage = 'Veuillez remplir tous les champs obligatoires.';
       return;
@@ -104,8 +178,8 @@ export class ProposeTripPageComponent {
     this.errorMessage = '';
 
     const payload: CreateTripDto = {
-      departureAddress: `${this.departure!.name}, ${this.departure!.country}`,
-      destination: `${this.destination!.name}, ${this.destination!.country}`,
+      departureAddress: this.formatLocation(this.departure!),
+      destination: this.formatLocation(this.destination!),
       departureTime: this.departureTime,
       arrivalTime: this.arrivalTime,
       maxWeight: this.maxWeight!,
@@ -113,16 +187,84 @@ export class ProposeTripPageComponent {
       instantAcceptance: this.instantAcceptance,
     };
 
-    this.tripService.createTrip(payload).subscribe({
+    const request$ = this.isEditMode && this.tripId !== null
+      ? this.tripService.updateTrip(this.tripId, payload)
+      : this.tripService.createTrip(payload);
+
+    request$.subscribe({
       next: () => {
         this.isLoading = false;
+        if (this.isEditMode) {
+          this.router.navigate(['/dashboard'], { queryParams: { tab: 'received' } });
+          return;
+        }
         this.router.navigate(['/search']);
       },
       error: () => {
         this.isLoading = false;
-        this.errorMessage =
-          'Une erreur est survenue lors de la publication du voyage. Veuillez réessayer.';
+        this.errorMessage = this.isEditMode
+          ? 'Une erreur est survenue lors de la mise à jour du voyage. Veuillez réessayer.'
+          : 'Une erreur est survenue lors de la publication du voyage. Veuillez réessayer.';
       },
     });
+  }
+
+  private loadTrip(tripId: number): void {
+    this.isPageLoading = true;
+    this.errorMessage = '';
+
+    this.tripService.getTripById(tripId).subscribe({
+      next: (trip) => {
+        this.loadedTripStatus = trip.status;
+        this.populateForm(trip);
+        if (trip.status !== 'ACTIVE') {
+          this.errorMessage = 'Seuls les voyages actifs peuvent être modifiés.';
+        }
+        this.isPageLoading = false;
+      },
+      error: () => {
+        this.errorMessage = 'Une erreur est survenue lors du chargement du voyage. Veuillez réessayer.';
+        this.isPageLoading = false;
+      },
+    });
+  }
+
+  private populateForm(trip: Trip): void {
+    this.departureQuery = trip.departureAddress;
+    this.destinationQuery = trip.destination;
+    this.departure = this.createLocationFromAddress(trip.departureAddress);
+    this.destination = this.createLocationFromAddress(trip.destination);
+    this.departureTime = this.toDateTimeLocalValue(trip.departureTime);
+    this.arrivalTime = this.toDateTimeLocalValue(trip.arrivalTime);
+    this.maxWeight = trip.maxWeight;
+    this.pricePerKilo = trip.pricePerKilo;
+    this.instantAcceptance = trip.instantAcceptance;
+  }
+
+  private createLocationFromAddress(address: string): Location {
+    const parts = address
+      .split(',')
+      .map((part) => part.trim())
+      .filter((part) => part.length > 0);
+
+    return {
+      id: 0,
+      name: parts[0] ?? address,
+      country: parts.slice(1).join(', '),
+      type: 'city',
+    };
+  }
+
+  private formatLocation(location: Location): string {
+    return location.country ? `${location.name}, ${location.country}` : location.name;
+  }
+
+  private toDateTimeLocalValue(value: string): string {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value.slice(0, 16);
+    }
+    const tzOffset = date.getTimezoneOffset() * 60000;
+    return new Date(date.getTime() - tzOffset).toISOString().slice(0, 16);
   }
 }

--- a/front-office/src/app/services/trip.service.spec.ts
+++ b/front-office/src/app/services/trip.service.spec.ts
@@ -50,6 +50,75 @@ describe('TripService', () => {
     ]);
   });
 
+  it('gets a trip by id and normalizes traveler photo URLs', () => {
+    service.getTripById(12).subscribe((trip) => {
+      expect(trip.id).toBe(12);
+      expect(trip.travelerPhotoUrl).toBe('/api/uploads/traveler.png');
+      expect(trip.travelerRatingCount).toBe(0);
+    });
+
+    const req = httpMock.expectOne('/api/trips/12');
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      id: 12,
+      travelerId: 2,
+      travelerName: 'Alice Martin',
+      travelerPhotoUrl: '/uploads/traveler.png',
+      travelerRatingAverage: 4.8,
+      travelerRatingCount: null,
+      departureAddress: 'Paris, France',
+      destination: "Abidjan, Côte d'Ivoire",
+      departureTime: '2025-03-02T08:00:00Z',
+      arrivalTime: '2025-03-02T16:00:00Z',
+      maxWeight: 20,
+      pricePerKilo: 15,
+      instantAcceptance: true,
+      status: 'ACTIVE',
+      availableWeight: 6,
+    });
+  });
+
+  it('updates a trip proposal', () => {
+    service.updateTrip(12, {
+      departureAddress: 'Paris, France',
+      destination: "Abidjan, Côte d'Ivoire",
+      departureTime: '2025-03-02T08:00',
+      arrivalTime: '2025-03-02T16:00',
+      maxWeight: 22,
+      pricePerKilo: 17,
+      instantAcceptance: false,
+    }).subscribe((trip) => {
+      expect(trip.id).toBe(12);
+      expect(trip.pricePerKilo).toBe(17);
+    });
+
+    const req = httpMock.expectOne('/api/trips/12');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({
+      departureAddress: 'Paris, France',
+      destination: "Abidjan, Côte d'Ivoire",
+      departureTime: '2025-03-02T08:00',
+      arrivalTime: '2025-03-02T16:00',
+      maxWeight: 22,
+      pricePerKilo: 17,
+      instantAcceptance: false,
+    });
+    req.flush({
+      id: 12,
+      travelerId: 2,
+      travelerName: 'Alice Martin',
+      departureAddress: 'Paris, France',
+      destination: "Abidjan, Côte d'Ivoire",
+      departureTime: '2025-03-02T08:00:00Z',
+      arrivalTime: '2025-03-02T16:00:00Z',
+      maxWeight: 22,
+      pricePerKilo: 17,
+      instantAcceptance: false,
+      status: 'ACTIVE',
+      availableWeight: 8,
+    });
+  });
+
   it('calls complete trip endpoint', () => {
     service.completeTrip(12).subscribe();
 

--- a/front-office/src/app/services/trip.service.ts
+++ b/front-office/src/app/services/trip.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { map, Observable } from 'rxjs';
-import { Trip, CreateTripDto } from '../models/trip.model';
+import { Trip, CreateTripDto, UpdateTripDto } from '../models/trip.model';
 import { CreateBookingRequest, BookingResponse, ConfirmBookingDeliveryRequest } from '../models/booking.model';
 import { PhotoUrlService } from './photo-url.service';
 
@@ -29,6 +29,20 @@ export class TripService {
   /** Create a new trip proposal. */
   createTrip(data: CreateTripDto): Observable<Trip> {
     return this.http.post<Trip>(this.baseUrl, data).pipe(
+      map((trip) => this.normalizeTrip(trip))
+    );
+  }
+
+  /** Get a trip published by its identifier. */
+  getTripById(tripId: number): Observable<Trip> {
+    return this.http.get<Trip>(`${this.baseUrl}/${tripId}`).pipe(
+      map((trip) => this.normalizeTrip(trip))
+    );
+  }
+
+  /** Update an existing trip proposal. */
+  updateTrip(tripId: number, data: UpdateTripDto): Observable<Trip> {
+    return this.http.put<Trip>(`${this.baseUrl}/${tripId}`, data).pipe(
       map((trip) => this.normalizeTrip(trip))
     );
   }


### PR DESCRIPTION
## Summary
- reuse the propose trip page in create and edit modes with a dedicated edit route
- add the traveler dashboard action to edit active trips and preload the existing trip data
- restrict trip updates to active trips and notify accepted bookings by email after an update

## Validation
- cd back-office && ./mvnw test
- cd front-office && npm test -- --watch=false --browsers=ChromeHeadless
- cd front-office && npm run build