### PR TITLE
feat: refonte desktop de la liste des voyages

### DIFF
--- a/front-office/src/app/app.routes.ts
+++ b/front-office/src/app/app.routes.ts
@@ -97,4 +97,12 @@ export const routes: Routes = [
         (m) => m.DashboardPageComponent
       ),
   },
+  {
+    path: 'trips',
+    canActivate: [authGuard],
+    loadComponent: () =>
+      import('./pages/trips-management/trips-management-page.component').then(
+        (m) => m.TripsManagementPageComponent
+      ),
+  },
 ];

--- a/front-office/src/app/components/dashboard/dashboard-received-mobile-card/dashboard-received-mobile-card.component.html
+++ b/front-office/src/app/components/dashboard/dashboard-received-mobile-card/dashboard-received-mobile-card.component.html
@@ -5,18 +5,6 @@
 >
   <!-- ── HEADER: compact icon + route on one line, status badge below ── -->
   <div class="flex items-start gap-3">
-    <!-- Flight icon pill -->
-    <div
-      class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-bg-secondary text-secondary"
-      aria-hidden="true"
-    >
-      <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="1.9" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M2 20h20" />
-        <path stroke-linecap="round" stroke-linejoin="round" d="M3 12.5l6.283 2.588a2 2 0 002.57-.92l1.14-2.197 6.447 1.608a1.75 1.75 0 001.93-.786l.63-.993" />
-        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.5l8.321 6.207" />
-      </svg>
-    </div>
-
     <!-- Route + status -->
     <div class="min-w-0 flex-1">
       <!-- Route: single compact line -->

--- a/front-office/src/app/components/dashboard/dashboard-received-mobile-card/dashboard-received-mobile-card.component.html
+++ b/front-office/src/app/components/dashboard/dashboard-received-mobile-card/dashboard-received-mobile-card.component.html
@@ -1,0 +1,146 @@
+<article
+  class="rounded-2xl border border-bg-primary bg-white p-4 shadow-sm transition font-['Poppins']"
+  [class.ring-2]="isSelected"
+  [class.ring-secondary]="isSelected"
+>
+  <!-- ── HEADER: compact icon + route on one line, status badge below ── -->
+  <div class="flex items-start gap-3">
+    <!-- Flight icon pill -->
+    <div
+      class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-bg-secondary text-secondary"
+      aria-hidden="true"
+    >
+      <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="1.9" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M2 20h20" />
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3 12.5l6.283 2.588a2 2 0 002.57-.92l1.14-2.197 6.447 1.608a1.75 1.75 0 001.93-.786l.63-.993" />
+        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.5l8.321 6.207" />
+      </svg>
+    </div>
+
+    <!-- Route + status -->
+    <div class="min-w-0 flex-1">
+      <!-- Route: single compact line -->
+      <h3 class="flex min-w-0 items-center gap-1 text-sm font-bold leading-snug text-primary">
+        <span class="truncate">{{ primaryLocationLabel(trip.departureAddress) }}</span>
+        <svg class="h-3.5 w-3.5 shrink-0 text-secondary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14m0 0-5-5m5 5-5 5" />
+        </svg>
+        <span class="truncate">{{ primaryLocationLabel(trip.destination) }}</span>
+      </h3>
+
+      <!-- Status badge: full-width pill, centred -->
+      <div
+        class="mt-2 flex w-full items-center justify-center gap-1.5 rounded-full border px-3 py-1.5 text-[0.65rem] font-semibold uppercase tracking-[0.14em]"
+        [class]="statusClass(trip.status)"
+        role="status"
+        [attr.aria-label]="statusLabel(trip.status)"
+      >
+        <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-current"></span>
+        <span>{{ statusLabel(trip.status) }}</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── SEPARATOR ── -->
+  <div class="my-3.5 h-px bg-bg-primary"></div>
+
+  <!-- ── INFO ROWS: flat list, no tile backgrounds ── -->
+  <div class="space-y-3">
+    <!-- Date & time -->
+    <div class="flex items-center gap-3">
+      <div class="flex h-8 w-8 shrink-0 items-center justify-center text-text-muted" aria-hidden="true">
+        <svg class="h-[1.1rem] w-[1.1rem]" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+      </div>
+      <div class="min-w-0">
+        <p class="text-[0.62rem] font-semibold uppercase tracking-[0.14em] text-text-muted">Date et heure</p>
+        <p class="mt-0.5 text-[0.8rem] font-semibold leading-snug text-primary">{{ departureDateTimeLabel() }}</p>
+      </div>
+    </div>
+
+    <!-- Capacity -->
+    <div class="flex items-center gap-3">
+      <div class="flex h-8 w-8 shrink-0 items-center justify-center text-text-muted" aria-hidden="true">
+        <svg class="h-[1.1rem] w-[1.1rem]" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M8 6.5A3.5 3.5 0 0111.5 3h1A3.5 3.5 0 0116 6.5V7h1a2 2 0 012 2l1.25 10A2 2 0 0118.264 21H5.736a2 2 0 01-1.986-2L5 9a2 2 0 012-2h1v-.5z" />
+        </svg>
+      </div>
+      <div class="min-w-0">
+        <p class="text-[0.62rem] font-semibold uppercase tracking-[0.14em] text-text-muted">Capacité</p>
+        <p class="mt-0.5 text-[0.8rem] font-semibold leading-snug text-primary">{{ availableWeightLabel() }}</p>
+      </div>
+    </div>
+
+    <!-- Price -->
+    <div class="flex items-center gap-3">
+      <div class="flex h-8 w-8 shrink-0 items-center justify-center text-secondary" aria-hidden="true">
+        <svg class="h-[1.1rem] w-[1.1rem]" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3 7.5A2.5 2.5 0 015.5 5h13A2.5 2.5 0 0121 7.5v9A2.5 2.5 0 0118.5 19h-13A2.5 2.5 0 013 16.5v-9z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3 9h18" />
+          <circle cx="12" cy="14" r="2.25" />
+        </svg>
+      </div>
+      <div class="min-w-0">
+        <p class="text-[0.62rem] font-semibold uppercase tracking-[0.14em] text-text-muted">Prix / kg</p>
+        <p class="mt-0.5 text-base font-bold leading-none text-secondary">
+          {{ trip.pricePerKilo | number:'1.0-2' }} €
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── SEPARATOR ── -->
+  <div class="mt-3.5 h-px bg-bg-primary"></div>
+
+  <!-- ── FOOTER: booking count left · actions right (eye / pencil / ⋮) ── -->
+  <div class="mt-2.5 flex items-center gap-1">
+    <!-- booking count -->
+    <span class="mr-auto text-[0.7rem] font-medium text-text-muted">{{ bookingCountLabel() }}</span>
+
+    <!-- view bookings -->
+    <button
+      type="button"
+      class="inline-flex h-9 w-9 items-center justify-center rounded-full text-text-secondary transition hover:bg-bg-secondary hover:text-secondary focus:outline-none focus:ring-2 focus:ring-secondary/20"
+      [ngClass]="isSelected ? 'bg-secondary/10 text-secondary' : ''"
+      (click)="onViewTrip()"
+      [attr.aria-pressed]="isSelected"
+      [attr.aria-label]="isSelected ? 'Demandes déjà affichées pour ce trajet' : 'Afficher les demandes de ce trajet'"
+    >
+      <svg class="h-[1.1rem] w-[1.1rem]" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12S5.25 6.75 12 6.75 21.75 12 21.75 12 18.75 17.25 12 17.25 2.25 12 2.25 12z" />
+        <circle cx="12" cy="12" r="3.25" />
+      </svg>
+    </button>
+
+    <!-- edit trip -->
+    <button
+      type="button"
+      class="inline-flex h-9 w-9 items-center justify-center rounded-full text-text-secondary transition hover:bg-bg-secondary hover:text-secondary focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-35"
+      [disabled]="trip.status !== 'ACTIVE'"
+      (click)="onEditTrip()"
+      aria-label="Modifier ce trajet"
+    >
+      <svg class="h-[1.1rem] w-[1.1rem]" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M4 20h4l10.5-10.5a2.121 2.121 0 10-3-3L5 17v3z" />
+      </svg>
+    </button>
+
+    <!-- options menu (three-dots) — moved from header to footer -->
+    <div (click)="$event.stopPropagation()">
+      <app-trip-options-menu
+        [tripId]="trip.id"
+        [tripLabel]="trip.departureAddress + ' vers ' + trip.destination"
+        [canDownload]="trip.status === 'ACTIVE'"
+        [canComplete]="trip.status === 'ACTIVE'"
+        [canCancel]="trip.status === 'ACTIVE'"
+        [isDownloading]="isGeneratingShareCard"
+        [isCompleting]="isCompletingTrip"
+        appearance="minimal"
+        (downloadPng)="downloadShareCard.emit($event)"
+        (completeTrip)="markTripCompleted.emit($event)"
+        (cancelTrip)="cancelTrip.emit($event)"
+      />
+    </div>
+  </div>
+</article>

--- a/front-office/src/app/components/dashboard/dashboard-received-mobile-card/dashboard-received-mobile-card.component.spec.ts
+++ b/front-office/src/app/components/dashboard/dashboard-received-mobile-card/dashboard-received-mobile-card.component.spec.ts
@@ -1,0 +1,101 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DashboardReceivedMobileCardComponent } from './dashboard-received-mobile-card.component';
+
+describe('DashboardReceivedMobileCardComponent', () => {
+  let fixture: ComponentFixture<DashboardReceivedMobileCardComponent>;
+  let component: DashboardReceivedMobileCardComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardReceivedMobileCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DashboardReceivedMobileCardComponent);
+    component = fixture.componentInstance;
+    component.trip = buildTrip();
+    component.bookingCount = 3;
+    fixture.detectChanges();
+  });
+
+  it('renders the route with primary city labels and the truthful price-per-kilo block', () => {
+    const textContent = fixture.nativeElement.textContent;
+
+    expect(textContent).toContain('Paris');
+    expect(textContent).toContain('Abidjan');
+    expect(textContent).toContain('Prix / kg');
+    expect(textContent).toContain('15 €');
+    expect(textContent).toContain('8 kg disponibles');
+  });
+
+  it('falls back to max weight when the available weight is missing', () => {
+    component.trip = {
+      ...buildTrip(),
+      maxWeight: 20,
+      availableWeight: undefined as unknown as number,
+    };
+    fixture.detectChanges();
+
+    expect(component.availableWeightLabel()).toBe('20 kg disponibles');
+    expect(fixture.nativeElement.textContent).toContain('20 kg disponibles');
+  });
+
+  it('renders the booking counter with the proper pluralization', () => {
+    expect(component.bookingCountLabel()).toBe('3 demandes');
+    expect(fixture.nativeElement.textContent).toContain('3 demandes');
+  });
+
+  it('uses the expected trip status mapping', () => {
+    expect(component.statusLabel('ACTIVE')).toBe('Actif');
+    expect(component.statusLabel('COMPLETED')).toBe('Terminé');
+    expect(component.statusLabel('CANCELLED')).toBe('Annulé');
+  });
+
+  it('emits the view and edit actions for an active trip', () => {
+    spyOn(component.viewTrip, 'emit');
+    spyOn(component.editTrip, 'emit');
+
+    const viewButton = fixture.nativeElement.querySelector(
+      'button[aria-label="Afficher les demandes de ce trajet"]'
+    ) as HTMLButtonElement;
+    const editButton = fixture.nativeElement.querySelector(
+      'button[aria-label="Modifier ce trajet"]'
+    ) as HTMLButtonElement;
+
+    viewButton.click();
+    editButton.click();
+
+    expect(component.viewTrip.emit).toHaveBeenCalledWith(12);
+    expect(component.editTrip.emit).toHaveBeenCalledWith(12);
+  });
+
+  it('does not emit the edit action when the trip is no longer active', () => {
+    spyOn(component.editTrip, 'emit');
+    component.trip = { ...buildTrip(), status: 'COMPLETED' };
+    fixture.detectChanges();
+
+    const editButton = fixture.nativeElement.querySelector(
+      'button[aria-label="Modifier ce trajet"]'
+    ) as HTMLButtonElement;
+    editButton.click();
+
+    expect(component.editTrip.emit).not.toHaveBeenCalled();
+    expect(editButton.disabled).toBeTrue();
+  });
+});
+
+function buildTrip() {
+  return {
+    id: 12,
+    travelerId: 1,
+    travelerName: 'Ada Lovelace',
+    departureAddress: 'Paris, France',
+    destination: "Abidjan, Côte d'Ivoire",
+    departureTime: '2025-07-14T08:00:00',
+    arrivalTime: '2025-07-14T16:00:00',
+    maxWeight: 20,
+    pricePerKilo: 15,
+    instantAcceptance: true,
+    status: 'ACTIVE' as const,
+    availableWeight: 8,
+  };
+}

--- a/front-office/src/app/components/dashboard/dashboard-received-mobile-card/dashboard-received-mobile-card.component.ts
+++ b/front-office/src/app/components/dashboard/dashboard-received-mobile-card/dashboard-received-mobile-card.component.ts
@@ -1,0 +1,110 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Trip } from '../../../models/trip.model';
+import { TripOptionsMenuComponent } from '../trip-options-menu/trip-options-menu.component';
+
+@Component({
+  selector: 'app-dashboard-received-mobile-card',
+  standalone: true,
+  imports: [CommonModule, TripOptionsMenuComponent],
+  templateUrl: './dashboard-received-mobile-card.component.html',
+})
+export class DashboardReceivedMobileCardComponent {
+  @Input({ required: true }) trip!: Trip;
+  @Input() bookingCount = 0;
+  @Input() isSelected = false;
+  @Input() isGeneratingShareCard = false;
+  @Input() isCompletingTrip = false;
+
+  @Output() viewTrip = new EventEmitter<number>();
+  @Output() editTrip = new EventEmitter<number>();
+  @Output() downloadShareCard = new EventEmitter<number>();
+  @Output() markTripCompleted = new EventEmitter<number>();
+  @Output() cancelTrip = new EventEmitter<number>();
+
+  statusLabel(status: Trip['status']): string {
+    return ({
+      ACTIVE: 'Actif',
+      COMPLETED: 'Terminé',
+      CANCELLED: 'Annulé',
+    } as Record<Trip['status'], string>)[status];
+  }
+
+  statusClass(status: Trip['status']): string {
+    return ({
+      ACTIVE: 'border-success/25 bg-success/10 text-success',
+      COMPLETED: 'border-secondary/20 bg-secondary/10 text-secondary',
+      CANCELLED: 'border-bg-primary bg-bg-primary text-text-muted',
+    } as Record<Trip['status'], string>)[status];
+  }
+
+  bookingCountLabel(): string {
+    return this.bookingCount === 1 ? `${this.bookingCount} demande` : `${this.bookingCount} demandes`;
+  }
+
+  primaryLocationLabel(value: string): string {
+    const [firstSegment] = value.split(',');
+    return firstSegment.trim() || value.trim();
+  }
+
+  departureDateTimeLabel(): string {
+    const departureDate = new Date(this.trip.departureTime);
+
+    if (Number.isNaN(departureDate.getTime())) {
+      return 'Date indisponible';
+    }
+
+    const formattedDate = departureDate.toLocaleDateString('fr-FR', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    });
+    const formattedTime = departureDate.toLocaleTimeString('fr-FR', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+    return `${formattedDate.charAt(0).toUpperCase()}${formattedDate.slice(1)} • ${formattedTime}`;
+  }
+
+  availableWeightLabel(): string {
+    const availableWeight = this.resolveAvailableWeight();
+
+    if (availableWeight === null) {
+      return 'Capacité indisponible';
+    }
+
+    return `${new Intl.NumberFormat('fr-FR', {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 2,
+    }).format(availableWeight)} kg disponibles`;
+  }
+
+  onViewTrip(): void {
+    this.viewTrip.emit(this.trip.id);
+  }
+
+  onEditTrip(): void {
+    if (this.trip.status !== 'ACTIVE') {
+      return;
+    }
+
+    this.editTrip.emit(this.trip.id);
+  }
+
+  private resolveAvailableWeight(): number | null {
+    if (this.isValidNumber(this.trip.availableWeight)) {
+      return this.trip.availableWeight;
+    }
+
+    if (this.isValidNumber(this.trip.maxWeight)) {
+      return this.trip.maxWeight;
+    }
+
+    return null;
+  }
+
+  private isValidNumber(value?: number | null): value is number {
+    return value !== null && value !== undefined && !Number.isNaN(value);
+  }
+}

--- a/front-office/src/app/components/dashboard/dashboard-received-mobile-card/dashboard-received-mobile-card.component.ts
+++ b/front-office/src/app/components/dashboard/dashboard-received-mobile-card/dashboard-received-mobile-card.component.ts
@@ -32,8 +32,8 @@ export class DashboardReceivedMobileCardComponent {
 
   statusClass(status: Trip['status']): string {
     return ({
-      ACTIVE: 'border-success/25 bg-success/10 text-success',
-      COMPLETED: 'border-secondary/20 bg-secondary/10 text-secondary',
+      ACTIVE: 'border-accent/25 bg-accent/10 text-accent',
+      COMPLETED: 'border-success/25 bg-success/10 text-success',
       CANCELLED: 'border-bg-primary bg-bg-primary text-text-muted',
     } as Record<Trip['status'], string>)[status];
   }

--- a/front-office/src/app/components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component.html
+++ b/front-office/src/app/components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component.html
@@ -1,0 +1,75 @@
+<div class="hidden lg:block">
+  <div class="overflow-hidden rounded-[1.5rem] border border-background-primary bg-white shadow-sm">
+    <div class="grid grid-cols-[minmax(0,2.2fr)_1.2fr_0.8fr_0.8fr_0.7fr_0.9fr_auto] gap-4 border-b border-background-primary bg-background-secondary px-6 py-4 text-xs font-semibold uppercase tracking-[0.16em] text-text-secondary">
+      <span>Voyage</span>
+      <span>Départ</span>
+      <span>Poids max</span>
+      <span>Prix/kg</span>
+      <span>Demandes</span>
+      <span>Statut</span>
+      <span class="text-right">Plus d'options</span>
+    </div>
+
+    <div class="divide-y divide-background-primary">
+      @for (trip of trips; track trip.id) {
+        <div
+          role="button"
+          tabindex="0"
+          class="grid grid-cols-[minmax(0,2.2fr)_1.2fr_0.8fr_0.8fr_0.7fr_0.9fr_auto] items-center gap-4 px-6 py-4 transition hover:bg-background-secondary"
+          [class.bg-background-secondary]="selectedTripId === trip.id"
+          [class.ring-1]="selectedTripId === trip.id"
+          [class.ring-secondary]="selectedTripId === trip.id"
+          [attr.aria-pressed]="selectedTripId === trip.id"
+          (click)="onSelect(trip.id)"
+          (keydown)="onRowKeydown($event, trip.id)"
+        >
+          <div class="min-w-0">
+            <p class="truncate text-sm font-semibold text-text-primary">
+              {{ trip.departureAddress }} → {{ trip.destination }}
+            </p>
+            <p class="mt-1 truncate text-xs text-text-secondary">
+              Voyageur · {{ trip.travelerName }}
+            </p>
+          </div>
+
+          <div class="text-sm text-text-primary">
+            {{ trip.departureTime | date:'dd/MM/yyyy HH:mm' }}
+          </div>
+
+          <div class="text-sm text-text-primary">
+            {{ trip.maxWeight }} kg
+          </div>
+
+          <div class="text-sm text-text-primary">
+            {{ trip.pricePerKilo | number:'1.0-2' }} €/kg
+          </div>
+
+          <div>
+            <span class="inline-flex min-w-10 items-center justify-center rounded-full bg-accent px-3 py-1 text-xs font-semibold text-white">
+              {{ bookingCount(trip.id) }}
+            </span>
+          </div>
+
+          <div>
+            <span [class]="tripStatusClass(trip.status) + ' inline-flex rounded-full px-3 py-1 text-xs font-semibold'">
+              {{ tripStatusLabel(trip.status) }}
+            </span>
+          </div>
+
+          <div class="flex justify-end" (click)="$event.stopPropagation()">
+            <app-trip-options-menu
+              [tripId]="trip.id"
+              [tripLabel]="trip.departureAddress + ' vers ' + trip.destination"
+              [canDownload]="trip.status === 'ACTIVE'"
+              [canComplete]="trip.status === 'ACTIVE'"
+              [isDownloading]="generatingShareCardTripId === trip.id"
+              [isCompleting]="completingTripId === trip.id"
+              (downloadPng)="downloadTripShareCard.emit($event)"
+              (completeTrip)="markTripCompleted.emit($event)"
+            />
+          </div>
+        </div>
+      }
+    </div>
+  </div>
+</div>

--- a/front-office/src/app/components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component.spec.ts
+++ b/front-office/src/app/components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Trip } from '../../../models/trip.model';
+import { TravelerTripsDesktopListComponent } from './traveler-trips-desktop-list.component';
+
+describe('TravelerTripsDesktopListComponent', () => {
+  let fixture: ComponentFixture<TravelerTripsDesktopListComponent>;
+  let component: TravelerTripsDesktopListComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TravelerTripsDesktopListComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TravelerTripsDesktopListComponent);
+    component = fixture.componentInstance;
+    component.trips = [buildTrip()];
+    component.tripBookingsMap = { 12: [{ id: 1 } as never, { id: 2 } as never] };
+    component.selectedTripId = 12;
+    fixture.detectChanges();
+  });
+
+  it('renders the desktop columns and booking count', () => {
+    const textContent = fixture.nativeElement.textContent;
+
+    expect(textContent).toContain('Voyage');
+    expect(textContent).toContain('Départ');
+    expect(textContent).toContain('Poids max');
+    expect(textContent).toContain('Prix/kg');
+    expect(textContent).toContain('Demandes');
+    expect(textContent).toContain("Plus d'options");
+    expect(textContent).toContain('2');
+  });
+
+  it('emits the selected trip id when a row is clicked', () => {
+    spyOn(component.selectTrip, 'emit');
+
+    const row = fixture.nativeElement.querySelector('[role="button"][tabindex="0"]') as HTMLDivElement;
+    row.click();
+
+    expect(component.selectTrip.emit).toHaveBeenCalledWith(12);
+  });
+
+  it('passes the exact actions to the options menu', () => {
+    const toggleButton = fixture.nativeElement.querySelector('button[aria-haspopup="menu"]') as HTMLButtonElement;
+
+    toggleButton.click();
+    fixture.detectChanges();
+
+    const menuItems = Array.from(
+      fixture.nativeElement.querySelectorAll('button[role="menuitem"]')
+    ) as HTMLButtonElement[];
+
+    expect(menuItems.map((item) => item.textContent?.trim())).toEqual([
+      'Télécharger la carte PNG',
+      'Marqué effectué',
+    ]);
+  });
+});
+
+function buildTrip(): Trip {
+  return {
+    id: 12,
+    travelerId: 1,
+    travelerName: 'Ada Lovelace',
+    departureAddress: 'Paris, France',
+    destination: "Abidjan, Côte d'Ivoire",
+    departureTime: '2025-07-14T08:00:00',
+    arrivalTime: '2025-07-14T16:00:00',
+    maxWeight: 20,
+    pricePerKilo: 15,
+    instantAcceptance: true,
+    status: 'ACTIVE',
+    availableWeight: 8,
+  };
+}

--- a/front-office/src/app/components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component.ts
+++ b/front-office/src/app/components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component.ts
@@ -41,7 +41,7 @@ export class TravelerTripsDesktopListComponent {
   tripStatusLabel(status: Trip['status']): string {
     return ({
       ACTIVE: 'Actif',
-      COMPLETED: 'Effectué',
+      COMPLETED: 'Terminé',
       CANCELLED: 'Annulé',
     } as Record<Trip['status'], string>)[status];
   }

--- a/front-office/src/app/components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component.ts
+++ b/front-office/src/app/components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component.ts
@@ -48,7 +48,7 @@ export class TravelerTripsDesktopListComponent {
 
   tripStatusClass(status: Trip['status']): string {
     return ({
-      ACTIVE: 'bg-secondary/10 text-secondary',
+      ACTIVE: 'bg-accent/10 text-accent',
       COMPLETED: 'bg-success/10 text-success',
       CANCELLED: 'bg-background-primary text-text-muted',
     } as Record<Trip['status'], string>)[status];

--- a/front-office/src/app/components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component.ts
+++ b/front-office/src/app/components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component.ts
@@ -1,0 +1,56 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { BookingResponse } from '../../../models/booking.model';
+import { Trip } from '../../../models/trip.model';
+import { TripOptionsMenuComponent } from '../trip-options-menu/trip-options-menu.component';
+
+@Component({
+  selector: 'app-traveler-trips-desktop-list',
+  standalone: true,
+  imports: [CommonModule, TripOptionsMenuComponent],
+  templateUrl: './traveler-trips-desktop-list.component.html',
+})
+export class TravelerTripsDesktopListComponent {
+  @Input({ required: true }) trips: Trip[] = [];
+  @Input({ required: true }) tripBookingsMap: Record<number, BookingResponse[]> = {};
+  @Input() selectedTripId: number | null = null;
+  @Input() generatingShareCardTripId: number | null = null;
+  @Input() completingTripId: number | null = null;
+
+  @Output() selectTrip = new EventEmitter<number>();
+  @Output() downloadTripShareCard = new EventEmitter<number>();
+  @Output() markTripCompleted = new EventEmitter<number>();
+
+  bookingCount(tripId: number): number {
+    return this.tripBookingsMap[tripId]?.length ?? 0;
+  }
+
+  onSelect(tripId: number): void {
+    this.selectTrip.emit(tripId);
+  }
+
+  onRowKeydown(event: KeyboardEvent, tripId: number): void {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+
+    event.preventDefault();
+    this.onSelect(tripId);
+  }
+
+  tripStatusLabel(status: Trip['status']): string {
+    return ({
+      ACTIVE: 'Actif',
+      COMPLETED: 'Effectué',
+      CANCELLED: 'Annulé',
+    } as Record<Trip['status'], string>)[status];
+  }
+
+  tripStatusClass(status: Trip['status']): string {
+    return ({
+      ACTIVE: 'bg-secondary/10 text-secondary',
+      COMPLETED: 'bg-success/10 text-success',
+      CANCELLED: 'bg-background-primary text-text-muted',
+    } as Record<Trip['status'], string>)[status];
+  }
+}

--- a/front-office/src/app/components/dashboard/trip-options-menu/trip-options-menu.component.html
+++ b/front-office/src/app/components/dashboard/trip-options-menu/trip-options-menu.component.html
@@ -1,7 +1,9 @@
 <div class="relative flex justify-end">
   <button
     type="button"
-    class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-background-primary bg-white text-text-secondary transition hover:border-secondary hover:text-secondary focus:outline-none focus:ring-2 focus:ring-secondary"
+    [class]="appearance === 'minimal'
+      ? 'inline-flex h-10 w-10 items-center justify-center rounded-full text-text-secondary transition hover:bg-bg-secondary hover:text-secondary focus:outline-none focus:ring-2 focus:ring-secondary/20'
+      : 'inline-flex h-10 w-10 items-center justify-center rounded-full border border-bg-primary bg-white text-text-secondary transition hover:border-secondary hover:text-secondary focus:outline-none focus:ring-2 focus:ring-secondary'"
     [attr.aria-expanded]="isOpen"
     aria-haspopup="menu"
     aria-label="Plus d'options"
@@ -14,13 +16,13 @@
 
   @if (isOpen) {
     <div
-      class="absolute right-0 top-full z-20 mt-2 w-56 rounded-2xl border border-background-primary bg-white p-2 shadow-xl"
+      class="absolute right-0 top-full z-20 mt-2 w-56 rounded-2xl border border-bg-primary bg-white p-2 shadow-xl"
       role="menu"
       aria-label="Options du trajet"
     >
       <button
         type="button"
-        class="flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-left text-sm font-medium text-text-primary transition hover:bg-background-secondary disabled:cursor-not-allowed disabled:text-text-muted"
+        class="flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-left text-sm font-medium text-text-primary transition hover:bg-bg-secondary disabled:cursor-not-allowed disabled:text-text-muted"
         role="menuitem"
         [disabled]="!canDownload || isDownloading"
         (click)="onDownload($event)"
@@ -33,7 +35,7 @@
 
       <button
         type="button"
-        class="mt-1 flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-left text-sm font-medium text-text-primary transition hover:bg-background-secondary disabled:cursor-not-allowed disabled:text-text-muted"
+        class="mt-1 flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-left text-sm font-medium text-text-primary transition hover:bg-bg-secondary disabled:cursor-not-allowed disabled:text-text-muted"
         role="menuitem"
         [disabled]="!canComplete || isCompleting"
         (click)="onComplete($event)"
@@ -43,6 +45,17 @@
           <span class="text-xs text-text-muted">En cours…</span>
         }
       </button>
+
+      @if (canCancel) {
+        <button
+          type="button"
+          class="mt-1 flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-left text-sm font-medium text-error transition hover:bg-error/10"
+          role="menuitem"
+          (click)="onCancel($event)"
+        >
+          <span>Annuler le trajet</span>
+        </button>
+      }
     </div>
   }
 </div>

--- a/front-office/src/app/components/dashboard/trip-options-menu/trip-options-menu.component.html
+++ b/front-office/src/app/components/dashboard/trip-options-menu/trip-options-menu.component.html
@@ -1,0 +1,48 @@
+<div class="relative flex justify-end">
+  <button
+    type="button"
+    class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-background-primary bg-white text-text-secondary transition hover:border-secondary hover:text-secondary focus:outline-none focus:ring-2 focus:ring-secondary"
+    [attr.aria-expanded]="isOpen"
+    aria-haspopup="menu"
+    aria-label="Plus d'options"
+    (click)="toggleMenu($event)"
+  >
+    <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 6h.01M12 12h.01M12 18h.01" />
+    </svg>
+  </button>
+
+  @if (isOpen) {
+    <div
+      class="absolute right-0 top-full z-20 mt-2 w-56 rounded-2xl border border-background-primary bg-white p-2 shadow-xl"
+      role="menu"
+      aria-label="Options du trajet"
+    >
+      <button
+        type="button"
+        class="flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-left text-sm font-medium text-text-primary transition hover:bg-background-secondary disabled:cursor-not-allowed disabled:text-text-muted"
+        role="menuitem"
+        [disabled]="!canDownload || isDownloading"
+        (click)="onDownload($event)"
+      >
+        <span>Télécharger la carte PNG</span>
+        @if (isDownloading) {
+          <span class="text-xs text-text-muted">Génération…</span>
+        }
+      </button>
+
+      <button
+        type="button"
+        class="mt-1 flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-left text-sm font-medium text-text-primary transition hover:bg-background-secondary disabled:cursor-not-allowed disabled:text-text-muted"
+        role="menuitem"
+        [disabled]="!canComplete || isCompleting"
+        (click)="onComplete($event)"
+      >
+        <span>Marqué effectué</span>
+        @if (isCompleting) {
+          <span class="text-xs text-text-muted">En cours…</span>
+        }
+      </button>
+    </div>
+  }
+</div>

--- a/front-office/src/app/components/dashboard/trip-options-menu/trip-options-menu.component.spec.ts
+++ b/front-office/src/app/components/dashboard/trip-options-menu/trip-options-menu.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TripOptionsMenuComponent } from './trip-options-menu.component';
+
+describe('TripOptionsMenuComponent', () => {
+  let fixture: ComponentFixture<TripOptionsMenuComponent>;
+  let component: TripOptionsMenuComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TripOptionsMenuComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TripOptionsMenuComponent);
+    component = fixture.componentInstance;
+    component.tripId = 12;
+    component.tripLabel = 'Paris vers Abidjan';
+    component.canDownload = true;
+    component.canComplete = true;
+    fixture.detectChanges();
+  });
+
+  it('opens the menu with the two expected actions', () => {
+    const toggleButton = fixture.nativeElement.querySelector('button[aria-haspopup="menu"]') as HTMLButtonElement;
+
+    toggleButton.click();
+    fixture.detectChanges();
+
+    const menuItems = Array.from(
+      fixture.nativeElement.querySelectorAll('button[role="menuitem"]')
+    ) as HTMLButtonElement[];
+
+    expect(menuItems.length).toBe(2);
+    expect(menuItems[0].textContent).toContain('Télécharger la carte PNG');
+    expect(menuItems[1].textContent).toContain('Marqué effectué');
+  });
+
+  it('emits the trip id when downloading the PNG', () => {
+    spyOn(component.downloadPng, 'emit');
+    component.isOpen = true;
+    fixture.detectChanges();
+
+    const menuItems = fixture.nativeElement.querySelectorAll('button[role="menuitem"]') as NodeListOf<HTMLButtonElement>;
+    menuItems[0].click();
+
+    expect(component.downloadPng.emit).toHaveBeenCalledWith(12);
+    expect(component.isOpen).toBeFalse();
+  });
+
+  it('does not emit completion when the action is disabled', () => {
+    spyOn(component.completeTrip, 'emit');
+    component.isOpen = true;
+    component.canComplete = false;
+    fixture.detectChanges();
+
+    const menuItems = fixture.nativeElement.querySelectorAll('button[role="menuitem"]') as NodeListOf<HTMLButtonElement>;
+    menuItems[1].click();
+
+    expect(component.completeTrip.emit).not.toHaveBeenCalled();
+  });
+});

--- a/front-office/src/app/components/dashboard/trip-options-menu/trip-options-menu.component.spec.ts
+++ b/front-office/src/app/components/dashboard/trip-options-menu/trip-options-menu.component.spec.ts
@@ -57,4 +57,18 @@ describe('TripOptionsMenuComponent', () => {
 
     expect(component.completeTrip.emit).not.toHaveBeenCalled();
   });
+
+  it('shows and emits the optional cancel action when enabled', () => {
+    spyOn(component.cancelTrip, 'emit');
+    component.canCancel = true;
+    component.isOpen = true;
+    fixture.detectChanges();
+
+    const menuItems = fixture.nativeElement.querySelectorAll('button[role="menuitem"]') as NodeListOf<HTMLButtonElement>;
+    menuItems[2].click();
+
+    expect(menuItems.length).toBe(3);
+    expect(menuItems[2].textContent).toContain('Annuler le trajet');
+    expect(component.cancelTrip.emit).toHaveBeenCalledWith(12);
+  });
 });

--- a/front-office/src/app/components/dashboard/trip-options-menu/trip-options-menu.component.ts
+++ b/front-office/src/app/components/dashboard/trip-options-menu/trip-options-menu.component.ts
@@ -14,11 +14,14 @@ export class TripOptionsMenuComponent {
   @Input({ required: true }) tripLabel!: string;
   @Input() canDownload = false;
   @Input() canComplete = false;
+  @Input() canCancel = false;
   @Input() isDownloading = false;
   @Input() isCompleting = false;
+  @Input() appearance: 'default' | 'minimal' = 'default';
 
   @Output() downloadPng = new EventEmitter<number>();
   @Output() completeTrip = new EventEmitter<number>();
+  @Output() cancelTrip = new EventEmitter<number>();
 
   isOpen = false;
 
@@ -50,6 +53,17 @@ export class TripOptionsMenuComponent {
     }
 
     this.completeTrip.emit(this.tripId);
+    this.closeMenu();
+  }
+
+  onCancel(event: Event): void {
+    event.stopPropagation();
+
+    if (!this.canCancel) {
+      return;
+    }
+
+    this.cancelTrip.emit(this.tripId);
     this.closeMenu();
   }
 

--- a/front-office/src/app/components/dashboard/trip-options-menu/trip-options-menu.component.ts
+++ b/front-office/src/app/components/dashboard/trip-options-menu/trip-options-menu.component.ts
@@ -1,0 +1,75 @@
+import { CommonModule } from '@angular/common';
+import { Component, ElementRef, EventEmitter, HostListener, Input, Output, inject } from '@angular/core';
+
+@Component({
+  selector: 'app-trip-options-menu',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './trip-options-menu.component.html',
+})
+export class TripOptionsMenuComponent {
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+
+  @Input({ required: true }) tripId!: number;
+  @Input({ required: true }) tripLabel!: string;
+  @Input() canDownload = false;
+  @Input() canComplete = false;
+  @Input() isDownloading = false;
+  @Input() isCompleting = false;
+
+  @Output() downloadPng = new EventEmitter<number>();
+  @Output() completeTrip = new EventEmitter<number>();
+
+  isOpen = false;
+
+  toggleMenu(event: Event): void {
+    event.stopPropagation();
+    this.isOpen = !this.isOpen;
+  }
+
+  closeMenu(): void {
+    this.isOpen = false;
+  }
+
+  onDownload(event: Event): void {
+    event.stopPropagation();
+
+    if (!this.canDownload || this.isDownloading) {
+      return;
+    }
+
+    this.downloadPng.emit(this.tripId);
+    this.closeMenu();
+  }
+
+  onComplete(event: Event): void {
+    event.stopPropagation();
+
+    if (!this.canComplete || this.isCompleting) {
+      return;
+    }
+
+    this.completeTrip.emit(this.tripId);
+    this.closeMenu();
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (!this.isOpen) {
+      return;
+    }
+
+    const target = event.target as Node | null;
+
+    if (target && this.elementRef.nativeElement.contains(target)) {
+      return;
+    }
+
+    this.closeMenu();
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    this.closeMenu();
+  }
+}

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.html
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.html
@@ -1,5 +1,5 @@
 <div class="min-h-screen bg-background-primary pt-20 pb-12 font-['Poppins']">
-  <div class="max-w-4xl mx-auto px-4 sm:px-6">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6">
 
     <!-- ── Profile header ──────────────────────────────────────────────────── -->
     <div class="bg-white rounded-2xl shadow-sm p-6 mb-6 flex items-center gap-4">

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.html
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.html
@@ -296,8 +296,19 @@
                 </a>
               </div>
             } @else {
+              <app-traveler-trips-desktop-list
+                [trips]="myTrips"
+                [tripBookingsMap]="tripBookingsMap"
+                [selectedTripId]="selectedTripId"
+                [generatingShareCardTripId]="generatingShareCardTripId"
+                [completingTripId]="completingTripId"
+                (selectTrip)="selectTrip($event)"
+                (downloadTripShareCard)="handleDesktopTripShareCardDownload($event)"
+                (markTripCompleted)="handleDesktopTripCompletion($event)"
+              />
+
               <!-- Trip selection grid -->
-              <div class="grid gap-4 sm:grid-cols-2">
+              <div class="grid gap-4 sm:grid-cols-2 lg:hidden">
                 @for (trip of myTrips; track trip.id) {
                   <button
                     (click)="selectTrip(trip.id)"
@@ -374,7 +385,7 @@
                         type="button"
                         (click)="downloadShareCardPng()"
                         [disabled]="!canGenerateShareCard()"
-                        class="inline-flex items-center justify-center rounded-lg bg-accent px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+                        class="inline-flex items-center justify-center rounded-lg bg-accent px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50 lg:hidden"
                       >
                         {{ isGeneratingShareCard ? 'Génération…' : 'Télécharger la carte PNG' }}
                       </button>

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.html
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.html
@@ -308,70 +308,20 @@
               />
 
               <!-- Trip selection grid -->
-              <div class="grid gap-4 sm:grid-cols-2 lg:hidden">
+              <div class="grid gap-4 lg:hidden">
                 @for (trip of myTrips; track trip.id) {
-                  <button
-                    (click)="selectTrip(trip.id)"
-                    [class.ring-2]="selectedTripId === trip.id"
-                    [class.ring-secondary]="selectedTripId === trip.id"
-                    class="text-left bg-background-secondary border border-gray-100 rounded-xl p-4 hover:shadow-md transition-all duration-200"
-                    [attr.aria-pressed]="selectedTripId === trip.id"
-                  >
-                    <div class="flex items-start justify-between gap-2">
-                      <p class="font-semibold text-text-primary text-sm">
-                        {{ trip.departureAddress }} → {{ trip.destination }}
-                      </p>
-                      <div class="flex items-center gap-2 shrink-0">
-                        <span [class]="tripStatusClass(trip.status) + ' inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-semibold'">
-                          {{ tripStatusLabel(trip.status) }}
-                        </span>
-                        @if ((tripBookingsMap[trip.id] || []).length > 0) {
-                          <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full bg-accent text-white text-xs font-bold">
-                            {{ tripBookingsMap[trip.id].length }}
-                          </span>
-                        } @else {
-                          <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full bg-gray-200 text-text-muted text-xs font-medium">
-                            0
-                          </span>
-                        }
-                      </div>
-                    </div>
-                    <p class="text-text-secondary text-xs mt-1">
-                      {{ trip.departureTime | date:'dd/MM/yyyy HH:mm' }}
-                    </p>
-                    <p class="text-text-muted text-xs mt-1">
-                      Poids max : {{ trip.maxWeight }} kg · {{ trip.pricePerKilo }} €/kg
-                    </p>
-                    <div class="mt-3 flex justify-end gap-3" (click)="$event.stopPropagation()">
-                      @if (trip.status === 'ACTIVE') {
-                        <!-- Edit action — navigates to the shared propose/edit page -->
-                        <button
-                          (click)="editTrip(trip.id)"
-                          class="inline-flex items-center gap-1 text-xs font-semibold text-secondary hover:underline"
-                          aria-label="Modifier ce trajet"
-                        >
-                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536M9 13l6.586-6.586a2 2 0 012.828 2.828L11.828 15.828a2 2 0 01-1.414.586H9v-2.414a2 2 0 01.586-1.414z"/>
-                          </svg>
-                          Modifier
-                        </button>
-                        <button
-                          (click)="completeTrip(trip.id)"
-                          [disabled]="isCompletingTrip"
-                          class="text-xs font-semibold text-success hover:underline disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          Marquer effectué
-                        </button>
-                        <button
-                          (click)="cancelTrip(trip.id)"
-                          [disabled]="isCancellingTrip"
-                          class="text-xs font-semibold text-error hover:underline disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          Annuler le trajet
-                        </button>
-                      }
-                    </div>
-                  </button>
+                  <app-dashboard-received-mobile-card
+                    [trip]="trip"
+                    [bookingCount]="(tripBookingsMap[trip.id] || []).length"
+                    [isSelected]="selectedTripId === trip.id"
+                    [isGeneratingShareCard]="generatingShareCardTripId === trip.id"
+                    [isCompletingTrip]="completingTripId === trip.id"
+                    (viewTrip)="selectTrip($event)"
+                    (editTrip)="editTrip($event)"
+                    (downloadShareCard)="downloadShareCardPng($event)"
+                    (markTripCompleted)="completeTrip($event)"
+                    (cancelTrip)="cancelTrip($event)"
+                  />
                 }
               </div>
 

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.spec.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.spec.ts
@@ -173,6 +173,24 @@ describe('DashboardPageComponent', () => {
     ]);
   });
 
+  it('uses the wider dashboard container and keeps the received desktop list rendered', () => {
+    const selectedTrip = buildTrip();
+
+    component.activeTab = 'received';
+    component.myTrips = [selectedTrip];
+    component.tripBookingsMap = { [selectedTrip.id]: [] };
+    component.selectedTripId = selectedTrip.id;
+
+    fixture.detectChanges();
+
+    const dashboardContainer = fixture.nativeElement.querySelector('.max-w-6xl') as HTMLElement | null;
+    const desktopList = fixture.nativeElement.querySelector('app-traveler-trips-desktop-list');
+
+    expect(dashboardContainer).not.toBeNull();
+    expect(dashboardContainer?.className).not.toContain('max-w-4xl');
+    expect(desktopList).not.toBeNull();
+  });
+
   it('shows an identity proof file field in the profile tab', () => {
     component.activeTab = 'profile';
     fixture.detectChanges();

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.spec.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.spec.ts
@@ -154,8 +154,9 @@ describe('DashboardPageComponent', () => {
 
     fixture.detectChanges();
 
+    const desktopList = fixture.nativeElement.querySelector('app-traveler-trips-desktop-list') as HTMLElement;
     const menuButtons = Array.from(
-      fixture.nativeElement.querySelectorAll('button[aria-haspopup="menu"]')
+      desktopList.querySelectorAll('button[aria-haspopup="menu"]')
     ) as HTMLButtonElement[];
 
     expect(menuButtons.length).toBe(2);
@@ -164,7 +165,7 @@ describe('DashboardPageComponent', () => {
     fixture.detectChanges();
 
     const menuItems = Array.from(
-      fixture.nativeElement.querySelectorAll('button[role="menuitem"]')
+      desktopList.querySelectorAll('button[role="menuitem"]')
     ) as HTMLButtonElement[];
 
     expect(menuItems.map((item) => item.textContent?.trim())).toEqual([
@@ -189,6 +190,42 @@ describe('DashboardPageComponent', () => {
     expect(dashboardContainer).not.toBeNull();
     expect(dashboardContainer?.className).not.toContain('max-w-4xl');
     expect(desktopList).not.toBeNull();
+  });
+
+  it('renders the redesigned mobile received cards with the truthful price-per-kilo label', () => {
+    const selectedTrip = buildTrip();
+
+    component.activeTab = 'received';
+    component.myTrips = [selectedTrip];
+    component.tripBookingsMap = { [selectedTrip.id]: [] };
+
+    fixture.detectChanges();
+
+    const mobileCard = fixture.nativeElement.querySelector('app-dashboard-received-mobile-card');
+
+    expect(mobileCard).not.toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('Prix / kg');
+    expect(fixture.nativeElement.textContent).toContain('15 €');
+  });
+
+  it('renders the effective mobile received card without exposing undefined capacity text', () => {
+    const selectedTrip = {
+      ...buildTrip(),
+      availableWeight: undefined as unknown as number,
+      maxWeight: 20,
+    };
+
+    component.activeTab = 'received';
+    component.myTrips = [selectedTrip];
+    component.tripBookingsMap = { [selectedTrip.id]: [] };
+
+    fixture.detectChanges();
+
+    const mobileCard = fixture.nativeElement.querySelector('app-dashboard-received-mobile-card');
+
+    expect(mobileCard).not.toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('20 kg disponibles');
+    expect(fixture.nativeElement.textContent).not.toContain('undefined kg disponibles');
   });
 
   it('shows an identity proof file field in the profile tab', () => {
@@ -259,6 +296,12 @@ describe('DashboardPageComponent', () => {
 
     expect(component.selectTrip).toHaveBeenCalledWith(selectedTrip.id);
     expect(component.completeTrip).toHaveBeenCalledWith(selectedTrip.id);
+  });
+
+  it('uses the expected received-trip status mapping', () => {
+    expect(component.tripStatusLabel('ACTIVE')).toBe('Actif');
+    expect(component.tripStatusLabel('COMPLETED')).toBe('Terminé');
+    expect(component.tripStatusLabel('CANCELLED')).toBe('Annulé');
   });
 });
 

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.spec.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.spec.ts
@@ -118,7 +118,7 @@ describe('DashboardPageComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('Mot de passe oublie');
   });
 
-  it('shows an edit action for active trips and opens the edit route', () => {
+  it('shows a desktop options menu with the two confirmed actions', () => {
     component.activeTab = 'received';
     component.myTrips = [
       {
@@ -154,15 +154,23 @@ describe('DashboardPageComponent', () => {
 
     fixture.detectChanges();
 
-    const editButtons = Array.from(
-      fixture.nativeElement.querySelectorAll('button[aria-label="Modifier ce trajet"]')
+    const menuButtons = Array.from(
+      fixture.nativeElement.querySelectorAll('button[aria-haspopup="menu"]')
     ) as HTMLButtonElement[];
 
-    expect(editButtons.length).toBe(1);
+    expect(menuButtons.length).toBe(2);
 
-    editButtons[0].click();
+    menuButtons[0].click();
+    fixture.detectChanges();
 
-    expect(router.navigate).toHaveBeenCalledWith(['/propose', 12]);
+    const menuItems = Array.from(
+      fixture.nativeElement.querySelectorAll('button[role="menuitem"]')
+    ) as HTMLButtonElement[];
+
+    expect(menuItems.map((item) => item.textContent?.trim())).toEqual([
+      'Télécharger la carte PNG',
+      'Marqué effectué',
+    ]);
   });
 
   it('shows an identity proof file field in the profile tab', () => {
@@ -197,7 +205,7 @@ describe('DashboardPageComponent', () => {
       tagName.toLowerCase() === 'a' ? anchor : originalCreateElement(tagName)
     ));
 
-    await component.downloadShareCardPng();
+    await component.downloadShareCardPng(selectedTrip.id);
 
     expect(requestAnimationFrameSpy).toHaveBeenCalled();
     expect(shareCardMapperServiceMock.mapActiveTripToShareCard).toHaveBeenCalledWith(selectedTrip, currentUser$.getValue());
@@ -205,6 +213,34 @@ describe('DashboardPageComponent', () => {
     expect(anchor.download).toBe('colick-carte-partage-2025-07-14.png');
     expect(anchorClickSpy).toHaveBeenCalled();
     expect(component.shareCardError).toBe('');
+  });
+
+  it('selects the trip before downloading it from the desktop options menu', async () => {
+    const selectedTrip = buildTrip();
+    component.activeTab = 'received';
+    component.myTrips = [selectedTrip];
+    component.tripBookingsMap = { [selectedTrip.id]: [] };
+    spyOn(component, 'selectTrip').and.callThrough();
+    spyOn(component, 'downloadShareCardPng').and.resolveTo();
+
+    component.handleDesktopTripShareCardDownload(selectedTrip.id);
+
+    expect(component.selectTrip).toHaveBeenCalledWith(selectedTrip.id);
+    expect(component.downloadShareCardPng).toHaveBeenCalledWith(selectedTrip.id);
+  });
+
+  it('selects the trip before marking it as completed from the desktop options menu', () => {
+    const selectedTrip = buildTrip();
+    component.activeTab = 'received';
+    component.myTrips = [selectedTrip];
+    component.tripBookingsMap = { [selectedTrip.id]: [] };
+    spyOn(component, 'selectTrip').and.callThrough();
+    spyOn(component, 'completeTrip');
+
+    component.handleDesktopTripCompletion(selectedTrip.id);
+
+    expect(component.selectTrip).toHaveBeenCalledWith(selectedTrip.id);
+    expect(component.completeTrip).toHaveBeenCalledWith(selectedTrip.id);
   });
 });
 

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.ts
@@ -13,6 +13,7 @@ import { BookingResponse } from '../../models/booking.model';
 import { UpdateProfileRequest } from '../../models/auth.model';
 import { ShareCardMapperService } from '../../services/share-card-mapper.service';
 import { ShareCardStoryComponent } from '../../components/share-card-story/share-card-story.component';
+import { TravelerTripsDesktopListComponent } from '../../components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component';
 import { ConfirmModalComponent } from '../../shared/components/confirm-modal/confirm-modal.component';
 
 type Tab = 'profile' | 'chats' | 'received' | 'sent';
@@ -20,7 +21,15 @@ type Tab = 'profile' | 'chats' | 'received' | 'sent';
 @Component({
   selector: 'app-dashboard-page',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterLink, ConfirmModalComponent, ShareCardStoryComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    RouterLink,
+    ConfirmModalComponent,
+    ShareCardStoryComponent,
+    TravelerTripsDesktopListComponent,
+  ],
   templateUrl: './dashboard-page.component.html',
 })
 export class DashboardPageComponent implements OnInit {
@@ -89,7 +98,9 @@ export class DashboardPageComponent implements OnInit {
   bookingActionError = '';
   isCancellingTrip = false;
   isCompletingTrip = false;
+  completingTripId: number | null = null;
   isGeneratingShareCard = false;
+  generatingShareCardTripId: number | null = null;
   shareCardError = '';
   shareCardData: ShareCardData | null = null;
   deliveryCodeByBookingId: Record<number, string> = {};
@@ -307,8 +318,10 @@ export class DashboardPageComponent implements OnInit {
     this.selectedTripBookings = this.tripBookingsMap[tripId] ?? [];
   }
 
-  async downloadShareCardPng(): Promise<void> {
-    const trip = this.selectedTrip();
+  async downloadShareCardPng(tripId?: number): Promise<void> {
+    const trip = typeof tripId === 'number'
+      ? this.myTrips.find((currentTrip) => currentTrip.id === tripId)
+      : this.selectedTrip();
     const user = this.authService.getUser();
 
     if (!trip || trip.status !== 'ACTIVE' || !user) {
@@ -320,6 +333,7 @@ export class DashboardPageComponent implements OnInit {
     this.shareCardData = this.shareCardMapperService.mapActiveTripToShareCard(trip, user);
     this.cdr.detectChanges();
     this.isGeneratingShareCard = true;
+    this.generatingShareCardTripId = trip.id;
 
     try {
       await new Promise<void>((resolve) => {
@@ -341,6 +355,7 @@ export class DashboardPageComponent implements OnInit {
       this.shareCardError = 'Impossible de générer la carte PNG pour le moment.';
     } finally {
       this.isGeneratingShareCard = false;
+      this.generatingShareCardTripId = null;
     }
   }
 
@@ -349,7 +364,12 @@ export class DashboardPageComponent implements OnInit {
   }
 
   completeTrip(tripId: number): void {
+    if (this.isCompletingTrip) {
+      return;
+    }
+
     this.isCompletingTrip = true;
+    this.completingTripId = tripId;
     this.bookingActionError = '';
     this.tripService.completeTrip(tripId).subscribe({
       next: (updatedTrip) => {
@@ -358,12 +378,24 @@ export class DashboardPageComponent implements OnInit {
           this.myTrips[tripIndex] = updatedTrip;
         }
         this.isCompletingTrip = false;
+        this.completingTripId = null;
       },
       error: (err: { error?: { message?: string } }) => {
         this.bookingActionError = err.error?.message || "Erreur lors du passage du trajet à l'état effectué.";
         this.isCompletingTrip = false;
+        this.completingTripId = null;
       },
     });
+  }
+
+  handleDesktopTripShareCardDownload(tripId: number): void {
+    this.selectTrip(tripId);
+    void this.downloadShareCardPng(tripId);
+  }
+
+  handleDesktopTripCompletion(tripId: number): void {
+    this.selectTrip(tripId);
+    this.completeTrip(tripId);
   }
 
   acceptBooking(bookingId: number): void {

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.ts
@@ -14,6 +14,7 @@ import { UpdateProfileRequest } from '../../models/auth.model';
 import { ShareCardMapperService } from '../../services/share-card-mapper.service';
 import { ShareCardStoryComponent } from '../../components/share-card-story/share-card-story.component';
 import { TravelerTripsDesktopListComponent } from '../../components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component';
+import { DashboardReceivedMobileCardComponent } from '../../components/dashboard/dashboard-received-mobile-card/dashboard-received-mobile-card.component';
 import { ConfirmModalComponent } from '../../shared/components/confirm-modal/confirm-modal.component';
 
 type Tab = 'profile' | 'chats' | 'received' | 'sent';
@@ -29,6 +30,7 @@ type Tab = 'profile' | 'chats' | 'received' | 'sent';
     ConfirmModalComponent,
     ShareCardStoryComponent,
     TravelerTripsDesktopListComponent,
+    DashboardReceivedMobileCardComponent,
   ],
   templateUrl: './dashboard-page.component.html',
 })
@@ -544,7 +546,7 @@ export class DashboardPageComponent implements OnInit {
   }
 
   tripStatusLabel(status: Trip['status']): string {
-    return ({ ACTIVE: 'Actif', COMPLETED: 'Effectué', CANCELLED: 'Annulé' } as Record<Trip['status'], string>)[status];
+    return ({ ACTIVE: 'Actif', COMPLETED: 'Terminé', CANCELLED: 'Annulé' } as Record<Trip['status'], string>)[status];
   }
 
   tripStatusClass(status: Trip['status']): string {

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.ts
@@ -110,6 +110,7 @@ export class DashboardPageComponent implements OnInit {
   isRemoveModalOpen = false;
   pendingRemoveBookingId: number | null = null;
   isRemoving = false;
+  pendingSelectTripId: number | null = null;
 
   // ── Sent requests ─────────────────────────────────────────────────────────
   myBookings: BookingResponse[] = [];
@@ -140,6 +141,8 @@ export class DashboardPageComponent implements OnInit {
     this.route.queryParamMap.subscribe((params) => {
       const tab = params.get('tab');
       if (this.isTab(tab)) this.setTab(tab);
+      const tripId = params.get('tripId');
+      if (tripId) this.pendingSelectTripId = Number(tripId);
     });
   }
 
@@ -305,6 +308,10 @@ export class DashboardPageComponent implements OnInit {
         forkJoin(requests).subscribe((results) => {
           trips.forEach((t, i) => { this.tripBookingsMap[t.id] = results[i] as BookingResponse[]; });
           this.isLoadingTrips = false;
+          if (this.pendingSelectTripId) {
+            this.selectTrip(this.pendingSelectTripId);
+            this.pendingSelectTripId = null;
+          }
         });
       },
       error: () => { this.isLoadingTrips = false; },

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.ts
@@ -550,7 +550,7 @@ export class DashboardPageComponent implements OnInit {
   }
 
   tripStatusClass(status: Trip['status']): string {
-    return ({ ACTIVE: 'bg-secondary/10 text-secondary', COMPLETED: 'bg-success/10 text-success', CANCELLED: 'bg-gray-100 text-gray-500' } as Record<Trip['status'], string>)[status];
+    return ({ ACTIVE: 'bg-accent/10 text-accent', COMPLETED: 'bg-success/10 text-success', CANCELLED: 'bg-background-primary text-text-muted' } as Record<Trip['status'], string>)[status];
   }
 
   selectedTrip(): Trip | undefined {

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.html
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.html
@@ -1,0 +1,230 @@
+<div class="min-h-screen bg-bg-primary pt-20 pb-12 font-sans">
+  <div class="mx-auto max-w-6xl px-6">
+
+    <!-- ── Section Header ──────────────────────────────────────────────────── -->
+    <div class="mb-8 flex items-start justify-between">
+      <div>
+        <h1 class="text-2xl font-bold text-primary">Gestion des trajets</h1>
+        <p class="mt-1 text-sm text-text-secondary">Visualisez et gérez vos propositions de transport.</p>
+      </div>
+      <a
+        routerLink="/propose"
+        class="inline-flex items-center gap-2 rounded-xl bg-secondary px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-secondary/90"
+      >
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+        </svg>
+        Proposer un voyage
+      </a>
+    </div>
+
+    <!-- ── Card Container ──────────────────────────────────────────────────── -->
+    <div class="overflow-hidden rounded-2xl bg-white shadow-sm">
+
+      <!-- ── Filter Bar ──────────────────────────────────────────────────── -->
+      <div class="flex items-center justify-between border-b border-gray-100 px-6 py-4">
+        <!-- Tabs -->
+        <div class="flex gap-6">
+          @for (tab of filterTabs; track tab.id) {
+            <button
+              type="button"
+              (click)="setFilter(tab.id)"
+              class="relative pb-2 text-sm font-medium transition"
+              [class.text-secondary]="activeFilter === tab.id"
+              [class.text-text-muted]="activeFilter !== tab.id"
+              [class.hover:text-text-secondary]="activeFilter !== tab.id"
+            >
+              {{ tab.label }}
+              @if (activeFilter === tab.id) {
+                <span class="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-secondary"></span>
+              }
+            </button>
+          }
+        </div>
+
+        <!-- Search -->
+        <div class="relative">
+          <svg class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+          </svg>
+          <input
+            type="text"
+            [(ngModel)]="searchQuery"
+            (ngModelChange)="onSearchChange()"
+            placeholder="Rechercher un trajet..."
+            class="w-64 rounded-lg border border-gray-200 bg-bg-secondary py-2 pl-10 pr-4 text-sm text-text-primary placeholder:text-text-muted focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary"
+          />
+        </div>
+      </div>
+
+      <!-- ── Loading State ───────────────────────────────────────────────── -->
+      @if (isLoading) {
+        <div class="flex justify-center py-16">
+          <div class="h-8 w-8 animate-spin rounded-full border-2 border-secondary border-t-transparent"></div>
+        </div>
+      }
+
+      <!-- ── Error State ─────────────────────────────────────────────────── -->
+      @if (loadError && !isLoading) {
+        <div class="px-6 py-8 text-center text-sm text-error">{{ loadError }}</div>
+      }
+
+      <!-- ── Empty State ─────────────────────────────────────────────────── -->
+      @if (!isLoading && !loadError && filteredTrips.length === 0) {
+        <div class="px-6 py-16 text-center">
+          <p class="text-sm text-text-secondary">Aucun trajet trouvé.</p>
+        </div>
+      }
+
+      <!-- ── Table ───────────────────────────────────────────────────────── -->
+      @if (!isLoading && !loadError && filteredTrips.length > 0) {
+        <table class="w-full">
+          <thead>
+            <tr class="border-b border-gray-100">
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">Trajet / Date</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">Capacité</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">Prix / kg</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">État</th>
+              <th class="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            @for (trip of paginatedTrips; track trip.id) {
+              <tr class="transition hover:bg-bg-secondary">
+                <!-- TRAJET / DATE -->
+                <td class="px-6 py-4">
+                  <p class="text-sm font-semibold text-primary">{{ trip.departureAddress }} → {{ trip.destination }}</p>
+                  <p class="mt-1 text-xs text-text-muted">{{ formatTripDate(trip.departureTime) }}</p>
+                </td>
+
+                <!-- CAPACITÉ -->
+                <td class="px-6 py-4">
+                  <span class="inline-flex rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-text-primary">
+                    {{ trip.maxWeight }} kg
+                  </span>
+                </td>
+
+                <!-- PRIX / KG -->
+                <td class="px-6 py-4">
+                  <span class="text-sm font-semibold text-text-primary">{{ trip.pricePerKilo }} € / kg</span>
+                </td>
+
+                <!-- ÉTAT -->
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-2">
+                    <span class="h-2 w-2 rounded-full" [ngClass]="tripStatusDotClass(trip.status)"></span>
+                    <span class="text-xs font-medium" [ngClass]="tripStatusTextClass(trip.status)">
+                      {{ tripStatusLabel(trip.status) }}
+                    </span>
+                  </div>
+                </td>
+
+                <!-- ACTIONS -->
+                <td class="px-6 py-4">
+                  <div class="flex items-center justify-end gap-2">
+                    <!-- Eye icon — View details -->
+                    <button
+                      type="button"
+                      (click)="viewTripDetails(trip.id)"
+                      class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-gray-100 text-text-secondary transition hover:bg-gray-200"
+                      aria-label="Voir les demandes"
+                    >
+                      <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                      </svg>
+                    </button>
+
+                    <!-- Pencil icon — Edit with pending badge -->
+                    <div class="relative">
+                      <button
+                        type="button"
+                        (click)="editTrip(trip.id)"
+                        class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-gray-100 text-text-secondary transition hover:bg-gray-200"
+                        aria-label="Modifier le trajet"
+                      >
+                        <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536M9 13l6.586-6.586a2 2 0 012.828 2.828L11.828 15.828a2 2 0 01-1.414.586H9v-2.414a2 2 0 01.586-1.414z"/>
+                        </svg>
+                      </button>
+                      @if (pendingBookingCount(trip.id) > 0) {
+                        <span class="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-error text-[10px] font-bold text-white">
+                          {{ pendingBookingCount(trip.id) }}
+                        </span>
+                      }
+                    </div>
+
+                    <!-- Three dots — Options menu -->
+                    <app-trip-options-menu
+                      [tripId]="trip.id"
+                      [tripLabel]="trip.departureAddress + ' vers ' + trip.destination"
+                      [canDownload]="trip.status === 'ACTIVE'"
+                      [canComplete]="trip.status === 'ACTIVE'"
+                      [isDownloading]="generatingShareCardTripId === trip.id"
+                      [isCompleting]="completingTripId === trip.id"
+                      (downloadPng)="downloadShareCardPng($event)"
+                      (completeTrip)="markTripCompleted($event)"
+                    />
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+
+        <!-- ── Pagination ──────────────────────────────────────────────────── -->
+        <div class="flex items-center justify-between border-t border-gray-100 px-6 py-4">
+          <p class="text-sm text-text-secondary">
+            Affichage de {{ paginatedTrips.length }} sur {{ filteredTrips.length }} trajets
+          </p>
+          <div class="flex items-center gap-1">
+            <button
+              type="button"
+              (click)="goToPage(currentPage - 1)"
+              [disabled]="currentPage === 1"
+              class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-sm text-text-secondary transition hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+              aria-label="Page précédente"
+            >
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/>
+              </svg>
+            </button>
+
+            @for (page of pageNumbers; track page) {
+              <button
+                type="button"
+                (click)="goToPage(page)"
+                class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-sm font-medium transition"
+                [class.bg-primary]="currentPage === page"
+                [class.text-white]="currentPage === page"
+                [class.text-text-secondary]="currentPage !== page"
+                [class.hover:bg-gray-100]="currentPage !== page"
+              >
+                {{ page }}
+              </button>
+            }
+
+            <button
+              type="button"
+              (click)="goToPage(currentPage + 1)"
+              [disabled]="currentPage === totalPages"
+              class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-sm text-text-secondary transition hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+              aria-label="Page suivante"
+            >
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+      }
+    </div>
+  </div>
+
+  <!-- Hidden share card capture element for PNG generation -->
+  @if (shareCardData) {
+    <div class="fixed left-[-9999px] top-0" #shareCardCapture>
+      <app-share-card-story [data]="shareCardData" />
+    </div>
+  }
+</div>

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.spec.ts
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.spec.ts
@@ -1,0 +1,268 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { TripsManagementPageComponent, TripStatusFilter } from './trips-management-page.component';
+import { TripService } from '../../services/trip.service';
+import { AuthService } from '../../services/auth.service';
+import { ShareCardMapperService } from '../../services/share-card-mapper.service';
+import { Trip } from '../../models/trip.model';
+import { BookingResponse } from '../../models/booking.model';
+
+describe('TripsManagementPageComponent', () => {
+  let component: TripsManagementPageComponent;
+  let fixture: ComponentFixture<TripsManagementPageComponent>;
+  let tripServiceSpy: jasmine.SpyObj<TripService>;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let shareCardMapperSpy: jasmine.SpyObj<ShareCardMapperService>;
+
+  const mockTrips: Trip[] = [
+    {
+      id: 1, travelerId: 10, travelerName: 'John',
+      departureAddress: 'Paris', destination: 'Lyon',
+      departureTime: '2024-03-15T10:00:00', arrivalTime: '2024-03-15T14:00:00',
+      maxWeight: 20, pricePerKilo: 5, instantAcceptance: false, status: 'ACTIVE', availableWeight: 15,
+    },
+    {
+      id: 2, travelerId: 10, travelerName: 'John',
+      departureAddress: 'Marseille', destination: 'Nice',
+      departureTime: '2024-03-20T08:00:00', arrivalTime: '2024-03-20T10:00:00',
+      maxWeight: 10, pricePerKilo: 8, instantAcceptance: true, status: 'COMPLETED', availableWeight: 0,
+    },
+    {
+      id: 3, travelerId: 10, travelerName: 'John',
+      departureAddress: 'Bordeaux', destination: 'Toulouse',
+      departureTime: '2024-04-01T12:00:00', arrivalTime: '2024-04-01T15:00:00',
+      maxWeight: 30, pricePerKilo: 4, instantAcceptance: false, status: 'CANCELLED', availableWeight: 30,
+    },
+    {
+      id: 4, travelerId: 10, travelerName: 'John',
+      departureAddress: 'Lille', destination: 'Strasbourg',
+      departureTime: '2024-04-05T09:00:00', arrivalTime: '2024-04-05T14:00:00',
+      maxWeight: 25, pricePerKilo: 6, instantAcceptance: false, status: 'ACTIVE', availableWeight: 20,
+    },
+    {
+      id: 5, travelerId: 10, travelerName: 'John',
+      departureAddress: 'Nantes', destination: 'Rennes',
+      departureTime: '2024-04-10T07:00:00', arrivalTime: '2024-04-10T09:00:00',
+      maxWeight: 15, pricePerKilo: 7, instantAcceptance: true, status: 'ACTIVE', availableWeight: 10,
+    },
+    {
+      id: 6, travelerId: 10, travelerName: 'John',
+      departureAddress: 'Dijon', destination: 'Grenoble',
+      departureTime: '2024-04-12T11:00:00', arrivalTime: '2024-04-12T14:00:00',
+      maxWeight: 18, pricePerKilo: 5, instantAcceptance: false, status: 'ACTIVE', availableWeight: 12,
+    },
+  ];
+
+  const mockBookings: BookingResponse[] = [
+    {
+      id: 100, tripId: 1, senderId: 20, senderName: 'Alice',
+      title: 'Colis A', weight: 5, recipientContact: 'alice@test.com',
+      status: 'PENDING', validationCodeActive: false,
+    },
+    {
+      id: 101, tripId: 1, senderId: 21, senderName: 'Bob',
+      title: 'Colis B', weight: 3, recipientContact: 'bob@test.com',
+      status: 'ACCEPTED', validationCodeActive: false,
+    },
+  ];
+
+  beforeEach(async () => {
+    tripServiceSpy = jasmine.createSpyObj('TripService', ['getMyTrips', 'getTripBookings', 'completeTrip']);
+    tripServiceSpy.getMyTrips.and.returnValue(of(mockTrips.map((t) => ({ ...t }))));
+    tripServiceSpy.getTripBookings.and.returnValue(of([...mockBookings]));
+    tripServiceSpy.completeTrip.and.returnValue(of({ ...mockTrips[0], status: 'COMPLETED' as const }));
+
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['isLoggedIn', 'getUser']);
+    authServiceSpy.isLoggedIn.and.returnValue(true);
+    authServiceSpy.getUser.and.returnValue({
+      id: 10, firstName: 'John', lastName: 'Doe', email: 'john@test.com',
+    } as any);
+
+    shareCardMapperSpy = jasmine.createSpyObj('ShareCardMapperService', ['mapActiveTripToShareCard', 'buildFileDate']);
+    shareCardMapperSpy.buildFileDate.and.returnValue('2024-03-15');
+
+    await TestBed.configureTestingModule({
+      imports: [TripsManagementPageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: TripService, useValue: tripServiceSpy },
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: ShareCardMapperService, useValue: shareCardMapperSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TripsManagementPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load trips on init', () => {
+    expect(tripServiceSpy.getMyTrips).toHaveBeenCalled();
+    expect(component.trips.length).toBe(6);
+  });
+
+  it('should load bookings for each trip', () => {
+    expect(tripServiceSpy.getTripBookings).toHaveBeenCalledTimes(6);
+  });
+
+  describe('Filtering', () => {
+    it('should show all trips when filter is ALL', () => {
+      component.activeFilter = 'ALL';
+      expect(component.filteredTrips.length).toBe(6);
+    });
+
+    it('should filter by ACTIVE status', () => {
+      component.setFilter('ACTIVE');
+      expect(component.filteredTrips.every((t) => t.status === 'ACTIVE')).toBeTrue();
+      expect(component.filteredTrips.length).toBe(4);
+    });
+
+    it('should filter by COMPLETED status', () => {
+      component.setFilter('COMPLETED');
+      expect(component.filteredTrips.every((t) => t.status === 'COMPLETED')).toBeTrue();
+      expect(component.filteredTrips.length).toBe(1);
+    });
+
+    it('should filter by CANCELLED status', () => {
+      component.setFilter('CANCELLED');
+      expect(component.filteredTrips.every((t) => t.status === 'CANCELLED')).toBeTrue();
+      expect(component.filteredTrips.length).toBe(1);
+    });
+
+    it('should filter by search query on departure address', () => {
+      component.searchQuery = 'Paris';
+      expect(component.filteredTrips.length).toBe(1);
+      expect(component.filteredTrips[0].departureAddress).toBe('Paris');
+    });
+
+    it('should filter by search query on destination', () => {
+      component.searchQuery = 'Lyon';
+      expect(component.filteredTrips.length).toBe(1);
+      expect(component.filteredTrips[0].destination).toBe('Lyon');
+    });
+
+    it('should combine status filter and search query', () => {
+      component.setFilter('ACTIVE');
+      component.searchQuery = 'Lille';
+      expect(component.filteredTrips.length).toBe(1);
+      expect(component.filteredTrips[0].id).toBe(4);
+    });
+
+    it('should reset current page when filter changes', () => {
+      component.currentPage = 2;
+      component.setFilter('ACTIVE');
+      expect(component.currentPage).toBe(1);
+    });
+
+    it('should reset current page when search changes', () => {
+      component.currentPage = 2;
+      component.onSearchChange();
+      expect(component.currentPage).toBe(1);
+    });
+  });
+
+  describe('Pagination', () => {
+    it('should paginate results with default 5 items per page', () => {
+      expect(component.itemsPerPage).toBe(5);
+      expect(component.paginatedTrips.length).toBe(5);
+      expect(component.totalPages).toBe(2);
+    });
+
+    it('should navigate to the next page', () => {
+      component.goToPage(2);
+      expect(component.currentPage).toBe(2);
+      expect(component.paginatedTrips.length).toBe(1);
+    });
+
+    it('should not navigate below page 1', () => {
+      component.goToPage(0);
+      expect(component.currentPage).toBe(1);
+    });
+
+    it('should not navigate above total pages', () => {
+      component.goToPage(999);
+      expect(component.currentPage).toBe(1);
+    });
+
+    it('should generate correct page numbers', () => {
+      expect(component.pageNumbers).toEqual([1, 2]);
+    });
+  });
+
+  describe('Pending booking count', () => {
+    it('should return the count of PENDING bookings for a trip', () => {
+      expect(component.pendingBookingCount(1)).toBe(1);
+    });
+
+    it('should return 0 for a trip with no bookings mapping', () => {
+      component.tripBookingsMap = {};
+      expect(component.pendingBookingCount(999)).toBe(0);
+    });
+  });
+
+  describe('Status display helpers', () => {
+    it('should return correct label for ACTIVE', () => {
+      expect(component.tripStatusLabel('ACTIVE')).toBe('Actif');
+    });
+
+    it('should return correct label for COMPLETED', () => {
+      expect(component.tripStatusLabel('COMPLETED')).toBe('Terminé');
+    });
+
+    it('should return correct label for CANCELLED', () => {
+      expect(component.tripStatusLabel('CANCELLED')).toBe('Annulé');
+    });
+
+    it('should return correct dot class for each status', () => {
+      expect(component.tripStatusDotClass('ACTIVE')).toBe('bg-success');
+      expect(component.tripStatusDotClass('COMPLETED')).toBe('bg-text-muted');
+      expect(component.tripStatusDotClass('CANCELLED')).toBe('bg-error');
+    });
+
+    it('should return correct text class for each status', () => {
+      expect(component.tripStatusTextClass('ACTIVE')).toBe('text-success');
+      expect(component.tripStatusTextClass('COMPLETED')).toBe('text-text-muted');
+      expect(component.tripStatusTextClass('CANCELLED')).toBe('text-error');
+    });
+  });
+
+  describe('Date formatting', () => {
+    it('should format a date string correctly', () => {
+      const result = component.formatTripDate('2024-03-15T10:00:00');
+      expect(result).toBe('15 Mars 2024 • 10:00');
+    });
+  });
+
+  describe('Trip completion', () => {
+    it('should call completeTrip on the service', () => {
+      component.markTripCompleted(1);
+      expect(tripServiceSpy.completeTrip).toHaveBeenCalledWith(1);
+    });
+
+    it('should update the trip status after completion', () => {
+      component.markTripCompleted(1);
+      expect(component.trips[0].status).toBe('COMPLETED');
+      expect(component.completingTripId).toBeNull();
+    });
+
+    it('should not call completeTrip if one is already in progress', () => {
+      component.completingTripId = 99;
+      component.markTripCompleted(1);
+      expect(tripServiceSpy.completeTrip).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle trip loading error', () => {
+      tripServiceSpy.getMyTrips.and.returnValue(throwError(() => new Error('fail')));
+      component.loadTrips();
+      expect(component.loadError).toBe('Impossible de charger vos trajets.');
+      expect(component.isLoading).toBeFalse();
+    });
+  });
+});

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.ts
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.ts
@@ -1,0 +1,258 @@
+import { ChangeDetectorRef, Component, ElementRef, ViewChild, inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import * as htmlToImage from 'html-to-image';
+import { TripService } from '../../services/trip.service';
+import { AuthService } from '../../services/auth.service';
+import { Trip } from '../../models/trip.model';
+import { BookingResponse } from '../../models/booking.model';
+import { ShareCardData } from '../../models/share-card.model';
+import { ShareCardMapperService } from '../../services/share-card-mapper.service';
+import { ShareCardStoryComponent } from '../../components/share-card-story/share-card-story.component';
+import { TripOptionsMenuComponent } from '../../components/dashboard/trip-options-menu/trip-options-menu.component';
+
+/** Status filter tabs for the trip list. */
+export type TripStatusFilter = 'ALL' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED';
+
+@Component({
+  selector: 'app-trips-management-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink, ShareCardStoryComponent, TripOptionsMenuComponent],
+  templateUrl: './trips-management-page.component.html',
+})
+export class TripsManagementPageComponent implements OnInit {
+  private readonly tripService = inject(TripService);
+  private readonly authService = inject(AuthService);
+  private readonly shareCardMapperService = inject(ShareCardMapperService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly router = inject(Router);
+  @ViewChild('shareCardCapture') private shareCardCapture?: ElementRef<HTMLElement>;
+
+  // ── Data ──────────────────────────────────────────────────────────────────
+  trips: Trip[] = [];
+  tripBookingsMap: Record<number, BookingResponse[]> = {};
+  isLoading = false;
+  loadError = '';
+
+  // ── Filters ───────────────────────────────────────────────────────────────
+  activeFilter: TripStatusFilter = 'ALL';
+  searchQuery = '';
+
+  /** Filter tab definitions. */
+  filterTabs: { id: TripStatusFilter; label: string }[] = [
+    { id: 'ALL', label: 'Tous les trajets' },
+    { id: 'ACTIVE', label: 'Actifs' },
+    { id: 'COMPLETED', label: 'Terminés' },
+    { id: 'CANCELLED', label: 'Annulés' },
+  ];
+
+  // ── Pagination ────────────────────────────────────────────────────────────
+  currentPage = 1;
+  itemsPerPage = 5;
+
+  // ── Share card generation ─────────────────────────────────────────────────
+  generatingShareCardTripId: number | null = null;
+  shareCardData: ShareCardData | null = null;
+
+  // ── Trip completion ───────────────────────────────────────────────────────
+  completingTripId: number | null = null;
+
+  ngOnInit(): void {
+    if (!this.authService.isLoggedIn()) {
+      this.router.navigate(['/login']);
+      return;
+    }
+    this.loadTrips();
+  }
+
+  /** Load all trips belonging to the current user along with their bookings. */
+  loadTrips(): void {
+    this.isLoading = true;
+    this.loadError = '';
+    this.tripService.getMyTrips().subscribe({
+      next: (trips) => {
+        this.trips = trips;
+        if (trips.length === 0) {
+          this.isLoading = false;
+          return;
+        }
+        const requests = trips.map((t) =>
+          this.tripService.getTripBookings(t.id).pipe(catchError(() => of([] as BookingResponse[])))
+        );
+        forkJoin(requests).subscribe((results) => {
+          trips.forEach((t, i) => {
+            this.tripBookingsMap[t.id] = results[i] as BookingResponse[];
+          });
+          this.isLoading = false;
+        });
+      },
+      error: () => {
+        this.loadError = 'Impossible de charger vos trajets.';
+        this.isLoading = false;
+      },
+    });
+  }
+
+  // ── Computed filtered & paginated list ────────────────────────────────────
+
+  /** Get trips filtered by status and search query. */
+  get filteredTrips(): Trip[] {
+    let result = this.trips;
+
+    // Filter by status
+    if (this.activeFilter !== 'ALL') {
+      result = result.filter((t) => t.status === this.activeFilter);
+    }
+
+    // Filter by search query
+    if (this.searchQuery.trim()) {
+      const query = this.searchQuery.trim().toLowerCase();
+      result = result.filter(
+        (t) =>
+          t.departureAddress.toLowerCase().includes(query) ||
+          t.destination.toLowerCase().includes(query)
+      );
+    }
+
+    return result;
+  }
+
+  /** Get the paginated subset of filtered trips for the current page. */
+  get paginatedTrips(): Trip[] {
+    const start = (this.currentPage - 1) * this.itemsPerPage;
+    return this.filteredTrips.slice(start, start + this.itemsPerPage);
+  }
+
+  /** Total number of pages based on filtered results. */
+  get totalPages(): number {
+    return Math.max(1, Math.ceil(this.filteredTrips.length / this.itemsPerPage));
+  }
+
+  /** Array of page numbers for the paginator. */
+  get pageNumbers(): number[] {
+    return Array.from({ length: this.totalPages }, (_, i) => i + 1);
+  }
+
+  // ── Filter actions ────────────────────────────────────────────────────────
+
+  setFilter(filter: TripStatusFilter): void {
+    this.activeFilter = filter;
+    this.currentPage = 1;
+  }
+
+  onSearchChange(): void {
+    this.currentPage = 1;
+  }
+
+  goToPage(page: number): void {
+    if (page >= 1 && page <= this.totalPages) {
+      this.currentPage = page;
+    }
+  }
+
+  // ── Trip actions ──────────────────────────────────────────────────────────
+
+  /** Navigate to trip bookings/details. */
+  viewTripDetails(tripId: number): void {
+    void this.router.navigate(['/dashboard'], { queryParams: { tab: 'received', tripId } });
+  }
+
+  /** Navigate to edit a trip. */
+  editTrip(tripId: number): void {
+    void this.router.navigate(['/propose', tripId]);
+  }
+
+  /** Get the number of pending bookings for a given trip. */
+  pendingBookingCount(tripId: number): number {
+    const bookings = this.tripBookingsMap[tripId] ?? [];
+    return bookings.filter((b) => b.status === 'PENDING').length;
+  }
+
+  /** Mark a trip as completed. */
+  markTripCompleted(tripId: number): void {
+    if (this.completingTripId !== null) return;
+    this.completingTripId = tripId;
+    this.tripService.completeTrip(tripId).subscribe({
+      next: (updatedTrip) => {
+        const idx = this.trips.findIndex((t) => t.id === updatedTrip.id);
+        if (idx >= 0) this.trips[idx] = updatedTrip;
+        this.completingTripId = null;
+      },
+      error: () => {
+        this.completingTripId = null;
+      },
+    });
+  }
+
+  /** Download the share card PNG for a trip. */
+  async downloadShareCardPng(tripId: number): Promise<void> {
+    const trip = this.trips.find((t) => t.id === tripId);
+    const user = this.authService.getUser();
+    if (!trip || trip.status !== 'ACTIVE' || !user) return;
+
+    this.shareCardData = this.shareCardMapperService.mapActiveTripToShareCard(trip, user);
+    this.cdr.detectChanges();
+    this.generatingShareCardTripId = tripId;
+
+    try {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+      const captureElement = this.shareCardCapture?.nativeElement;
+      if (!captureElement) throw new Error('Share card capture element missing');
+
+      const pngDataUrl = await htmlToImage.toPng(captureElement, {
+        cacheBust: true,
+        pixelRatio: 2,
+      });
+
+      const downloadLink = document.createElement('a');
+      downloadLink.href = pngDataUrl;
+      downloadLink.download = `colick-carte-partage-${this.shareCardMapperService.buildFileDate(trip.departureTime)}.png`;
+      downloadLink.click();
+    } catch {
+      // Silent fail for PNG generation
+    } finally {
+      this.generatingShareCardTripId = null;
+    }
+  }
+
+  // ── Status display helpers ────────────────────────────────────────────────
+
+  tripStatusLabel(status: Trip['status']): string {
+    return ({ ACTIVE: 'Actif', COMPLETED: 'Terminé', CANCELLED: 'Annulé' } as Record<Trip['status'], string>)[status];
+  }
+
+  tripStatusDotClass(status: Trip['status']): string {
+    return ({
+      ACTIVE: 'bg-success',
+      COMPLETED: 'bg-text-muted',
+      CANCELLED: 'bg-error',
+    } as Record<Trip['status'], string>)[status];
+  }
+
+  tripStatusTextClass(status: Trip['status']): string {
+    return ({
+      ACTIVE: 'text-success',
+      COMPLETED: 'text-text-muted',
+      CANCELLED: 'text-error',
+    } as Record<Trip['status'], string>)[status];
+  }
+
+  /** Format a date string into "DD Mois YYYY • HH:MM". */
+  formatTripDate(dateStr: string): string {
+    const date = new Date(dateStr);
+    const months = [
+      'Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin',
+      'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre',
+    ];
+    const day = date.getDate().toString().padStart(2, '0');
+    const month = months[date.getMonth()];
+    const year = date.getFullYear();
+    const hours = date.getHours().toString().padStart(2, '0');
+    const minutes = date.getMinutes().toString().padStart(2, '0');
+    return `${day} ${month} ${year} • ${hours}:${minutes}`;
+  }
+}

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.ts
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.ts
@@ -227,17 +227,17 @@ export class TripsManagementPageComponent implements OnInit {
 
   tripStatusDotClass(status: Trip['status']): string {
     return ({
-      ACTIVE: 'bg-success',
-      COMPLETED: 'bg-text-muted',
-      CANCELLED: 'bg-error',
+      ACTIVE: 'bg-accent',
+      COMPLETED: 'bg-success',
+      CANCELLED: 'bg-text-muted',
     } as Record<Trip['status'], string>)[status];
   }
 
   tripStatusTextClass(status: Trip['status']): string {
     return ({
-      ACTIVE: 'text-success',
-      COMPLETED: 'text-text-muted',
-      CANCELLED: 'text-error',
+      ACTIVE: 'text-accent',
+      COMPLETED: 'text-success',
+      CANCELLED: 'text-text-muted',
     } as Record<Trip['status'], string>)[status];
   }
 

--- a/front-office/src/app/services/trip.service.spec.ts
+++ b/front-office/src/app/services/trip.service.spec.ts
@@ -119,6 +119,54 @@ describe('TripService', () => {
     });
   });
 
+  it('falls back to maxWeight when availableWeight is missing from the API response', () => {
+    service.getMyTrips().subscribe((trips) => {
+      expect(trips).toHaveSize(1);
+      expect(trips[0].availableWeight).toBe(20);
+    });
+
+    const req = httpMock.expectOne('/api/trips/mine');
+    expect(req.request.method).toBe('GET');
+    req.flush([
+      {
+        id: 12,
+        travelerId: 2,
+        travelerName: 'Alice Martin',
+        departureAddress: 'Paris, France',
+        destination: "Abidjan, Côte d'Ivoire",
+        departureTime: '2025-03-02T08:00:00Z',
+        arrivalTime: '2025-03-02T16:00:00Z',
+        maxWeight: 20,
+        pricePerKilo: 17,
+        instantAcceptance: false,
+        status: 'ACTIVE',
+      },
+    ]);
+  });
+
+  it('uses remainingWeight when the API provides it instead of availableWeight', () => {
+    service.getTripById(12).subscribe((trip) => {
+      expect(trip.availableWeight).toBe(9);
+    });
+
+    const req = httpMock.expectOne('/api/trips/12');
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      id: 12,
+      travelerId: 2,
+      travelerName: 'Alice Martin',
+      departureAddress: 'Paris, France',
+      destination: "Abidjan, Côte d'Ivoire",
+      departureTime: '2025-03-02T08:00:00Z',
+      arrivalTime: '2025-03-02T16:00:00Z',
+      maxWeight: 20,
+      pricePerKilo: 15,
+      instantAcceptance: true,
+      status: 'ACTIVE',
+      remainingWeight: 9,
+    });
+  });
+
   it('calls complete trip endpoint', () => {
     service.completeTrip(12).subscribe();
 

--- a/front-office/src/app/services/trip.service.ts
+++ b/front-office/src/app/services/trip.service.ts
@@ -16,6 +16,10 @@ export class TripService {
   private readonly photoUrlService = inject(PhotoUrlService);
   private readonly baseUrl = '/api/trips';
 
+  private isValidNumber(value?: number | null): value is number {
+    return value !== null && value !== undefined && !Number.isNaN(value);
+  }
+
   /** Search trips by departure and destination locations. */
   searchTrips(departure: string, destination: string): Observable<Trip[]> {
     const params = new HttpParams()
@@ -110,9 +114,23 @@ export class TripService {
     return this.http.put<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/cancel`, {});
   }
 
-  private normalizeTrip(trip: Trip): Trip {
+  private normalizeTrip(
+    trip: Trip & {
+      availableWeight?: number | null;
+      remainingWeight?: number | null;
+    }
+  ): Trip {
+    const normalizedAvailableWeight = this.isValidNumber(trip.availableWeight)
+      ? trip.availableWeight
+      : this.isValidNumber(trip.remainingWeight)
+        ? trip.remainingWeight
+        : this.isValidNumber(trip.maxWeight)
+          ? trip.maxWeight
+          : 0;
+
     return {
       ...trip,
+      availableWeight: normalizedAvailableWeight,
       travelerPhotoUrl: this.photoUrlService.normalizePhotoUrl(trip.travelerPhotoUrl),
       travelerRatingCount: trip.travelerRatingCount ?? 0,
     };


### PR DESCRIPTION
## Summary
- Refonte complète du dashboard des voyages conforme à la maquette
- Refactor the desktop dashboard list for traveler-created trips into reusable standalone components
- Replace direct desktop actions with a plus-options menu containing only `Télécharger la carte PNG` and `Marqué effectué`
- Add unit coverage for the new menu/list components and dashboard interactions

## Validation
- npm run build
- npm test -- --watch=false --browsers=ChromeHeadless
- docker compose build front-office