### PR TITLE
feat(front-office): add dedicated reservation details page (#81)

### DIFF
--- a/.cursor/rules/design-system.mdc
+++ b/.cursor/rules/design-system.mdc
@@ -2,30 +2,71 @@
 alwaysApply: true
 ---
 
-# Design System
-## Brand Colors
-Use these exact colors throughout the application:
-- **Primary**: #023047
-- **Secondary**: #219ebc
-- **Accent**: #fb8500
-- **Error**: #EF4444
-- **Success**: #22C55E
-- **Warning**: #F97316
-## Background Colors
-- **Background Primary**: #f5f5f5
-- **Background Secondary**: #F9FAFB
-- **Background Dark**: #111827
-## Text Colors
-- **Text Primary**: #111827
-- **Text Secondary**: #6B7280
-- **Text Muted**: #9CA3AF
+# Colick
 
-## Font
-- **Font**: Poppins
+## Overview
+An editorial precision interface for a community platform where developers discover, share, and download design system files. The aesthetic is quietly confident — bold display typography, generous spacing, and gallery-frame card surfaces. The mood is professional and modern without being sterile. High information density balanced by breathing room. 
 
-## Usage
-Always use these color variables when:
-- Creating new components
-- Styling UI elements
-- Defining themes
-- Writing CSS/Tailwind classes
+## Colors
+- **Primary** (#023047): CTAs, active states, links, focus rings, interactive highlights — Deep Ocean Blue
+- **Primary Hover** (#4F46E5): Darker Deep Ocean Blue for hover states on primary elements
+- **Secondary** (#219ebc): Reserved exclusively for the DESIGN.md brand highlight on the homepage — green
+- **Neutral** (#9C9C9C): Muted text, placeholders, timestamps, disabled states
+- **Background** (#FAFAFA): Page background, light warm gray
+- **Surface** (#FFFFFF): Cards, panels, modals, nav backdrop
+- **Text Primary** (#0A0A0A): Headings, body text, primary labels — near-black
+- **Text Secondary** (#6B6B6B): Descriptions, metadata, secondary labels
+- **Border** (#E8E8EC): Card borders, dividers, input borders — subtle and recessive
+- **Success** (#10B981): Published status, confirmations, positive indicators
+- **Warning** (#F59E0B): Pending states, caution banners
+- **Error** (#EF4444): Destructive actions, validation errors, rejected status
+
+## Typography
+- **Display Font**: General Sans — loaded from Fontshare
+- **Body Font**: DM Sans — loaded from Google Fonts
+- **Code Font**: JetBrains Mono — loaded from Google Fonts
+
+Display and heading text uses General Sans at bold weight with tight letter spacing (-0.03em to -0.04em). Body and UI text uses DM Sans at regular and medium weights. The contrast between the geometric display font and the humanist body font creates a refined editorial feel. Code blocks, API keys, and CLI commands use JetBrains Mono at regular weight.
+
+Type scale: Display 72px, Headline 60px, Section heading 32px, Subhead 24px, Body 15px, Small 13px, Caption 12px, Overline 11px uppercase.
+
+## Elevation
+This design uses minimal shadows. Cards rest flat with a 1px border and gain a subtle shadow on hover (0 8px 30px rgba(0,0,0,0.08)) combined with a -2px vertical lift. Primary buttons gain a tinted glow shadow on hover (0 4px 12px rgba(99,102,241,0.35)). The nav uses backdrop-blur rather than a shadow to convey elevation. Dropdowns and popovers use shadow-lg. Focus states use a 3px Deep Ocean Blue ring (0 0 0 3px rgba(99,102,241,0.12)) rather than a shadow.
+
+## Components
+- **Buttons**: Primary uses Deep Ocean Blue fill with white text, 6px radius, medium weight. Secondary uses transparent bg with 1px border, same radius. Ghost has no border or bg, just text color change on hover. Destructive uses red text with red border. All buttons shift up 1px on hover. Sizes: small (32px), medium (38px), large (44px).
+- **Cards**: White surface, 1px subtle border, 12px radius, overflow hidden. Kit preview cards have a 200px image area on top and a content area below with name, author avatar, and stats. Hover lifts the card 2px and increases shadow. Transition duration 200ms.
+- **Inputs**: 1px subtle border, surface background, 6px radius, 10px vertical and 14px horizontal padding, 14px font size. Focus: border turns Deep Ocean Blue with a 3px rgba ring. Error: border turns red. Placeholder text uses muted color.
+- **Chips**: Tag chips use rounded-full (pill shape), gray-100 background, gray-600 text, 4px vertical and 12px horizontal padding, 12px font size. Active state: Deep Ocean Blue background with white text. Status chips follow the same shape but use semantic colors (green for published, yellow for pending, red for rejected).
+- **Lists**: Stacked rows with 1px dividers between items. Each row is flex with space-between, 12px vertical and 16px horizontal padding. Hover: subtle background change.
+- **Checkboxes**: 20px size, rounded-full, gray-200 unchecked, Deep Ocean Blue checked with white checkmark. Used as toggle switches for preferences.
+- **Tooltips**: Native browser tooltips via title attributes. No custom tooltip component currently.
+- **Navigation**: Sticky top nav with backdrop-blur, 56px height, 1px bottom border. Logo left, links center (desktop) or hamburger drawer (mobile), user avatar dropdown right. Nav links: 14px medium weight, hover shows bg-alt background.
+- **Search**: Global search triggered by ⌘K. Rendered as a rounded-xl bar with magnifying glass icon and keyboard shortcut badge.
+
+## Spacing
+- Base unit: 4px
+- Scale: 4, 8, 12, 16, 20, 24, 32, 40, 48, 64, 80, 96px
+- Component padding: small 8×12, medium 10×16, large 12×24
+- Section spacing: 32px mobile, 48px tablet, 64px desktop
+- Container max width: 1280px with 24px horizontal padding
+- Card grid gap: 20-24px
+
+## Border Radius
+- 4px: Tags, chips, badges, inline code
+- 6px: Buttons, inputs, selects
+- 8px: Metadata cards, dropdowns, panels
+- 12px: Kit preview cards, search bar, featured sections
+- 9999px: Avatars, status dots, pill badges
+
+## Do's and Don'ts
+- Do use Deep Ocean Blue (#023047) only for interactive elements — never for decoration or static text
+- Do maintain the 4px spacing grid for all padding, margins, and gaps
+- Do use General Sans for headings and DM Sans for body — never swap them
+- Do keep kit cards at 12px radius and buttons/inputs at 6px — don't mix these values
+- Do provide sufficient contrast in both light and dark modes — test both
+- Don't use pure black (#000000) or pure white (#FFFFFF) for text — use the defined palette values
+- Don't add decorative gradients or illustrations — the interactive dot grid is the only decorative element
+- Don't use shadows on static elements — reserve shadow elevation for hover and focus states
+- Don't use more than two font weights on a single screen
+- Don't place more than one primary (filled Deep Ocean Blue) button in the same view section

--- a/.github/agents/ui-design.agent.md
+++ b/.github/agents/ui-design.agent.md
@@ -11,24 +11,7 @@ You are a UI/UX design expert specializing in high-quality Angular + Tailwind CS
 
 ## Colick Design System (mandatory)
 
-Always use these exact colors — never substitute with raw Tailwind defaults:
-
-| Token              | Hex       | Usage                              |
-|--------------------|-----------|------------------------------------|
-| `primary`          | `#023047` | Headers, primary buttons, nav      |
-| `secondary`        | `#219ebc` | Links, hover states, accents       |
-| `accent`           | `#fb8500` | CTAs, highlights, badges           |
-| `error`            | `#EF4444` | Error states                       |
-| `success`          | `#22C55E` | Success states                     |
-| `warning`          | `#F97316` | Warnings                           |
-| `background-primary`   | `#f5f5f5` | Default page background        |
-| `background-secondary` | `#F9FAFB` | Cards, sections                |
-| `background-dark`      | `#111827` | Dark sections, footers         |
-| `text-primary`     | `#111827` | Body text                          |
-| `text-secondary`   | `#6B7280` | Subtitles, labels                  |
-| `text-muted`       | `#9CA3AF` | Placeholders, captions             |
-
-**Font**: Poppins — apply `font-['Poppins']` or via Tailwind `fontFamily` config.
+use design instructions from .github/instructions/design-system.instructions.md
 
 ## Approach
 1. Think about the best visual representation of the component before writing code.

--- a/.github/instructions/design-system.instructions.md
+++ b/.github/instructions/design-system.instructions.md
@@ -3,67 +3,72 @@ description: "Use when creating components, styling UI elements, writing CSS/Tai
 applyTo: "front-office/src/**"
 ---
 
-# Colick Design System
 
-## Brand Colors
+# Colick
 
-| Role      | Hex       | Tailwind Custom / Usage          |
-|-----------|-----------|----------------------------------|
-| Primary   | `#023047` | Dark navy — headers, buttons     |
-| Secondary | `#219ebc` | Teal — links, accents            |
-| Accent    | `#fb8500` | Orange — CTAs, highlights        |
-| Error     | `#EF4444` | Red — error states               |
-| Success   | `#22C55E` | Green — success states           |
-| Warning   | `#F97316` | Orange — warnings                |
+## Overview
+An editorial precision interface for a community platform where developers discover, share, and download design system files. The aesthetic is quietly confident — bold display typography, generous spacing, and gallery-frame card surfaces. The mood is professional and modern without being sterile. High information density balanced by breathing room. 
 
-## Background Colors
-
-| Role                | Hex       |
-|---------------------|-----------|
-| Background Primary  | `#f5f5f5` |
-| Background Secondary| `#F9FAFB` |
-| Background Dark     | `#111827` |
-
-## Text Colors
-
-| Role           | Hex       |
-|----------------|-----------|
-| Text Primary   | `#111827` |
-| Text Secondary | `#6B7280` |
-| Text Muted     | `#9CA3AF` |
+## Colors
+- **Primary** (#023047): CTAs, active states, links, focus rings, interactive highlights — Deep Ocean Blue
+- **Primary Hover** (#4F46E5): Darker Deep Ocean Blue for hover states on primary elements
+- **Secondary** (#219ebc): Reserved exclusively for the DESIGN.md brand highlight on the homepage — green
+- **Neutral** (#9C9C9C): Muted text, placeholders, timestamps, disabled states
+- **Background** (#FAFAFA): Page background, light warm gray
+- **Surface** (#FFFFFF): Cards, panels, modals, nav backdrop
+- **Text Primary** (#0A0A0A): Headings, body text, primary labels — near-black
+- **Text Secondary** (#6B6B6B): Descriptions, metadata, secondary labels
+- **Border** (#E8E8EC): Card borders, dividers, input borders — subtle and recessive
+- **Success** (#10B981): Published status, confirmations, positive indicators
+- **Warning** (#F59E0B): Pending states, caution banners
+- **Error** (#EF4444): Destructive actions, validation errors, rejected status
 
 ## Typography
+- **Display Font**: General Sans — loaded from Fontshare
+- **Body Font**: DM Sans — loaded from Google Fonts
+- **Code Font**: JetBrains Mono — loaded from Google Fonts
 
-- **Font**: Poppins — must be applied globally and on all components.
+Display and heading text uses General Sans at bold weight with tight letter spacing (-0.03em to -0.04em). Body and UI text uses DM Sans at regular and medium weights. The contrast between the geometric display font and the humanist body font creates a refined editorial feel. Code blocks, API keys, and CLI commands use JetBrains Mono at regular weight.
 
-## Rules
+Type scale: Display 72px, Headline 60px, Section heading 32px, Subhead 24px, Body 15px, Small 13px, Caption 12px, Overline 11px uppercase.
 
-- Always use the exact hex values above. Do not substitute with default Tailwind palette equivalents (e.g., do not use `blue-900` instead of `#023047`).
-- Configure these colors in `tailwind.config.js` under `theme.extend.colors` and reference them by name (e.g., `bg-primary`, `text-secondary`).
-- Never hardcode raw hex values inline in templates; always reference the named Tailwind token.
-- Apply `font-['Poppins']` or configure Poppins as the default sans-serif in Tailwind config.
-- Use `bg-background-dark` (`#111827`) for dark sections, never plain `bg-black`.
+## Elevation
+This design uses minimal shadows. Cards rest flat with a 1px border and gain a subtle shadow on hover (0 8px 30px rgba(0,0,0,0.08)) combined with a -2px vertical lift. Primary buttons gain a tinted glow shadow on hover (0 4px 12px rgba(99,102,241,0.35)). The nav uses backdrop-blur rather than a shadow to convey elevation. Dropdowns and popovers use shadow-lg. Focus states use a 3px Deep Ocean Blue ring (0 0 0 3px rgba(99,102,241,0.12)) rather than a shadow.
 
-## Tailwind Config Reference
+## Components
+- **Buttons**: Primary uses Deep Ocean Blue fill with white text, 6px radius, medium weight. Secondary uses transparent bg with 1px border, same radius. Ghost has no border or bg, just text color change on hover. Destructive uses red text with red border. All buttons shift up 1px on hover. Sizes: small (32px), medium (38px), large (44px).
+- **Cards**: White surface, 1px subtle border, 12px radius, overflow hidden. Kit preview cards have a 200px image area on top and a content area below with name, author avatar, and stats. Hover lifts the card 2px and increases shadow. Transition duration 200ms.
+- **Inputs**: 1px subtle border, surface background, 6px radius, 10px vertical and 14px horizontal padding, 14px font size. Focus: border turns Deep Ocean Blue with a 3px rgba ring. Error: border turns red. Placeholder text uses muted color.
+- **Chips**: Tag chips use rounded-full (pill shape), gray-100 background, gray-600 text, 4px vertical and 12px horizontal padding, 12px font size. Active state: Deep Ocean Blue background with white text. Status chips follow the same shape but use semantic colors (green for published, yellow for pending, red for rejected).
+- **Lists**: Stacked rows with 1px dividers between items. Each row is flex with space-between, 12px vertical and 16px horizontal padding. Hover: subtle background change.
+- **Checkboxes**: 20px size, rounded-full, gray-200 unchecked, Deep Ocean Blue checked with white checkmark. Used as toggle switches for preferences.
+- **Tooltips**: Native browser tooltips via title attributes. No custom tooltip component currently.
+- **Navigation**: Sticky top nav with backdrop-blur, 56px height, 1px bottom border. Logo left, links center (desktop) or hamburger drawer (mobile), user avatar dropdown right. Nav links: 14px medium weight, hover shows bg-alt background.
+- **Search**: Global search triggered by ⌘K. Rendered as a rounded-xl bar with magnifying glass icon and keyboard shortcut badge.
 
-```js
-// tailwind.config.js — extend colors with these tokens
-colors: {
-  primary:    '#023047',
-  secondary:  '#219ebc',
-  accent:     '#fb8500',
-  error:      '#EF4444',
-  success:    '#22C55E',
-  warning:    '#F97316',
-  background: {
-    primary:   '#f5f5f5',
-    secondary: '#F9FAFB',
-    dark:      '#111827',
-  },
-  text: {
-    primary:   '#111827',
-    secondary: '#6B7280',
-    muted:     '#9CA3AF',
-  },
-}
-```
+## Spacing
+- Base unit: 4px
+- Scale: 4, 8, 12, 16, 20, 24, 32, 40, 48, 64, 80, 96px
+- Component padding: small 8×12, medium 10×16, large 12×24
+- Section spacing: 32px mobile, 48px tablet, 64px desktop
+- Container max width: 1280px with 24px horizontal padding
+- Card grid gap: 20-24px
+
+## Border Radius
+- 4px: Tags, chips, badges, inline code
+- 6px: Buttons, inputs, selects
+- 8px: Metadata cards, dropdowns, panels
+- 12px: Kit preview cards, search bar, featured sections
+- 9999px: Avatars, status dots, pill badges
+
+## Do's and Don'ts
+- Do use Deep Ocean Blue (#023047) only for interactive elements — never for decoration or static text
+- Do maintain the 4px spacing grid for all padding, margins, and gaps
+- Do use General Sans for headings and DM Sans for body — never swap them
+- Do keep kit cards at 12px radius and buttons/inputs at 6px — don't mix these values
+- Do provide sufficient contrast in both light and dark modes — test both
+- Don't use pure black (#000000) or pure white (#FFFFFF) for text — use the defined palette values
+- Don't add decorative gradients or illustrations — the interactive dot grid is the only decorative element
+- Don't use shadows on static elements — reserve shadow elevation for hover and focus states
+- Don't use more than two font weights on a single screen
+- Don't place more than one primary (filled Deep Ocean Blue) button in the same view section

--- a/back-office/src/main/java/com/colick/backoffice/exception/GlobalExceptionHandler.java
+++ b/back-office/src/main/java/com/colick/backoffice/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -98,9 +99,16 @@ public class GlobalExceptionHandler {
                 .body(new ApiError(HttpStatus.BAD_REQUEST.value(), message));
     }
 
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiError> handleNoResourceFound(NoResourceFoundException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ApiError(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
+    }
+
     /**
-     * Handles Spring MVC exceptions (NoResourceFoundException, MethodNotAllowedException, etc.)
-     * and returns the correct HTTP status code instead of masking them as 500.
+     * Handles Spring MVC exceptions that already carry an HTTP status and
+     * returns that status instead of masking them as 500.
      */
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<ApiError> handleResponseStatus(ResponseStatusException ex) {

--- a/back-office/src/main/java/com/colick/backoffice/file/FileStorageService.java
+++ b/back-office/src/main/java/com/colick/backoffice/file/FileStorageService.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 @Service
 public class FileStorageService {
 
+    private static final String PUBLIC_UPLOAD_PREFIX = "/uploads/";
     @Value("${upload.dir:./uploads}")
     private String uploadDir;
 
@@ -41,9 +42,54 @@ public class FileStorageService {
             String filename = UUID.randomUUID() + ext;
             Path target = dir.resolve(filename);
             Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
-            return "/uploads/" + filename;
+            return PUBLIC_UPLOAD_PREFIX + filename;
         } catch (IOException e) {
             throw new RuntimeException("Failed to store file", e);
         }
+    }
+
+    /**
+     * Returns the given public upload URL only when it points to an existing
+     * local file. Unknown or external URLs are returned as-is.
+     */
+    public String sanitizePublicUrl(String publicUrl) {
+        String sanitizedUrl = publicUrl == null ? null : publicUrl.trim();
+        if (sanitizedUrl == null || sanitizedUrl.isBlank()) {
+            return null;
+        }
+
+        if (!isManagedUploadUrl(sanitizedUrl)) {
+            return sanitizedUrl;
+        }
+
+        Path filePath = resolveManagedUploadPath(sanitizedUrl);
+        return filePath != null && Files.isRegularFile(filePath)
+                ? toPublicUploadUrl(filePath.getFileName().toString())
+                : null;
+    }
+
+    private boolean isManagedUploadUrl(String publicUrl) {
+        return publicUrl.startsWith(PUBLIC_UPLOAD_PREFIX) || publicUrl.startsWith("uploads/");
+    }
+
+    private Path resolveManagedUploadPath(String publicUrl) {
+        String relativePath = publicUrl.startsWith(PUBLIC_UPLOAD_PREFIX)
+                ? publicUrl.substring(PUBLIC_UPLOAD_PREFIX.length())
+                : publicUrl.substring("uploads/".length());
+        if (relativePath.isBlank()) {
+            return null;
+        }
+
+        Path uploadPath = Paths.get(uploadDir).toAbsolutePath().normalize();
+        Path resolvedPath = uploadPath.resolve(relativePath).normalize();
+        if (!resolvedPath.startsWith(uploadPath)) {
+            return null;
+        }
+
+        return resolvedPath;
+    }
+
+    private String toPublicUploadUrl(String filename) {
+        return PUBLIC_UPLOAD_PREFIX + filename;
     }
 }

--- a/back-office/src/main/java/com/colick/backoffice/trip/dto/TripBookingResponse.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/dto/TripBookingResponse.java
@@ -18,6 +18,7 @@ public class TripBookingResponse {
     private Long tripId;
     private Long senderId;
     private String senderName;
+    private String senderPhotoUrl;
     private String title;
     private BigDecimal weight;
     private String description;
@@ -41,6 +42,7 @@ public class TripBookingResponse {
                 .tripId(booking.getTrip().getId())
                 .senderId(booking.getSender().getId())
                 .senderName(booking.getSender().getFirstName() + " " + booking.getSender().getLastName())
+                .senderPhotoUrl(booking.getSender().getPhotoUrl())
                 .title(booking.getTitle())
                 .weight(booking.getWeight())
                 .description(booking.getDescription())

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
@@ -7,6 +7,7 @@ import com.colick.backoffice.exception.ResourceNotFoundException;
 import com.colick.backoffice.exception.TripBookingConflictException;
 import com.colick.backoffice.exception.TripUpdateNotAllowedException;
 import com.colick.backoffice.exception.ValidationCodeDeliveryException;
+import com.colick.backoffice.file.FileStorageService;
 import com.colick.backoffice.i18n.LocalizedMessages;
 import com.colick.backoffice.location.entity.LocationType;
 import com.colick.backoffice.location.repository.LocationRepository;
@@ -39,14 +40,16 @@ public class TripServiceImpl implements TripService {
     private final BookingValidationService bookingValidationService;
     private final TravelerReviewService travelerReviewService;
     private final LocalizedMessages localizedMessages;
+    private final FileStorageService fileStorageService;
 
     public TripServiceImpl(TripRepository tripRepository,
                            TripBookingRepository bookingRepository,
-                           EmailService emailService,
-                           LocationRepository locationRepository,
-                           BookingValidationService bookingValidationService,
-                           TravelerReviewService travelerReviewService,
-                           LocalizedMessages localizedMessages) {
+                            EmailService emailService,
+                            LocationRepository locationRepository,
+                            BookingValidationService bookingValidationService,
+                            TravelerReviewService travelerReviewService,
+                            LocalizedMessages localizedMessages,
+                            FileStorageService fileStorageService) {
         this.tripRepository = tripRepository;
         this.bookingRepository = bookingRepository;
         this.emailService = emailService;
@@ -54,6 +57,7 @@ public class TripServiceImpl implements TripService {
         this.bookingValidationService = bookingValidationService;
         this.travelerReviewService = travelerReviewService;
         this.localizedMessages = localizedMessages;
+        this.fileStorageService = fileStorageService;
     }
 
     @Override
@@ -157,7 +161,7 @@ public class TripServiceImpl implements TripService {
         assertTripOwner(trip, requester);
         return bookingRepository.findByTrip(trip).stream()
                 .filter(booking -> booking.getStatus() != TripBooking.BookingStatus.REMOVED)
-                .map(TripBookingResponse::from)
+                .map(this::toTripBookingResponse)
                 .toList();
     }
 
@@ -215,7 +219,7 @@ public class TripServiceImpl implements TripService {
             trip.getDestination()
         );
 
-        return TripBookingResponse.from(saved);
+        return toTripBookingResponse(saved);
     }
 
     @Override
@@ -227,7 +231,7 @@ public class TripServiceImpl implements TripService {
         }
 
         if (booking.getStatus() == TripBooking.BookingStatus.ACCEPTED) {
-            return TripBookingResponse.from(booking);
+            return toTripBookingResponse(booking);
         }
         if (booking.getStatus() != TripBooking.BookingStatus.PENDING) {
             throw new ConflictException(localizedMessages.get("error.trip.onlyPendingBookingsAcceptable"));
@@ -244,7 +248,7 @@ public class TripServiceImpl implements TripService {
             booking.getTrip().getDestination()
         );
 
-        return TripBookingResponse.from(saved);
+        return toTripBookingResponse(saved);
     }
 
     @Override
@@ -256,7 +260,7 @@ public class TripServiceImpl implements TripService {
         assertTripOwner(booking.getTrip(), requester);
 
         if (booking.getStatus() == TripBooking.BookingStatus.DELIVERED) {
-            return TripBookingResponse.from(booking);
+            return toTripBookingResponse(booking);
         }
         if (booking.getTrip().getStatus() != Trip.TripStatus.COMPLETED) {
             throw new ConflictException(localizedMessages.get("error.trip.completedRequiredForDelivery"));
@@ -274,7 +278,7 @@ public class TripServiceImpl implements TripService {
         booking.setStatus(TripBooking.BookingStatus.DELIVERED);
         booking.setDeliveredAt(LocalDateTime.now());
         bookingValidationService.invalidateValidationCode(booking);
-        return TripBookingResponse.from(bookingRepository.save(booking));
+        return toTripBookingResponse(bookingRepository.save(booking));
     }
 
     @Override
@@ -286,7 +290,7 @@ public class TripServiceImpl implements TripService {
         }
 
         if (booking.getStatus() == TripBooking.BookingStatus.REJECTED) {
-            return TripBookingResponse.from(booking);
+            return toTripBookingResponse(booking);
         }
         if (booking.getStatus() != TripBooking.BookingStatus.PENDING) {
             throw new ConflictException(localizedMessages.get("error.trip.onlyPendingBookingsRejectable"));
@@ -303,7 +307,7 @@ public class TripServiceImpl implements TripService {
             booking.getTrip().getDestination()
         );
 
-        return TripBookingResponse.from(saved);
+        return toTripBookingResponse(saved);
     }
 
     @Override
@@ -354,7 +358,7 @@ public class TripServiceImpl implements TripService {
                 booking.getTrip().getDepartureAddress(),
                 booking.getTrip().getDestination());
 
-        return TripBookingResponse.from(saved);
+        return toTripBookingResponse(saved);
     }
 
     private Trip findTripOrThrow(Long id) {
@@ -469,7 +473,7 @@ public class TripServiceImpl implements TripService {
     @Transactional(readOnly = true)
     public List<TripBookingResponse> getMyBookings(User user) {
         return bookingRepository.findBySender(user).stream()
-                .map(TripBookingResponse::from)
+                .map(this::toTripBookingResponse)
                 .toList();
     }
 
@@ -511,11 +515,20 @@ public class TripServiceImpl implements TripService {
                                         BigDecimal availableWeight,
                                         Map<Long, TravelerRatingSummary> travelerRatingSummaries) {
         TravelerRatingSummary summary = travelerRatingSummaries.get(trip.getTraveler().getId());
-        return TripResponse.from(
+        TripResponse response = TripResponse.from(
                 trip,
                 availableWeight,
                 summary != null ? summary.averageRating() : null,
                 summary != null ? summary.reviewCount() : 0L
         );
+        response.setTravelerPhotoUrl(fileStorageService.sanitizePublicUrl(response.getTravelerPhotoUrl()));
+        return response;
+    }
+
+    private TripBookingResponse toTripBookingResponse(TripBooking booking) {
+        TripBookingResponse response = TripBookingResponse.from(booking);
+        response.setSenderPhotoUrl(fileStorageService.sanitizePublicUrl(response.getSenderPhotoUrl()));
+        response.setPackagePhotoUrl(fileStorageService.sanitizePublicUrl(response.getPackagePhotoUrl()));
+        return response;
     }
 }

--- a/back-office/src/test/java/com/colick/backoffice/exception/GlobalExceptionHandlerTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/exception/GlobalExceptionHandlerTest.java
@@ -4,8 +4,10 @@ import com.colick.backoffice.support.TestLocalizedMessages;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.Locale;
 
@@ -55,5 +57,17 @@ class GlobalExceptionHandlerTest {
         assertNotNull(response.getBody());
         assertEquals(400, response.getBody().getStatus());
         assertEquals("Requested weight exceeds available weight", response.getBody().getMessage());
+    }
+
+    @Test
+    void handleNoResourceFound_shouldReturn404InsteadOf500() {
+        NoResourceFoundException ex = new NoResourceFoundException(HttpMethod.GET, "/uploads/missing.png");
+
+        ResponseEntity<ApiError> response = handler.handleNoResourceFound(ex);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(404, response.getBody().getStatus());
+        assertTrue(response.getBody().getMessage().contains("/uploads/missing.png"));
     }
 }

--- a/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
@@ -7,6 +7,7 @@ import com.colick.backoffice.exception.ResourceNotFoundException;
 import com.colick.backoffice.exception.TripBookingConflictException;
 import com.colick.backoffice.exception.TripUpdateNotAllowedException;
 import com.colick.backoffice.exception.ValidationCodeDeliveryException;
+import com.colick.backoffice.file.FileStorageService;
 import com.colick.backoffice.i18n.LocalizedMessages;
 import com.colick.backoffice.location.entity.LocationType;
 import com.colick.backoffice.location.repository.LocationRepository;
@@ -43,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -65,6 +67,9 @@ class TripServiceImplTest {
 
     @Mock
     private TravelerReviewService travelerReviewService;
+
+    @Mock
+    private FileStorageService fileStorageService;
 
     @Spy
     private LocalizedMessages localizedMessages = TestLocalizedMessages.create();
@@ -92,6 +97,7 @@ class TripServiceImplTest {
                 .firstName("Bob")
                 .lastName("Martin")
                 .email("bob@example.com")
+                .photoUrl("/uploads/bob.png")
                 .role(User.Role.USER)
                 .build();
 
@@ -112,6 +118,8 @@ class TripServiceImplTest {
                 .thenAnswer(invocation -> invocation.getArgument(0));
         lenient().when(travelerReviewService.getTravelerRatingSummaries(anyCollection()))
                 .thenReturn(Map.of());
+        lenient().when(fileStorageService.sanitizePublicUrl(nullable(String.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test
@@ -300,6 +308,26 @@ class TripServiceImplTest {
 
         assertThat(bookings).hasSize(1);
         assertThat(bookings.get(0).getId()).isEqualTo(1L);
+        assertThat(bookings.get(0).getSenderPhotoUrl()).isEqualTo("/uploads/bob.png");
+    }
+
+    @Test
+    void getBookings_shouldHideBrokenUploadUrls() {
+        TripBooking pending = TripBooking.builder()
+                .id(1L).trip(sampleTrip).sender(sender)
+                .packagePhotoUrl("/uploads/package.png")
+                .status(TripBooking.BookingStatus.PENDING).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findByTrip(sampleTrip)).thenReturn(List.of(pending));
+        when(fileStorageService.sanitizePublicUrl("/uploads/bob.png")).thenReturn(null);
+        when(fileStorageService.sanitizePublicUrl("/uploads/package.png")).thenReturn(null);
+
+        List<TripBookingResponse> bookings = tripService.getBookings(10L, traveler);
+
+        assertThat(bookings).hasSize(1);
+        assertThat(bookings.get(0).getSenderPhotoUrl()).isNull();
+        assertThat(bookings.get(0).getPackagePhotoUrl()).isNull();
     }
 
     @Test

--- a/front-office/src/app/app.component.html
+++ b/front-office/src/app/app.component.html
@@ -1,18 +1,22 @@
-<!-- Skip link for accessibility -->
-<a
-  href="#main"
-  class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-accent text-white px-4 py-2 rounded-lg z-50 font-medium"
->
-  Aller au contenu principal
-</a>
+@if (showSharedChrome) {
+  <!-- Skip link for accessibility -->
+  <a
+    href="#main"
+    class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-accent text-white px-4 py-2 rounded-lg z-50 font-medium"
+  >
+    Aller au contenu principal
+  </a>
 
-<!-- Header Navigation -->
-<app-header />
+  <!-- Header Navigation -->
+  <app-header />
+}
 
 <!-- Main Content -->
 <main id="main">
   <router-outlet />
 </main>
 
-<!-- Footer -->
-<app-footer />
+@if (showSharedChrome) {
+  <!-- Footer -->
+  <app-footer />
+}

--- a/front-office/src/app/app.component.ts
+++ b/front-office/src/app/app.component.ts
@@ -1,7 +1,8 @@
-import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { Component, inject } from '@angular/core';
+import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
+import { filter } from 'rxjs';
 
 /**
  * AppComponent - Root component for the Colick front-office application.
@@ -15,8 +16,23 @@ import { FooterComponent } from './components/footer/footer.component';
   styleUrl: './app.component.css',
 })
 export class AppComponent {
+  private readonly router = inject(Router);
   /**
    * Application title
    */
   title = 'Colick - Envoyez vos colis avec des voyageurs de confiance';
+  showSharedChrome = true;
+
+  constructor() {
+    this.updateSharedChrome(this.router.url);
+    this.router.events
+      .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
+      .subscribe((event) => {
+        this.updateSharedChrome(event.urlAfterRedirects);
+      });
+  }
+
+  private updateSharedChrome(url: string): void {
+    this.showSharedChrome = !/^\/trips\/\d+\/reservations(?:[/?#]|$)/.test(url);
+  }
 }

--- a/front-office/src/app/app.routes.ts
+++ b/front-office/src/app/app.routes.ts
@@ -98,6 +98,14 @@ export const routes: Routes = [
       ),
   },
   {
+    path: 'trips/:tripId/reservations',
+    canActivate: [authGuard],
+    loadComponent: () =>
+      import('./pages/reservation-details/reservation-details-page.component').then(
+        (m) => m.ReservationDetailsPageComponent
+      ),
+  },
+  {
     path: 'trips',
     canActivate: [authGuard],
     loadComponent: () =>

--- a/front-office/src/app/components/hero/hero.component.html
+++ b/front-office/src/app/components/hero/hero.component.html
@@ -21,14 +21,31 @@
 
         <!-- CTA Buttons -->
         <div class="flex flex-col sm:flex-row gap-4">
-          <a routerLink="/search" class="inline-flex items-center justify-center bg-accent text-white font-bold px-8 py-4 rounded-full hover:bg-opacity-90 transition shadow-xl shadow-accent/40 text-lg">
-            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <!-- Primary CTA: solid accent fill on all sizes; lighter, tighter presentation on desktop -->
+          <a routerLink="/search"
+             class="inline-flex items-center justify-center rounded-full transition
+                    bg-accent text-white font-bold
+                    px-8 py-4 text-lg shadow-xl shadow-accent/40
+                    hover:bg-opacity-90
+                    lg:px-6 lg:py-2.5 lg:text-sm lg:font-semibold lg:shadow-md lg:shadow-accent/20
+                    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-transparent">
+            <svg class="w-5 h-5 mr-2 lg:w-4 lg:h-4 lg:mr-1.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>
             Rechercher un voyage
           </a>
-          <a routerLink="/propose" class="inline-flex items-center justify-center bg-white text-primary font-bold px-8 py-4 rounded-full hover:bg-opacity-90 transition shadow-xl text-lg">
-            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+
+          <!-- Secondary CTA: solid white on mobile → ghost outline on desktop for clear hierarchy -->
+          <a routerLink="/propose"
+             class="inline-flex items-center justify-center rounded-full transition
+                    bg-white text-primary font-bold shadow-xl
+                    px-8 py-4 text-lg
+                    hover:bg-opacity-90
+                    lg:bg-transparent lg:text-white lg:font-medium lg:border lg:border-white/60
+                    lg:px-6 lg:py-2.5 lg:text-sm lg:shadow-none
+                    lg:hover:bg-white/10
+                    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-1 focus-visible:ring-offset-transparent">
+            <svg class="w-5 h-5 mr-2 lg:w-4 lg:h-4 lg:mr-1.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
             </svg>
             Proposer un voyage

--- a/front-office/src/app/components/hero/hero.component.html
+++ b/front-office/src/app/components/hero/hero.component.html
@@ -4,11 +4,6 @@
     <div class="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
       <!-- Left Content -->
       <div class="text-white">
-        <!-- Badge -->
-        <span class="inline-block bg-white/20 text-white text-sm font-medium px-4 py-1.5 rounded-full mb-6">
-          Nouveau : Réservation instantanée disponible
-        </span>
-
         <!-- Title -->
         <h1 id="hero-title" class="text-4xl sm:text-5xl lg:text-6xl font-extrabold leading-tight mb-6">
           Envoyez vos colis avec des <span class="text-accent">voyageurs</span> de confiance

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
@@ -1,267 +1,243 @@
+<!-- ============================================================
+     Booking Request Card — matches mockup (code.html) layout
+     Collapsed: header / divider / 2-col body / footer
+     Expanded details panel (toggled by "Détails" button)
+     ============================================================ -->
 <article
-  class="mb-3 overflow-hidden rounded-xl border border-background-primary bg-background-secondary shadow-sm transition-shadow hover:shadow"
+  class="flex h-full flex-col overflow-hidden rounded-xl border border-border bg-background-secondary transition-all duration-200 hover:-translate-y-0.5 hover:shadow-card"
   [attr.data-trip-id]="tripId"
   [attr.aria-busy]="isProcessing"
 >
-  <div class="flex flex-col gap-3.5 p-4 sm:p-5">
 
-    <!-- ── Header: avatar · identity · meta · thumbnail ── -->
-    <div class="flex items-start gap-3">
-
-      <!-- Sender avatar -->
-      <div
-        class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-secondary/10 text-sm font-bold text-secondary"
-        aria-hidden="true"
-      >
-        {{ booking.senderName.charAt(0) || '?' }}
-      </div>
-
-      <!-- Identity + meta -->
-      <div class="min-w-0 flex-1">
-        <!-- Name + status badge -->
-        <div class="flex flex-wrap items-center gap-2">
-          <h3 class="text-sm font-semibold text-text-primary">{{ booking.senderName }}</h3>
-          <span
-            class="inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-widest"
-            [class]="statusClass(booking.status)"
-          >
-            <span class="h-1.5 w-1.5 rounded-full bg-current" aria-hidden="true"></span>
-            {{ statusLabel(booking.status) }}
-          </span>
+  <!-- ── Card Header: avatar · name · status ── -->
+  <div class="flex items-start justify-between p-5 pb-4">
+    <div class="flex items-center gap-3">
+      @if (senderPhotoUrl(); as photoUrl) {
+        <img
+          [src]="photoUrl"
+          [alt]="'Photo de profil de ' + booking.senderName"
+          class="h-12 w-12 shrink-0 rounded-full border border-border object-cover"
+          loading="lazy"
+          decoding="async"
+          (error)="onSenderPhotoError()"
+        />
+      } @else {
+        <div
+          class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-border bg-primary/10 text-sm font-bold text-primary"
+          aria-hidden="true"
+        >
+          {{ senderInitial() }}
         </div>
+      }
 
-        <!-- Booking title -->
-        <p class="mt-0.5 text-sm font-medium text-primary">{{ booking.title }}</p>
+      <div class="min-w-0">
+        <h3 class="font-bold text-text-primary">{{ booking.senderName }}</h3>
+        <!-- Fallback subtitle: package title acts as sender context -->
+        <p class="truncate text-sm text-text-secondary">{{ booking.title }}</p>
+      </div>
+    </div>
 
-        <!-- Inline meta: weight · amount · recipient contact -->
-        <dl class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1">
-          <div class="flex items-center gap-1">
-            <!-- Package / weight icon -->
-            <svg class="h-3.5 w-3.5 shrink-0 text-text-muted" fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" />
-            </svg>
-            <dt class="sr-only">Poids</dt>
-            <dd class="text-xs text-text-secondary">{{ booking.weight | number:'1.0-2' }} kg</dd>
-          </div>
-          @if (reservationAmount() !== null) {
-            <span class="text-text-muted" aria-hidden="true">·</span>
-            <div class="flex items-center gap-1">
-              <!-- Reservation amount icon -->
-              <svg class="h-3.5 w-3.5 shrink-0 text-text-muted" fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m3.5-9.5H10.75a2.25 2.25 0 1 0 0 4.5h2.5a2.25 2.25 0 1 1 0 4.5H8" />
-              </svg>
-              <dt class="sr-only">Montant de la réservation</dt>
-              <dd class="text-xs text-text-secondary">{{ reservationAmount()! | number:'1.0-2' }} €</dd>
-            </div>
-          }
-          <span class="text-text-muted" aria-hidden="true">·</span>
-          <div class="flex items-center gap-1 min-w-0">
-            <!-- Contact / phone icon -->
-            <svg class="h-3.5 w-3.5 shrink-0 text-text-muted" fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 0 0 6 3.75v16.5a2.25 2.25 0 0 0 2.25 2.25h7.5A2.25 2.25 0 0 0 18 20.25V3.75a2.25 2.25 0 0 0-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
-            </svg>
-            <dt class="sr-only">Contact destinataire</dt>
-            <dd class="truncate text-xs text-text-secondary">{{ booking.recipientContact }}</dd>
-          </div>
-        </dl>
+    <!-- Status badge -->
+    <span
+      class="shrink-0 rounded px-2 py-1 text-[11px] font-bold uppercase tracking-wide"
+      [class]="statusBadgeClass(booking.status)"
+    >
+      {{ statusLabel(booking.status) }}
+    </span>
+  </div>
+
+  <!-- ── Divider ── -->
+  <hr class="mx-5 border-border" />
+
+  <!-- ── Card Body: 2-column grid ── -->
+  <div class="grid min-h-[8.5rem] flex-1 grid-cols-2 gap-6 px-5 py-4">
+    <div>
+      <p class="mb-1 text-[11px] font-bold uppercase tracking-wide text-text-muted">Objet &amp; Type</p>
+      <p class="font-bold text-text-primary">{{ booking.title }}</p>
+      @if (booking.description) {
+        <p class="text-sm italic text-text-secondary">{{ booking.description }}</p>
+      } @else {
+        <p class="text-sm italic text-text-muted">—</p>
+      }
+    </div>
+
+    <div class="text-right">
+      <p class="mb-1 text-[11px] font-bold uppercase tracking-wide text-text-muted">Volume estimé</p>
+      <p class="font-bold text-text-primary">{{ booking.weight | number:'1.0-2' }} kg</p>
+    </div>
+  </div>
+
+  <!-- ── Card Footer: gain + action buttons ── -->
+  <div
+    class="mt-auto flex items-end justify-between border-t border-border/50 px-5 py-3"
+  >
+    <!-- Gain proposé -->
+    <div>
+      <p class="mb-1 text-[11px] font-bold uppercase tracking-wide text-text-muted">Gain Proposé</p>
+      @if (reservationAmount() !== null) {
+        <p class="text-xl font-bold text-primary">{{ reservationAmount()! | number:'1.0-2' }} €</p>
+      } @else {
+        <p class="text-xl font-bold text-text-muted">—</p>
+      }
+    </div>
+
+    <!-- Action buttons -->
+    <div class="flex flex-wrap justify-end gap-2">
+      <!-- Details toggle -->
+      <button
+        type="button"
+        class="rounded-xl border px-4 py-2 text-sm transition focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:opacity-50"
+        [class]="isDetailsOpen
+          ? 'border-primary bg-background-primary text-primary'
+          : 'border-border bg-background-secondary text-text-primary hover:bg-background-primary'"
+        [attr.aria-expanded]="isDetailsOpen"
+        [disabled]="isProcessing"
+        (click)="toggleDetails()"
+      >
+        Détails
+      </button>
+
+      <!-- PENDING → Accept -->
+      @if (booking.status === 'PENDING') {
+        <button
+          type="button"
+          class="rounded-xl bg-primary px-4 py-2 text-sm font-bold text-background-secondary transition hover:opacity-90 hover:shadow-primary-glow focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+          [disabled]="isProcessing"
+          (click)="onAccept()"
+        >
+          {{ isProcessing ? '...' : 'Accepter' }}
+        </button>
+      }
+
+      <!-- ACCEPTED → Remove (styled as cancel) -->
+      @if (booking.status === 'ACCEPTED') {
+        <button
+          type="button"
+          class="rounded-xl border border-error/30 bg-background-secondary px-4 py-2 text-sm font-bold text-error transition hover:bg-error/5 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-50"
+          [disabled]="isProcessing"
+          (click)="onRemove()"
+        >
+          Annuler
+        </button>
+      }
+    </div>
+  </div>
+
+  <!-- ── Collapsible Details Panel ── -->
+  @if (isDetailsOpen) {
+    <div class="space-y-4 border-t border-border bg-background-primary px-5 py-4 animate-fade-in">
+
+      <!-- Secondary action row -->
+      <div class="flex flex-wrap gap-2">
+        <!-- Message sender -->
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-md border border-border bg-background-secondary px-3 py-2 text-sm font-medium text-text-primary transition hover:-translate-y-px hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:opacity-50"
+          [disabled]="isProcessing"
+          (click)="onMessage()"
+        >
+          <!-- chat bubble icon -->
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 0 1-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8Z" />
+          </svg>
+          Envoyer un message
+        </button>
+
+        <!-- PENDING: Reject -->
+        @if (booking.status === 'PENDING') {
+          <button
+            type="button"
+            class="inline-flex items-center gap-1.5 rounded-md border border-error/20 bg-background-secondary px-3 py-2 text-sm font-medium text-error transition hover:-translate-y-px hover:bg-error/10 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:opacity-50"
+            [disabled]="isProcessing"
+            (click)="onReject()"
+          >
+            Refuser
+          </button>
+        }
       </div>
 
-      <!-- Package photo — thumbnail (desktop: inline; mobile: hidden here, shown below) -->
+      <!-- Recipient contact -->
+      <div class="rounded-md border border-border bg-background-secondary px-3 py-2.5">
+        <p class="text-[11px] font-bold uppercase tracking-wide text-text-muted">Contact destinataire</p>
+        <p class="mt-1 text-sm font-medium text-text-primary">{{ booking.recipientContact }}</p>
+      </div>
+
+      <!-- Package photo -->
       @if (booking.packagePhotoUrl) {
-        <div class="hidden shrink-0 sm:block" aria-hidden="true">
+        <div>
+          <p class="mb-2 text-[11px] font-bold uppercase tracking-wide text-text-muted">Photo du colis</p>
           <img
             [src]="booking.packagePhotoUrl"
             [alt]="'Photo du colis ' + booking.title"
-            class="h-14 w-14 rounded-lg object-cover ring-1 ring-background-primary"
+            class="h-44 w-full rounded-md border border-border object-cover"
             loading="lazy"
           />
         </div>
       }
-    </div>
 
-    <!-- ── Description (optional) ── -->
-    @if (booking.description) {
-      <p class="border-l-2 border-background-primary pl-3 text-xs leading-5 text-text-secondary">
-        {{ booking.description }}
-      </p>
-    }
-
-    <!-- ── Package photo — mobile fallback ── -->
-    @if (booking.packagePhotoUrl) {
-      <div class="sm:hidden">
-        <img
-          [src]="booking.packagePhotoUrl"
-          [alt]="'Photo du colis ' + booking.title"
-          class="h-36 w-full rounded-lg object-cover"
-          loading="lazy"
-        />
-      </div>
-    }
-
-    <!-- ── Status banners ── -->
-    @if (booking.validationCodeActive && booking.validationDeliveryChannel && booking.validationCodeSentAt) {
-      <div
-        role="status"
-        aria-live="polite"
-        [class]="tripStatus === 'COMPLETED'
-          ? 'flex items-start gap-2 rounded-lg border border-secondary/20 bg-secondary/10 px-3 py-2.5'
-          : 'flex items-start gap-2 rounded-lg border border-secondary/10 bg-background-primary px-3 py-2'"
-      >
-        <svg
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          [class]="tripStatus === 'COMPLETED'
-            ? 'mt-0.5 h-4 w-4 shrink-0 text-secondary'
-            : 'mt-0.5 h-4 w-4 shrink-0 text-secondary/70'"
-        >
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
-        </svg>
-        <div class="min-w-0">
-          <p
-            [class]="tripStatus === 'COMPLETED'
-              ? 'text-xs font-semibold leading-4 text-secondary'
-              : 'text-xs font-medium leading-4 text-secondary'"
-          >
-            Code de validation actif
-          </p>
-          <p
-            [class]="tripStatus === 'COMPLETED'
-              ? 'mt-0.5 text-xs leading-4 text-text-primary'
-              : 'mt-0.5 text-xs leading-4 text-text-muted'"
-          >
-            Code envoyé par <span class="font-medium">{{ validationChannelLabel(booking.validationDeliveryChannel) }}</span>
+      <!-- Validation code info -->
+      @if (booking.validationCodeActive && booking.validationDeliveryChannel && booking.validationCodeSentAt) {
+        <div class="rounded-md border border-warning/20 bg-warning/10 px-4 py-3">
+          <p class="text-sm font-medium text-text-primary">Code de validation actif</p>
+          <p class="mt-1 text-xs text-text-secondary">
+            Envoyé par {{ validationChannelLabel(booking.validationDeliveryChannel) }}
             le {{ booking.validationCodeSentAt | date:'dd/MM/yyyy à HH:mm' }}.
           </p>
-          @if (tripStatus === 'COMPLETED') {
-            <p class="mt-0.5 text-xs text-text-secondary">Saisissez le code ci-dessous pour confirmer la remise.</p>
-          }
         </div>
-      </div>
-    }
-
-    @if (booking.validationDeliveryStatus === 'FAILED' && booking.validationCodeDeliveryFailedAt) {
-      <div class="flex items-start gap-2.5 rounded-lg border border-error/20 bg-error/10 px-3 py-2.5" role="alert">
-        <svg class="mt-px h-4 w-4 shrink-0 text-error" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
-        </svg>
-        <div class="min-w-0">
-          <p class="text-xs font-semibold text-error">Envoi du code échoué</p>
-          <p class="mt-0.5 text-xs text-text-primary">Le code n'a pas pu être transmis au destinataire.</p>
-          <p class="mt-0.5 text-xs text-text-muted">Échec le {{ booking.validationCodeDeliveryFailedAt | date:'dd/MM/yyyy à HH:mm' }}</p>
-        </div>
-      </div>
-    }
-
-    @if (booking.deliveredAt) {
-      <div class="flex items-start gap-2.5 rounded-lg border border-success/20 bg-success/10 px-3 py-2.5" role="status">
-        <svg class="mt-px h-4 w-4 shrink-0 text-success" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-        </svg>
-        <div class="min-w-0">
-          <p class="text-xs font-semibold text-success">Colis remis</p>
-          <p class="mt-0.5 text-xs text-text-primary">Remise confirmée le {{ booking.deliveredAt | date:'dd/MM/yyyy à HH:mm' }}.</p>
-        </div>
-      </div>
-    }
-
-    <!-- ── Confirm-delivery inline form ── -->
-    @if (canShowConfirmDelivery()) {
-      <div class="flex flex-col gap-2 rounded-lg bg-background-primary px-3 py-2.5 sm:flex-row sm:items-end sm:gap-3">
-        <div class="flex-1">
-          <label [for]="'delivery-code-' + booking.id" class="mb-1 block text-xs font-medium text-text-secondary">
-            Code de remise destinataire
-          </label>
-          <input
-            [id]="'delivery-code-' + booking.id"
-            type="text"
-            inputmode="numeric"
-            maxlength="6"
-            [value]="deliveryCode"
-            (input)="deliveryCode = $any($event.target).value"
-            placeholder="000000"
-            class="w-full rounded-lg border border-background-primary bg-background-secondary px-3 py-2 text-sm tracking-[0.2em] text-text-primary placeholder:text-text-muted focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/20"
-          />
-        </div>
-        <button
-          type="button"
-          class="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-semibold text-white transition hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
-          [disabled]="deliveryCode.trim().length !== 6 || isProcessing"
-          (click)="onConfirmDelivery()"
-        >
-          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m5 13 4 4L19 7" />
-          </svg>
-          {{ isProcessing ? 'Traitement…' : 'Confirmer' }}
-        </button>
-      </div>
-    }
-
-    <!-- ── Action bar ── -->
-    <div class="flex flex-col gap-2 border-t border-background-primary pt-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
-
-      <!-- Message — always visible -->
-      <button
-        type="button"
-        class="inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-secondary/30 px-2.5 py-1.5 text-xs font-medium text-secondary transition hover:border-secondary hover:bg-secondary/10 focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:justify-start"
-        [disabled]="isProcessing"
-        (click)="onMessage()"
-        aria-label="Envoyer un message à l'expéditeur"
-      >
-        <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.42-4.03 8-9 8-1.43 0-2.79-.27-4.02-.76L3 20l1.28-3.41A7.65 7.65 0 0 1 3 12c0-4.42 4.03-8 9-8s9 3.58 9 8Z" />
-        </svg>
-        Message
-      </button>
-
-      <!-- Remove — ACCEPTED only -->
-      @if (booking.status === 'ACCEPTED') {
-        <button
-          type="button"
-          class="inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-warning/30 px-2.5 py-1.5 text-xs font-medium text-warning transition hover:border-warning hover:bg-warning/10 focus:outline-none focus:ring-2 focus:ring-warning/20 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:justify-start"
-          [disabled]="isProcessing"
-          (click)="onRemove()"
-          aria-label="Retirer la réservation acceptée"
-        >
-          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-          </svg>
-          Retirer
-        </button>
       }
 
-      <!-- Reject + Accept — PENDING only -->
-      @if (booking.status === 'PENDING') {
-        <button
-          type="button"
-          class="inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-error/30 px-2.5 py-1.5 text-xs font-medium text-error transition hover:border-error hover:bg-error/10 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:justify-start"
-          [disabled]="isProcessing"
-          (click)="onReject()"
-          aria-label="Refuser la demande de réservation"
-        >
-          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m6 6 12 12M18 6 6 18" />
-          </svg>
-          Refuser
-        </button>
-
-        <button
-          type="button"
-          class="inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-success px-2.5 py-1.5 text-xs font-semibold text-white transition hover:bg-success/90 focus:outline-none focus:ring-2 focus:ring-success/20 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:justify-start"
-          [disabled]="isProcessing"
-          (click)="onAccept()"
-          aria-label="Accepter la demande de réservation"
-        >
-          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m5 13 4 4L19 7" />
-          </svg>
-          {{ isProcessing ? 'Traitement…' : 'Accepter' }}
-        </button>
+      @if (booking.validationDeliveryStatus === 'FAILED' && booking.validationCodeDeliveryFailedAt) {
+        <div class="rounded-md border border-error/20 bg-error/10 px-4 py-3">
+          <p class="text-sm font-medium text-error">Envoi du code échoué</p>
+          <p class="mt-1 text-xs text-text-secondary">
+            Échec le {{ booking.validationCodeDeliveryFailedAt | date:'dd/MM/yyyy à HH:mm' }}
+          </p>
+        </div>
       }
 
+      @if (booking.deliveredAt) {
+        <div class="rounded-md border border-success/20 bg-success/10 px-4 py-3">
+          <p class="text-sm font-medium text-success">Colis remis</p>
+          <p class="mt-1 text-xs text-text-secondary">
+            Confirmé le {{ booking.deliveredAt | date:'dd/MM/yyyy à HH:mm' }}
+          </p>
+        </div>
+      }
+
+      <!-- Delivery confirmation form -->
+      @if (canShowConfirmDelivery()) {
+        <div class="rounded-md border border-border bg-background-secondary p-4">
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
+            <div class="flex-1">
+              <label
+                [for]="'delivery-code-' + booking.id"
+                class="mb-2 block text-xs font-medium text-text-secondary"
+              >
+                Code de remise
+              </label>
+              <input
+                [id]="'delivery-code-' + booking.id"
+                type="text"
+                inputmode="numeric"
+                maxlength="6"
+                [value]="deliveryCode"
+                (input)="deliveryCode = $any($event.target).value"
+                placeholder="000000"
+                class="w-full rounded-md border border-border bg-background-secondary px-4 py-3 text-sm tracking-[0.25em] text-text-primary placeholder:text-text-secondary focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              />
+            </div>
+
+            <button
+              type="button"
+              class="rounded-md bg-primary px-4 py-3 text-sm font-semibold text-background-secondary transition hover:-translate-y-px hover:shadow-primary-glow focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+              [disabled]="deliveryCode.trim().length !== 6 || isProcessing"
+              (click)="onConfirmDelivery()"
+            >
+              {{ isProcessing ? 'Traitement...' : 'Confirmer la remise' }}
+            </button>
+          </div>
+        </div>
+      }
     </div>
-
-  </div>
+  }
 </article>

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
@@ -84,14 +84,6 @@
         </div>
       }
 
-      @if (booking.validationCodeInvalidatedAt) {
-        <div class="rounded-2xl border border-warning/20 bg-warning/10 p-4">
-          <p class="text-xs font-semibold uppercase tracking-[0.16em] text-warning">Code invalidé</p>
-          <p class="mt-2 text-sm text-text-primary">Le précédent code n'est plus utilisable. Un nouveau code peut être nécessaire avant la remise.</p>
-          <p class="mt-1 text-sm text-text-secondary">Invalidé le {{ booking.validationCodeInvalidatedAt | date:'dd/MM/yyyy • HH:mm' }}</p>
-        </div>
-      }
-
       @if (booking.deliveredAt) {
         <div class="rounded-2xl border border-success/20 bg-success/10 p-4">
           <p class="text-xs font-semibold uppercase tracking-[0.16em] text-success">Colis remis</p>

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
@@ -101,7 +101,7 @@
       @if (booking.status === 'PENDING') {
         <button
           type="button"
-          class="rounded-xl bg-primary px-3.5 py-2 text-[13px] font-bold text-background-secondary transition hover:opacity-90 hover:shadow-primary-glow focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 sm:px-4 sm:text-sm"
+          class="rounded-xl bg-secondary px-3.5 py-2 text-[13px] font-bold text-white transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-50 sm:px-4 sm:text-sm"
           [disabled]="isProcessing"
           (click)="onAccept()"
         >
@@ -229,7 +229,7 @@
 
             <button
               type="button"
-              class="rounded-md bg-primary px-4 py-3 text-sm font-semibold text-background-secondary transition hover:-translate-y-px hover:shadow-primary-glow focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+              class="rounded-md bg-secondary px-4 py-3 text-sm font-semibold text-white transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-50"
               [disabled]="deliveryCode.trim().length !== 6 || isProcessing"
               (click)="onConfirmDelivery()"
             >

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
@@ -1,0 +1,192 @@
+<article
+  class="overflow-hidden rounded-2xl border border-background-primary bg-background-secondary shadow-sm"
+  [attr.data-trip-id]="tripId"
+  [attr.aria-busy]="isProcessing"
+>
+  <div class="flex flex-col gap-5 p-5 sm:p-6">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div class="flex min-w-0 items-start gap-3">
+        <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-secondary/10 text-sm font-bold text-secondary">
+          {{ booking.senderName.charAt(0) || '?' }}
+        </div>
+
+        <div class="min-w-0">
+          <div class="flex flex-wrap items-center gap-2">
+            <h3 class="text-lg font-semibold text-text-primary">{{ booking.senderName }}</h3>
+            <span
+              class="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.16em]"
+              [class]="statusClass(booking.status)"
+            >
+              <span class="h-2 w-2 rounded-full bg-current"></span>
+              {{ statusLabel(booking.status) }}
+            </span>
+          </div>
+
+          <p class="mt-1 text-base font-semibold text-primary">{{ booking.title }}</p>
+          <p class="mt-1 text-sm text-text-secondary">Demande de réservation pour l'envoi d'un colis.</p>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:min-w-[18rem]">
+        <div class="rounded-2xl bg-background-primary p-3">
+          <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Poids</p>
+          <p class="mt-1 text-sm font-semibold text-text-primary">{{ booking.weight | number:'1.0-2' }} kg</p>
+        </div>
+        <div class="rounded-2xl bg-background-primary p-3">
+          <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Contact destinataire</p>
+          <p class="mt-1 text-sm font-semibold text-text-primary break-all">{{ booking.recipientContact }}</p>
+        </div>
+      </div>
+    </div>
+
+    @if (booking.description || booking.packagePhotoUrl) {
+      <div class="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,0.9fr)]">
+        @if (booking.description) {
+          <div class="rounded-2xl bg-background-primary p-4">
+            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Description</p>
+            <p class="mt-2 text-sm leading-6 text-text-secondary">{{ booking.description }}</p>
+          </div>
+        }
+
+        @if (booking.packagePhotoUrl) {
+          <div class="overflow-hidden rounded-2xl bg-background-primary">
+            <img
+              [src]="booking.packagePhotoUrl"
+              [alt]="'Photo du colis ' + booking.title"
+              class="h-full max-h-56 w-full object-cover"
+              loading="lazy"
+            />
+          </div>
+        }
+      </div>
+    }
+
+    <div class="space-y-3">
+      @if (booking.validationCodeActive && booking.validationDeliveryChannel && booking.validationCodeSentAt) {
+        <div class="rounded-2xl border border-secondary/20 bg-secondary/10 p-4">
+          <p class="text-xs font-semibold uppercase tracking-[0.16em] text-secondary">Code de validation actif</p>
+          <p class="mt-2 text-sm text-text-primary">
+            Un code a été envoyé au destinataire par
+            <span class="font-semibold">{{ validationChannelLabel(booking.validationDeliveryChannel) }}</span>.
+          </p>
+          <p class="mt-1 text-sm text-text-secondary">Envoyé le {{ booking.validationCodeSentAt | date:'dd/MM/yyyy • HH:mm' }}</p>
+          @if (tripStatus === 'COMPLETED') {
+            <p class="mt-2 text-sm text-text-secondary">Saisissez le code reçu pour confirmer la remise du colis.</p>
+          }
+        </div>
+      }
+
+      @if (booking.validationDeliveryStatus === 'FAILED' && booking.validationCodeDeliveryFailedAt) {
+        <div class="rounded-2xl border border-error/20 bg-error/10 p-4">
+          <p class="text-xs font-semibold uppercase tracking-[0.16em] text-error">Envoi du code échoué</p>
+          <p class="mt-2 text-sm text-text-primary">Le code n'a pas pu être transmis au destinataire. Vous pouvez reprendre contact avant de réessayer.</p>
+          <p class="mt-1 text-sm text-text-secondary">Échec signalé le {{ booking.validationCodeDeliveryFailedAt | date:'dd/MM/yyyy • HH:mm' }}</p>
+        </div>
+      }
+
+      @if (booking.validationCodeInvalidatedAt) {
+        <div class="rounded-2xl border border-warning/20 bg-warning/10 p-4">
+          <p class="text-xs font-semibold uppercase tracking-[0.16em] text-warning">Code invalidé</p>
+          <p class="mt-2 text-sm text-text-primary">Le précédent code n'est plus utilisable. Un nouveau code peut être nécessaire avant la remise.</p>
+          <p class="mt-1 text-sm text-text-secondary">Invalidé le {{ booking.validationCodeInvalidatedAt | date:'dd/MM/yyyy • HH:mm' }}</p>
+        </div>
+      }
+
+      @if (booking.deliveredAt) {
+        <div class="rounded-2xl border border-success/20 bg-success/10 p-4">
+          <p class="text-xs font-semibold uppercase tracking-[0.16em] text-success">Colis remis</p>
+          <p class="mt-2 text-sm text-text-primary">La remise du colis a bien été confirmée.</p>
+          <p class="mt-1 text-sm text-text-secondary">Confirmée le {{ booking.deliveredAt | date:'dd/MM/yyyy • HH:mm' }}</p>
+        </div>
+      }
+    </div>
+
+    <div class="flex flex-col gap-3 border-t border-background-primary pt-4">
+      <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+        @if (booking.status === 'PENDING') {
+          <button
+            type="button"
+            class="inline-flex items-center justify-center gap-2 rounded-xl bg-success px-4 py-3 text-sm font-semibold text-white transition hover:bg-success/90 focus:outline-none focus:ring-2 focus:ring-success/20 disabled:cursor-not-allowed disabled:opacity-60"
+            [disabled]="isProcessing"
+            (click)="onAccept()"
+          >
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m5 13 4 4L19 7" />
+            </svg>
+            {{ isProcessing ? 'Traitement...' : 'Accepter' }}
+          </button>
+
+          <button
+            type="button"
+            class="inline-flex items-center justify-center gap-2 rounded-xl bg-error px-4 py-3 text-sm font-semibold text-white transition hover:bg-error/90 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-60"
+            [disabled]="isProcessing"
+            (click)="onReject()"
+          >
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m6 6 12 12M18 6 6 18" />
+            </svg>
+            {{ isProcessing ? 'Traitement...' : 'Refuser' }}
+          </button>
+        }
+
+        @if (booking.status === 'ACCEPTED') {
+          <button
+            type="button"
+            class="inline-flex items-center justify-center gap-2 rounded-xl bg-warning px-4 py-3 text-sm font-semibold text-white transition hover:bg-warning/90 focus:outline-none focus:ring-2 focus:ring-warning/20 disabled:cursor-not-allowed disabled:opacity-60"
+            [disabled]="isProcessing"
+            (click)="onRemove()"
+          >
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 7 5 21M5 7l14 14" />
+            </svg>
+            {{ isProcessing ? 'Traitement...' : 'Retirer' }}
+          </button>
+        }
+
+        <button
+          type="button"
+          class="inline-flex items-center justify-center gap-2 rounded-xl border border-secondary/20 bg-secondary/10 px-4 py-3 text-sm font-semibold text-secondary transition hover:bg-secondary hover:text-white focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-60"
+          [disabled]="isProcessing"
+          (click)="onMessage()"
+        >
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.42-4.03 8-9 8-1.43 0-2.79-.27-4.02-.76L3 20l1.28-3.41A7.65 7.65 0 0 1 3 12c0-4.42 4.03-8 9-8s9 3.58 9 8Z" />
+          </svg>
+          {{ isProcessing ? 'Traitement...' : 'Message' }}
+        </button>
+      </div>
+
+      @if (canShowConfirmDelivery()) {
+        <div class="flex flex-col gap-3 rounded-2xl bg-background-primary p-4 lg:flex-row lg:items-center">
+          <div class="min-w-0 flex-1">
+            <label [for]="'delivery-code-' + booking.id" class="mb-2 block text-sm font-medium text-text-primary">
+              Confirmer la remise avec le code destinataire
+            </label>
+            <input
+              [id]="'delivery-code-' + booking.id"
+              type="text"
+              inputmode="numeric"
+              maxlength="6"
+              [value]="deliveryCode"
+              (input)="deliveryCode = $any($event.target).value"
+              placeholder="000000"
+              class="w-full rounded-xl border border-background-primary bg-background-secondary px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/20"
+            />
+          </div>
+
+          <button
+            type="button"
+            class="inline-flex items-center justify-center gap-2 rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60 lg:self-end"
+            [disabled]="deliveryCode.trim().length !== 6 || isProcessing"
+            (click)="onConfirmDelivery()"
+          >
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m5 13 4 4L19 7" />
+            </svg>
+            {{ isProcessing ? 'Traitement...' : 'Confirmer la remise' }}
+          </button>
+        </div>
+      }
+    </div>
+  </div>
+</article>

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
@@ -164,12 +164,12 @@
     }
 
     <!-- ── Action bar ── -->
-    <div class="flex flex-wrap items-center justify-end gap-2 border-t border-background-primary pt-3">
+    <div class="flex flex-col gap-2 border-t border-background-primary pt-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
 
       <!-- Message — always visible -->
       <button
         type="button"
-        class="inline-flex items-center gap-1.5 rounded-lg border border-secondary/30 px-2.5 py-1.5 text-xs font-medium text-secondary transition hover:border-secondary hover:bg-secondary/10 focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-50"
+        class="inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-secondary/30 px-2.5 py-1.5 text-xs font-medium text-secondary transition hover:border-secondary hover:bg-secondary/10 focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:justify-start"
         [disabled]="isProcessing"
         (click)="onMessage()"
         aria-label="Envoyer un message à l'expéditeur"
@@ -184,7 +184,7 @@
       @if (booking.status === 'ACCEPTED') {
         <button
           type="button"
-          class="inline-flex items-center gap-1.5 rounded-lg border border-warning/30 px-2.5 py-1.5 text-xs font-medium text-warning transition hover:border-warning hover:bg-warning/10 focus:outline-none focus:ring-2 focus:ring-warning/20 disabled:cursor-not-allowed disabled:opacity-50"
+          class="inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-warning/30 px-2.5 py-1.5 text-xs font-medium text-warning transition hover:border-warning hover:bg-warning/10 focus:outline-none focus:ring-2 focus:ring-warning/20 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:justify-start"
           [disabled]="isProcessing"
           (click)="onRemove()"
           aria-label="Retirer la réservation acceptée"
@@ -200,7 +200,7 @@
       @if (booking.status === 'PENDING') {
         <button
           type="button"
-          class="inline-flex items-center gap-1.5 rounded-lg border border-error/30 px-2.5 py-1.5 text-xs font-medium text-error transition hover:border-error hover:bg-error/10 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-50"
+          class="inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-error/30 px-2.5 py-1.5 text-xs font-medium text-error transition hover:border-error hover:bg-error/10 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:justify-start"
           [disabled]="isProcessing"
           (click)="onReject()"
           aria-label="Refuser la demande de réservation"
@@ -213,7 +213,7 @@
 
         <button
           type="button"
-          class="inline-flex items-center gap-1.5 rounded-lg bg-success px-2.5 py-1.5 text-xs font-semibold text-white transition hover:bg-success/90 focus:outline-none focus:ring-2 focus:ring-success/20 disabled:cursor-not-allowed disabled:opacity-50"
+          class="inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-success px-2.5 py-1.5 text-xs font-semibold text-white transition hover:bg-success/90 focus:outline-none focus:ring-2 focus:ring-success/20 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:justify-start"
           [disabled]="isProcessing"
           (click)="onAccept()"
           aria-label="Accepter la demande de réservation"

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
@@ -33,7 +33,7 @@
         <!-- Booking title -->
         <p class="mt-0.5 text-sm font-medium text-primary">{{ booking.title }}</p>
 
-        <!-- Inline meta: weight · recipient contact -->
+        <!-- Inline meta: weight · amount · recipient contact -->
         <dl class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1">
           <div class="flex items-center gap-1">
             <!-- Package / weight icon -->
@@ -43,6 +43,17 @@
             <dt class="sr-only">Poids</dt>
             <dd class="text-xs text-text-secondary">{{ booking.weight | number:'1.0-2' }} kg</dd>
           </div>
+          @if (reservationAmount() !== null) {
+            <span class="text-text-muted" aria-hidden="true">·</span>
+            <div class="flex items-center gap-1">
+              <!-- Reservation amount icon -->
+              <svg class="h-3.5 w-3.5 shrink-0 text-text-muted" fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m3.5-9.5H10.75a2.25 2.25 0 1 0 0 4.5h2.5a2.25 2.25 0 1 1 0 4.5H8" />
+              </svg>
+              <dt class="sr-only">Montant de la réservation</dt>
+              <dd class="text-xs text-text-secondary">{{ reservationAmount()! | number:'1.0-2' }} €</dd>
+            </div>
+          }
           <span class="text-text-muted" aria-hidden="true">·</span>
           <div class="flex items-center gap-1 min-w-0">
             <!-- Contact / phone icon -->

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
@@ -100,13 +100,38 @@
 
     <!-- ── Status banners ── -->
     @if (booking.validationCodeActive && booking.validationDeliveryChannel && booking.validationCodeSentAt) {
-      <div class="flex items-start gap-2.5 rounded-lg border border-secondary/20 bg-secondary/10 px-3 py-2.5" role="status">
-        <svg class="mt-px h-4 w-4 shrink-0 text-secondary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+      <div
+        role="status"
+        aria-live="polite"
+        [class]="tripStatus === 'COMPLETED'
+          ? 'flex items-start gap-2 rounded-lg border border-secondary/20 bg-secondary/10 px-3 py-2.5'
+          : 'flex items-start gap-2 rounded-lg border border-secondary/10 bg-background-primary px-3 py-2'"
+      >
+        <svg
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          [class]="tripStatus === 'COMPLETED'
+            ? 'mt-0.5 h-4 w-4 shrink-0 text-secondary'
+            : 'mt-0.5 h-4 w-4 shrink-0 text-secondary/70'"
+        >
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
         </svg>
         <div class="min-w-0">
-          <p class="text-xs font-semibold text-secondary">Code de validation actif</p>
-          <p class="mt-0.5 text-xs text-text-primary">
+          <p
+            [class]="tripStatus === 'COMPLETED'
+              ? 'text-xs font-semibold leading-4 text-secondary'
+              : 'text-xs font-medium leading-4 text-secondary'"
+          >
+            Code de validation actif
+          </p>
+          <p
+            [class]="tripStatus === 'COMPLETED'
+              ? 'mt-0.5 text-xs leading-4 text-text-primary'
+              : 'mt-0.5 text-xs leading-4 text-text-muted'"
+          >
             Code envoyé par <span class="font-medium">{{ validationChannelLabel(booking.validationDeliveryChannel) }}</span>
             le {{ booking.validationCodeSentAt | date:'dd/MM/yyyy à HH:mm' }}.
           </p>

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
@@ -1,184 +1,231 @@
 <article
-  class="overflow-hidden rounded-2xl border border-background-primary bg-background-secondary shadow-sm"
+  class="mb-3 overflow-hidden rounded-xl border border-background-primary bg-background-secondary shadow-sm transition-shadow hover:shadow"
   [attr.data-trip-id]="tripId"
   [attr.aria-busy]="isProcessing"
 >
-  <div class="flex flex-col gap-5 p-5 sm:p-6">
-    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-      <div class="flex min-w-0 items-start gap-3">
-        <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-secondary/10 text-sm font-bold text-secondary">
-          {{ booking.senderName.charAt(0) || '?' }}
+  <div class="flex flex-col gap-3.5 p-4 sm:p-5">
+
+    <!-- ── Header: avatar · identity · meta · thumbnail ── -->
+    <div class="flex items-start gap-3">
+
+      <!-- Sender avatar -->
+      <div
+        class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-secondary/10 text-sm font-bold text-secondary"
+        aria-hidden="true"
+      >
+        {{ booking.senderName.charAt(0) || '?' }}
+      </div>
+
+      <!-- Identity + meta -->
+      <div class="min-w-0 flex-1">
+        <!-- Name + status badge -->
+        <div class="flex flex-wrap items-center gap-2">
+          <h3 class="text-sm font-semibold text-text-primary">{{ booking.senderName }}</h3>
+          <span
+            class="inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-widest"
+            [class]="statusClass(booking.status)"
+          >
+            <span class="h-1.5 w-1.5 rounded-full bg-current" aria-hidden="true"></span>
+            {{ statusLabel(booking.status) }}
+          </span>
         </div>
 
-        <div class="min-w-0">
-          <div class="flex flex-wrap items-center gap-2">
-            <h3 class="text-lg font-semibold text-text-primary">{{ booking.senderName }}</h3>
-            <span
-              class="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.16em]"
-              [class]="statusClass(booking.status)"
-            >
-              <span class="h-2 w-2 rounded-full bg-current"></span>
-              {{ statusLabel(booking.status) }}
-            </span>
+        <!-- Booking title -->
+        <p class="mt-0.5 text-sm font-medium text-primary">{{ booking.title }}</p>
+
+        <!-- Inline meta: weight · recipient contact -->
+        <dl class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1">
+          <div class="flex items-center gap-1">
+            <!-- Package / weight icon -->
+            <svg class="h-3.5 w-3.5 shrink-0 text-text-muted" fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" />
+            </svg>
+            <dt class="sr-only">Poids</dt>
+            <dd class="text-xs text-text-secondary">{{ booking.weight | number:'1.0-2' }} kg</dd>
           </div>
-
-          <p class="mt-1 text-base font-semibold text-primary">{{ booking.title }}</p>
-          <p class="mt-1 text-sm text-text-secondary">Demande de réservation pour l'envoi d'un colis.</p>
-        </div>
+          <span class="text-text-muted" aria-hidden="true">·</span>
+          <div class="flex items-center gap-1 min-w-0">
+            <!-- Contact / phone icon -->
+            <svg class="h-3.5 w-3.5 shrink-0 text-text-muted" fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 0 0 6 3.75v16.5a2.25 2.25 0 0 0 2.25 2.25h7.5A2.25 2.25 0 0 0 18 20.25V3.75a2.25 2.25 0 0 0-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
+            </svg>
+            <dt class="sr-only">Contact destinataire</dt>
+            <dd class="truncate text-xs text-text-secondary">{{ booking.recipientContact }}</dd>
+          </div>
+        </dl>
       </div>
 
-      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:min-w-[18rem]">
-        <div class="rounded-2xl bg-background-primary p-3">
-          <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Poids</p>
-          <p class="mt-1 text-sm font-semibold text-text-primary">{{ booking.weight | number:'1.0-2' }} kg</p>
+      <!-- Package photo — thumbnail (desktop: inline; mobile: hidden here, shown below) -->
+      @if (booking.packagePhotoUrl) {
+        <div class="hidden shrink-0 sm:block" aria-hidden="true">
+          <img
+            [src]="booking.packagePhotoUrl"
+            [alt]="'Photo du colis ' + booking.title"
+            class="h-14 w-14 rounded-lg object-cover ring-1 ring-background-primary"
+            loading="lazy"
+          />
         </div>
-        <div class="rounded-2xl bg-background-primary p-3">
-          <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Contact destinataire</p>
-          <p class="mt-1 text-sm font-semibold text-text-primary break-all">{{ booking.recipientContact }}</p>
-        </div>
-      </div>
+      }
     </div>
 
-    @if (booking.description || booking.packagePhotoUrl) {
-      <div class="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,0.9fr)]">
-        @if (booking.description) {
-          <div class="rounded-2xl bg-background-primary p-4">
-            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Description</p>
-            <p class="mt-2 text-sm leading-6 text-text-secondary">{{ booking.description }}</p>
-          </div>
-        }
+    <!-- ── Description (optional) ── -->
+    @if (booking.description) {
+      <p class="border-l-2 border-background-primary pl-3 text-xs leading-5 text-text-secondary">
+        {{ booking.description }}
+      </p>
+    }
 
-        @if (booking.packagePhotoUrl) {
-          <div class="overflow-hidden rounded-2xl bg-background-primary">
-            <img
-              [src]="booking.packagePhotoUrl"
-              [alt]="'Photo du colis ' + booking.title"
-              class="h-full max-h-56 w-full object-cover"
-              loading="lazy"
-            />
-          </div>
-        }
+    <!-- ── Package photo — mobile fallback ── -->
+    @if (booking.packagePhotoUrl) {
+      <div class="sm:hidden">
+        <img
+          [src]="booking.packagePhotoUrl"
+          [alt]="'Photo du colis ' + booking.title"
+          class="h-36 w-full rounded-lg object-cover"
+          loading="lazy"
+        />
       </div>
     }
 
-    <div class="space-y-3">
-      @if (booking.validationCodeActive && booking.validationDeliveryChannel && booking.validationCodeSentAt) {
-        <div class="rounded-2xl border border-secondary/20 bg-secondary/10 p-4">
-          <p class="text-xs font-semibold uppercase tracking-[0.16em] text-secondary">Code de validation actif</p>
-          <p class="mt-2 text-sm text-text-primary">
-            Un code a été envoyé au destinataire par
-            <span class="font-semibold">{{ validationChannelLabel(booking.validationDeliveryChannel) }}</span>.
+    <!-- ── Status banners ── -->
+    @if (booking.validationCodeActive && booking.validationDeliveryChannel && booking.validationCodeSentAt) {
+      <div class="flex items-start gap-2.5 rounded-lg border border-secondary/20 bg-secondary/10 px-3 py-2.5" role="status">
+        <svg class="mt-px h-4 w-4 shrink-0 text-secondary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+        </svg>
+        <div class="min-w-0">
+          <p class="text-xs font-semibold text-secondary">Code de validation actif</p>
+          <p class="mt-0.5 text-xs text-text-primary">
+            Code envoyé par <span class="font-medium">{{ validationChannelLabel(booking.validationDeliveryChannel) }}</span>
+            le {{ booking.validationCodeSentAt | date:'dd/MM/yyyy à HH:mm' }}.
           </p>
-          <p class="mt-1 text-sm text-text-secondary">Envoyé le {{ booking.validationCodeSentAt | date:'dd/MM/yyyy • HH:mm' }}</p>
           @if (tripStatus === 'COMPLETED') {
-            <p class="mt-2 text-sm text-text-secondary">Saisissez le code reçu pour confirmer la remise du colis.</p>
+            <p class="mt-0.5 text-xs text-text-secondary">Saisissez le code ci-dessous pour confirmer la remise.</p>
           }
         </div>
-      }
+      </div>
+    }
 
-      @if (booking.validationDeliveryStatus === 'FAILED' && booking.validationCodeDeliveryFailedAt) {
-        <div class="rounded-2xl border border-error/20 bg-error/10 p-4">
-          <p class="text-xs font-semibold uppercase tracking-[0.16em] text-error">Envoi du code échoué</p>
-          <p class="mt-2 text-sm text-text-primary">Le code n'a pas pu être transmis au destinataire. Vous pouvez reprendre contact avant de réessayer.</p>
-          <p class="mt-1 text-sm text-text-secondary">Échec signalé le {{ booking.validationCodeDeliveryFailedAt | date:'dd/MM/yyyy • HH:mm' }}</p>
+    @if (booking.validationDeliveryStatus === 'FAILED' && booking.validationCodeDeliveryFailedAt) {
+      <div class="flex items-start gap-2.5 rounded-lg border border-error/20 bg-error/10 px-3 py-2.5" role="alert">
+        <svg class="mt-px h-4 w-4 shrink-0 text-error" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+        </svg>
+        <div class="min-w-0">
+          <p class="text-xs font-semibold text-error">Envoi du code échoué</p>
+          <p class="mt-0.5 text-xs text-text-primary">Le code n'a pas pu être transmis au destinataire.</p>
+          <p class="mt-0.5 text-xs text-text-muted">Échec le {{ booking.validationCodeDeliveryFailedAt | date:'dd/MM/yyyy à HH:mm' }}</p>
         </div>
-      }
+      </div>
+    }
 
-      @if (booking.deliveredAt) {
-        <div class="rounded-2xl border border-success/20 bg-success/10 p-4">
-          <p class="text-xs font-semibold uppercase tracking-[0.16em] text-success">Colis remis</p>
-          <p class="mt-2 text-sm text-text-primary">La remise du colis a bien été confirmée.</p>
-          <p class="mt-1 text-sm text-text-secondary">Confirmée le {{ booking.deliveredAt | date:'dd/MM/yyyy • HH:mm' }}</p>
+    @if (booking.deliveredAt) {
+      <div class="flex items-start gap-2.5 rounded-lg border border-success/20 bg-success/10 px-3 py-2.5" role="status">
+        <svg class="mt-px h-4 w-4 shrink-0 text-success" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+        </svg>
+        <div class="min-w-0">
+          <p class="text-xs font-semibold text-success">Colis remis</p>
+          <p class="mt-0.5 text-xs text-text-primary">Remise confirmée le {{ booking.deliveredAt | date:'dd/MM/yyyy à HH:mm' }}.</p>
         </div>
+      </div>
+    }
+
+    <!-- ── Confirm-delivery inline form ── -->
+    @if (canShowConfirmDelivery()) {
+      <div class="flex flex-col gap-2 rounded-lg bg-background-primary px-3 py-2.5 sm:flex-row sm:items-end sm:gap-3">
+        <div class="flex-1">
+          <label [for]="'delivery-code-' + booking.id" class="mb-1 block text-xs font-medium text-text-secondary">
+            Code de remise destinataire
+          </label>
+          <input
+            [id]="'delivery-code-' + booking.id"
+            type="text"
+            inputmode="numeric"
+            maxlength="6"
+            [value]="deliveryCode"
+            (input)="deliveryCode = $any($event.target).value"
+            placeholder="000000"
+            class="w-full rounded-lg border border-background-primary bg-background-secondary px-3 py-2 text-sm tracking-[0.2em] text-text-primary placeholder:text-text-muted focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/20"
+          />
+        </div>
+        <button
+          type="button"
+          class="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-semibold text-white transition hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+          [disabled]="deliveryCode.trim().length !== 6 || isProcessing"
+          (click)="onConfirmDelivery()"
+        >
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m5 13 4 4L19 7" />
+          </svg>
+          {{ isProcessing ? 'Traitement…' : 'Confirmer' }}
+        </button>
+      </div>
+    }
+
+    <!-- ── Action bar ── -->
+    <div class="flex flex-wrap items-center justify-end gap-2 border-t border-background-primary pt-3">
+
+      <!-- Message — always visible -->
+      <button
+        type="button"
+        class="inline-flex items-center gap-1.5 rounded-lg border border-secondary/30 px-2.5 py-1.5 text-xs font-medium text-secondary transition hover:border-secondary hover:bg-secondary/10 focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-50"
+        [disabled]="isProcessing"
+        (click)="onMessage()"
+        aria-label="Envoyer un message à l'expéditeur"
+      >
+        <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.42-4.03 8-9 8-1.43 0-2.79-.27-4.02-.76L3 20l1.28-3.41A7.65 7.65 0 0 1 3 12c0-4.42 4.03-8 9-8s9 3.58 9 8Z" />
+        </svg>
+        Message
+      </button>
+
+      <!-- Remove — ACCEPTED only -->
+      @if (booking.status === 'ACCEPTED') {
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-lg border border-warning/30 px-2.5 py-1.5 text-xs font-medium text-warning transition hover:border-warning hover:bg-warning/10 focus:outline-none focus:ring-2 focus:ring-warning/20 disabled:cursor-not-allowed disabled:opacity-50"
+          [disabled]="isProcessing"
+          (click)="onRemove()"
+          aria-label="Retirer la réservation acceptée"
+        >
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+          </svg>
+          Retirer
+        </button>
       }
-    </div>
 
-    <div class="flex flex-col gap-3 border-t border-background-primary pt-4">
-      <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
-        @if (booking.status === 'PENDING') {
-          <button
-            type="button"
-            class="inline-flex items-center justify-center gap-2 rounded-xl bg-success px-4 py-3 text-sm font-semibold text-white transition hover:bg-success/90 focus:outline-none focus:ring-2 focus:ring-success/20 disabled:cursor-not-allowed disabled:opacity-60"
-            [disabled]="isProcessing"
-            (click)="onAccept()"
-          >
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m5 13 4 4L19 7" />
-            </svg>
-            {{ isProcessing ? 'Traitement...' : 'Accepter' }}
-          </button>
-
-          <button
-            type="button"
-            class="inline-flex items-center justify-center gap-2 rounded-xl bg-error px-4 py-3 text-sm font-semibold text-white transition hover:bg-error/90 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-60"
-            [disabled]="isProcessing"
-            (click)="onReject()"
-          >
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m6 6 12 12M18 6 6 18" />
-            </svg>
-            {{ isProcessing ? 'Traitement...' : 'Refuser' }}
-          </button>
-        }
-
-        @if (booking.status === 'ACCEPTED') {
-          <button
-            type="button"
-            class="inline-flex items-center justify-center gap-2 rounded-xl bg-warning px-4 py-3 text-sm font-semibold text-white transition hover:bg-warning/90 focus:outline-none focus:ring-2 focus:ring-warning/20 disabled:cursor-not-allowed disabled:opacity-60"
-            [disabled]="isProcessing"
-            (click)="onRemove()"
-          >
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M19 7 5 21M5 7l14 14" />
-            </svg>
-            {{ isProcessing ? 'Traitement...' : 'Retirer' }}
-          </button>
-        }
+      <!-- Reject + Accept — PENDING only -->
+      @if (booking.status === 'PENDING') {
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-lg border border-error/30 px-2.5 py-1.5 text-xs font-medium text-error transition hover:border-error hover:bg-error/10 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-50"
+          [disabled]="isProcessing"
+          (click)="onReject()"
+          aria-label="Refuser la demande de réservation"
+        >
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m6 6 12 12M18 6 6 18" />
+          </svg>
+          Refuser
+        </button>
 
         <button
           type="button"
-          class="inline-flex items-center justify-center gap-2 rounded-xl border border-secondary/20 bg-secondary/10 px-4 py-3 text-sm font-semibold text-secondary transition hover:bg-secondary hover:text-white focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-60"
+          class="inline-flex items-center gap-1.5 rounded-lg bg-success px-2.5 py-1.5 text-xs font-semibold text-white transition hover:bg-success/90 focus:outline-none focus:ring-2 focus:ring-success/20 disabled:cursor-not-allowed disabled:opacity-50"
           [disabled]="isProcessing"
-          (click)="onMessage()"
+          (click)="onAccept()"
+          aria-label="Accepter la demande de réservation"
         >
-          <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.42-4.03 8-9 8-1.43 0-2.79-.27-4.02-.76L3 20l1.28-3.41A7.65 7.65 0 0 1 3 12c0-4.42 4.03-8 9-8s9 3.58 9 8Z" />
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m5 13 4 4L19 7" />
           </svg>
-          {{ isProcessing ? 'Traitement...' : 'Message' }}
+          {{ isProcessing ? 'Traitement…' : 'Accepter' }}
         </button>
-      </div>
-
-      @if (canShowConfirmDelivery()) {
-        <div class="flex flex-col gap-3 rounded-2xl bg-background-primary p-4 lg:flex-row lg:items-center">
-          <div class="min-w-0 flex-1">
-            <label [for]="'delivery-code-' + booking.id" class="mb-2 block text-sm font-medium text-text-primary">
-              Confirmer la remise avec le code destinataire
-            </label>
-            <input
-              [id]="'delivery-code-' + booking.id"
-              type="text"
-              inputmode="numeric"
-              maxlength="6"
-              [value]="deliveryCode"
-              (input)="deliveryCode = $any($event.target).value"
-              placeholder="000000"
-              class="w-full rounded-xl border border-background-primary bg-background-secondary px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/20"
-            />
-          </div>
-
-          <button
-            type="button"
-            class="inline-flex items-center justify-center gap-2 rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60 lg:self-end"
-            [disabled]="deliveryCode.trim().length !== 6 || isProcessing"
-            (click)="onConfirmDelivery()"
-          >
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m5 13 4 4L19 7" />
-            </svg>
-            {{ isProcessing ? 'Traitement...' : 'Confirmer la remise' }}
-          </button>
-        </div>
       }
+
     </div>
+
   </div>
 </article>

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.html
@@ -4,26 +4,26 @@
      Expanded details panel (toggled by "Détails" button)
      ============================================================ -->
 <article
-  class="flex h-full flex-col overflow-hidden rounded-xl border border-border bg-background-secondary transition-all duration-200 hover:-translate-y-0.5 hover:shadow-card"
+  class="flex flex-col overflow-hidden rounded-xl border border-border bg-background-secondary transition-all duration-200 hover:-translate-y-0.5 hover:shadow-card xl:h-full"
   [attr.data-trip-id]="tripId"
   [attr.aria-busy]="isProcessing"
 >
 
   <!-- ── Card Header: avatar · name · status ── -->
-  <div class="flex items-start justify-between p-5 pb-4">
+  <div class="flex items-start justify-between p-4 pb-3 sm:p-5 sm:pb-4">
     <div class="flex items-center gap-3">
       @if (senderPhotoUrl(); as photoUrl) {
         <img
           [src]="photoUrl"
           [alt]="'Photo de profil de ' + booking.senderName"
-          class="h-12 w-12 shrink-0 rounded-full border border-border object-cover"
+          class="h-10 w-10 shrink-0 rounded-full border border-border object-cover sm:h-12 sm:w-12"
           loading="lazy"
           decoding="async"
           (error)="onSenderPhotoError()"
         />
       } @else {
         <div
-          class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-border bg-primary/10 text-sm font-bold text-primary"
+          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-border bg-primary/10 text-xs font-bold text-primary sm:h-12 sm:w-12 sm:text-sm"
           aria-hidden="true"
         >
           {{ senderInitial() }}
@@ -31,15 +31,15 @@
       }
 
       <div class="min-w-0">
-        <h3 class="font-bold text-text-primary">{{ booking.senderName }}</h3>
+        <h3 class="text-[15px] font-bold text-text-primary sm:text-base">{{ booking.senderName }}</h3>
         <!-- Fallback subtitle: package title acts as sender context -->
-        <p class="truncate text-sm text-text-secondary">{{ booking.title }}</p>
+        <p class="truncate text-[13px] text-text-secondary sm:text-sm">{{ booking.title }}</p>
       </div>
     </div>
 
     <!-- Status badge -->
     <span
-      class="shrink-0 rounded px-2 py-1 text-[11px] font-bold uppercase tracking-wide"
+      class="shrink-0 rounded px-2 py-1 text-[10px] font-bold uppercase tracking-wide sm:text-[11px]"
       [class]="statusBadgeClass(booking.status)"
     >
       {{ statusLabel(booking.status) }}
@@ -47,37 +47,37 @@
   </div>
 
   <!-- ── Divider ── -->
-  <hr class="mx-5 border-border" />
+  <hr class="mx-4 border-border sm:mx-5" />
 
   <!-- ── Card Body: 2-column grid ── -->
-  <div class="grid min-h-[8.5rem] flex-1 grid-cols-2 gap-6 px-5 py-4">
+  <div class="grid grid-cols-2 gap-4 px-4 py-3 sm:gap-6 sm:px-5 sm:py-4 xl:min-h-[8.5rem] xl:flex-1">
     <div>
-      <p class="mb-1 text-[11px] font-bold uppercase tracking-wide text-text-muted">Objet &amp; Type</p>
-      <p class="font-bold text-text-primary">{{ booking.title }}</p>
+      <p class="mb-1 text-[10px] font-bold uppercase tracking-wide text-text-muted sm:text-[11px]">Objet &amp; Type</p>
+      <p class="text-[15px] font-bold text-text-primary sm:text-base">{{ booking.title }}</p>
       @if (booking.description) {
-        <p class="text-sm italic text-text-secondary">{{ booking.description }}</p>
+        <p class="text-[13px] italic text-text-secondary sm:text-sm">{{ booking.description }}</p>
       } @else {
-        <p class="text-sm italic text-text-muted">—</p>
+        <p class="text-[13px] italic text-text-muted sm:text-sm">—</p>
       }
     </div>
 
     <div class="text-right">
-      <p class="mb-1 text-[11px] font-bold uppercase tracking-wide text-text-muted">Volume estimé</p>
-      <p class="font-bold text-text-primary">{{ booking.weight | number:'1.0-2' }} kg</p>
+      <p class="mb-1 text-[10px] font-bold uppercase tracking-wide text-text-muted sm:text-[11px]">Volume estimé</p>
+      <p class="text-[15px] font-bold text-text-primary sm:text-base">{{ booking.weight | number:'1.0-2' }} kg</p>
     </div>
   </div>
 
   <!-- ── Card Footer: gain + action buttons ── -->
   <div
-    class="mt-auto flex items-end justify-between border-t border-border/50 px-5 py-3"
+    class="flex items-end justify-between border-t border-border/50 px-4 py-3 sm:px-5 xl:mt-auto"
   >
     <!-- Gain proposé -->
     <div>
-      <p class="mb-1 text-[11px] font-bold uppercase tracking-wide text-text-muted">Gain Proposé</p>
+      <p class="mb-1 text-[10px] font-bold uppercase tracking-wide text-text-muted sm:text-[11px]">Gain Proposé</p>
       @if (reservationAmount() !== null) {
-        <p class="text-xl font-bold text-primary">{{ reservationAmount()! | number:'1.0-2' }} €</p>
+        <p class="text-lg font-bold text-primary sm:text-xl">{{ reservationAmount()! | number:'1.0-2' }} €</p>
       } @else {
-        <p class="text-xl font-bold text-text-muted">—</p>
+        <p class="text-lg font-bold text-text-muted sm:text-xl">—</p>
       }
     </div>
 
@@ -86,7 +86,7 @@
       <!-- Details toggle -->
       <button
         type="button"
-        class="rounded-xl border px-4 py-2 text-sm transition focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:opacity-50"
+        class="rounded-xl border px-3.5 py-2 text-[13px] transition focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:opacity-50 sm:px-4 sm:text-sm"
         [class]="isDetailsOpen
           ? 'border-primary bg-background-primary text-primary'
           : 'border-border bg-background-secondary text-text-primary hover:bg-background-primary'"
@@ -101,7 +101,7 @@
       @if (booking.status === 'PENDING') {
         <button
           type="button"
-          class="rounded-xl bg-primary px-4 py-2 text-sm font-bold text-background-secondary transition hover:opacity-90 hover:shadow-primary-glow focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+          class="rounded-xl bg-primary px-3.5 py-2 text-[13px] font-bold text-background-secondary transition hover:opacity-90 hover:shadow-primary-glow focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 sm:px-4 sm:text-sm"
           [disabled]="isProcessing"
           (click)="onAccept()"
         >
@@ -113,7 +113,7 @@
       @if (booking.status === 'ACCEPTED') {
         <button
           type="button"
-          class="rounded-xl border border-error/30 bg-background-secondary px-4 py-2 text-sm font-bold text-error transition hover:bg-error/5 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-50"
+          class="rounded-xl border border-error/30 bg-background-secondary px-3.5 py-2 text-[13px] font-bold text-error transition hover:bg-error/5 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-50 sm:px-4 sm:text-sm"
           [disabled]="isProcessing"
           (click)="onRemove()"
         >

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.spec.ts
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.spec.ts
@@ -86,6 +86,37 @@ describe('BookingRequestCardComponent', () => {
     expect(component.confirmDelivery.emit).not.toHaveBeenCalled();
   });
 
+  it('returns the sender initial for the avatar badge', () => {
+    expect(component.senderInitial()).toBe('G');
+  });
+
+  it('renders the sender profile photo when available', () => {
+    component.booking = {
+      ...buildBooking(),
+      senderPhotoUrl: '/api/uploads/grace.png',
+    };
+
+    fixture.detectChanges();
+
+    const profileImage = fixture.nativeElement.querySelector('img[alt="Photo de profil de Grace Hopper"]');
+    expect(profileImage?.getAttribute('src')).toBe('/api/uploads/grace.png');
+  });
+
+  it('falls back to initials when the sender profile photo fails to load', () => {
+    component.booking = {
+      ...buildBooking(),
+      senderPhotoUrl: '/api/uploads/broken-grace.png',
+    };
+
+    fixture.detectChanges();
+    fixture.componentInstance.onSenderPhotoError();
+    fixture.detectChanges();
+
+    const profileImage = fixture.nativeElement.querySelector('img[alt="Photo de profil de Grace Hopper"]');
+    expect(profileImage).toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('G');
+  });
+
   it('does not render an invalidated-code information block', () => {
     component.booking = {
       ...buildBooking(),
@@ -111,6 +142,53 @@ describe('BookingRequestCardComponent', () => {
     expect(component.reservationAmount()).toBe(60);
     expect(fixture.nativeElement.textContent).toContain('60 €');
   });
+
+  it('starts collapsed (isDetailsOpen is false by default)', () => {
+    expect(component.isDetailsOpen).toBeFalse();
+  });
+
+  it('toggleDetails() opens the details panel', () => {
+    expect(component.isDetailsOpen).toBeFalse();
+
+    component.toggleDetails();
+
+    expect(component.isDetailsOpen).toBeTrue();
+  });
+
+  it('toggleDetails() collapses the details panel when already open', () => {
+    component.isDetailsOpen = true;
+
+    component.toggleDetails();
+
+    expect(component.isDetailsOpen).toBeFalse();
+  });
+
+  it('details panel is not rendered when isDetailsOpen is false', () => {
+    component.isDetailsOpen = false;
+    fixture.detectChanges();
+
+    // Recipient contact only appears inside the details panel
+    expect(fixture.nativeElement.textContent).not.toContain('+22501020304');
+  });
+
+  it('details panel shows recipient contact when isDetailsOpen is true', () => {
+    component.isDetailsOpen = true;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('+22501020304');
+  });
+
+  it('statusBadgeClass() returns neutral style for pending status', () => {
+    expect(component.statusBadgeClass('PENDING')).toContain('text-text-secondary');
+  });
+
+  it('statusBadgeClass() returns green/secondary style for accepted status', () => {
+    expect(component.statusBadgeClass('ACCEPTED')).toContain('text-secondary');
+  });
+
+  it('statusBadgeClass() returns red style for rejected status', () => {
+    expect(component.statusBadgeClass('REJECTED')).toContain('text-error');
+  });
 });
 
 function buildBooking(): BookingResponse {
@@ -119,6 +197,7 @@ function buildBooking(): BookingResponse {
     tripId: 12,
     senderId: 99,
     senderName: 'Grace Hopper',
+    senderPhotoUrl: undefined,
     title: 'Valise cabine',
     weight: 4,
     description: 'Objets personnels',

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.spec.ts
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.spec.ts
@@ -15,6 +15,7 @@ describe('BookingRequestCardComponent', () => {
     component = fixture.componentInstance;
     component.tripId = 12;
     component.tripStatus = 'ACTIVE';
+    component.pricePerKilo = 15;
     component.booking = buildBooking();
     fixture.detectChanges();
   });
@@ -96,6 +97,19 @@ describe('BookingRequestCardComponent', () => {
 
     expect(fixture.nativeElement.textContent).not.toContain('Code invalidé');
     expect(fixture.nativeElement.textContent).not.toContain('Invalidé le');
+  });
+
+  it('renders the reservation amount when the trip price per kilo is available', () => {
+    component.booking = {
+      ...buildBooking(),
+      weight: 4,
+    };
+    component.pricePerKilo = 15;
+
+    fixture.detectChanges();
+
+    expect(component.reservationAmount()).toBe(60);
+    expect(fixture.nativeElement.textContent).toContain('60 €');
   });
 });
 

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.spec.ts
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.spec.ts
@@ -1,0 +1,103 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BookingResponse } from '../../../models/booking.model';
+import { BookingRequestCardComponent } from './booking-request-card.component';
+
+describe('BookingRequestCardComponent', () => {
+  let fixture: ComponentFixture<BookingRequestCardComponent>;
+  let component: BookingRequestCardComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BookingRequestCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BookingRequestCardComponent);
+    component = fixture.componentInstance;
+    component.tripId = 12;
+    component.tripStatus = 'ACTIVE';
+    component.booking = buildBooking();
+    fixture.detectChanges();
+  });
+
+  it('emits the booking id when accepting a pending request', () => {
+    spyOn(component.accept, 'emit');
+
+    component.onAccept();
+
+    expect(component.accept.emit).toHaveBeenCalledWith(7);
+  });
+
+  it('emits the booking id when rejecting a pending request', () => {
+    spyOn(component.reject, 'emit');
+
+    component.onReject();
+
+    expect(component.reject.emit).toHaveBeenCalledWith(7);
+  });
+
+  it('emits the booking id when removing an accepted request', () => {
+    component.booking = { ...buildBooking(), status: 'ACCEPTED' };
+    spyOn(component.remove, 'emit');
+
+    component.onRemove();
+
+    expect(component.remove.emit).toHaveBeenCalledWith(7);
+  });
+
+  it('emits the booking id when messaging the sender', () => {
+    spyOn(component.message, 'emit');
+
+    component.onMessage();
+
+    expect(component.message.emit).toHaveBeenCalledWith(7);
+  });
+
+  it('emits the delivery confirmation payload with a valid six-digit code', () => {
+    component.booking = {
+      ...buildBooking(),
+      status: 'ACCEPTED',
+      validationCodeActive: true,
+    };
+    component.tripStatus = 'COMPLETED';
+    component.deliveryCode = '123456';
+    spyOn(component.confirmDelivery, 'emit');
+
+    component.onConfirmDelivery();
+
+    expect(component.confirmDelivery.emit).toHaveBeenCalledWith({
+      bookingId: 7,
+      code: '123456',
+    });
+  });
+
+  it('does not emit the delivery confirmation payload with an invalid code', () => {
+    component.booking = {
+      ...buildBooking(),
+      status: 'ACCEPTED',
+      validationCodeActive: true,
+    };
+    component.tripStatus = 'COMPLETED';
+    component.deliveryCode = '12345';
+    spyOn(component.confirmDelivery, 'emit');
+
+    component.onConfirmDelivery();
+
+    expect(component.confirmDelivery.emit).not.toHaveBeenCalled();
+  });
+});
+
+function buildBooking(): BookingResponse {
+  return {
+    id: 7,
+    tripId: 12,
+    senderId: 99,
+    senderName: 'Grace Hopper',
+    title: 'Valise cabine',
+    weight: 4,
+    description: 'Objets personnels',
+    packagePhotoUrl: 'https://example.com/package.png',
+    recipientContact: '+22501020304',
+    status: 'PENDING',
+    validationCodeActive: false,
+  };
+}

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.spec.ts
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.spec.ts
@@ -84,6 +84,19 @@ describe('BookingRequestCardComponent', () => {
 
     expect(component.confirmDelivery.emit).not.toHaveBeenCalled();
   });
+
+  it('does not render an invalidated-code information block', () => {
+    component.booking = {
+      ...buildBooking(),
+      status: 'ACCEPTED',
+      validationCodeInvalidatedAt: '2026-05-22T15:08:00',
+    };
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain('Code invalidé');
+    expect(fixture.nativeElement.textContent).not.toContain('Invalidé le');
+  });
 });
 
 function buildBooking(): BookingResponse {

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.ts
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.ts
@@ -1,0 +1,101 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { BookingResponse } from '../../../models/booking.model';
+import { Trip } from '../../../models/trip.model';
+
+@Component({
+  selector: 'app-booking-request-card',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './booking-request-card.component.html',
+})
+export class BookingRequestCardComponent {
+  @Input({ required: true }) booking!: BookingResponse;
+  @Input({ required: true }) tripStatus!: Trip['status'];
+  @Input() isProcessing = false;
+  @Input({ required: true }) tripId!: number;
+
+  @Output() accept = new EventEmitter<number>();
+  @Output() reject = new EventEmitter<number>();
+  @Output() remove = new EventEmitter<number>();
+  @Output() message = new EventEmitter<number>();
+  @Output() confirmDelivery = new EventEmitter<{ bookingId: number; code: string }>();
+
+  deliveryCode = '';
+
+  statusLabel(status: BookingResponse['status']): string {
+    return ({
+      PENDING: 'En attente',
+      ACCEPTED: 'Acceptée',
+      REJECTED: 'Refusée',
+      CANCELLED: 'Annulée',
+      REMOVED: 'Retirée',
+    } as Record<BookingResponse['status'], string>)[status];
+  }
+
+  statusClass(status: BookingResponse['status']): string {
+    return ({
+      PENDING: 'border-warning/20 bg-warning/10 text-warning',
+      ACCEPTED: 'border-success/20 bg-success/10 text-success',
+      REJECTED: 'border-error/20 bg-error/10 text-error',
+      CANCELLED: 'border-error/20 bg-error/10 text-error',
+      REMOVED: 'border-text-muted/20 bg-background-primary text-text-muted',
+    } as Record<BookingResponse['status'], string>)[status];
+  }
+
+  validationChannelLabel(channel?: BookingResponse['validationDeliveryChannel']): string {
+    return channel === 'SMS' ? 'SMS' : 'e-mail';
+  }
+
+  canShowConfirmDelivery(): boolean {
+    return this.tripStatus === 'COMPLETED'
+      && this.booking.status === 'ACCEPTED'
+      && this.booking.validationCodeActive
+      && !this.booking.deliveredAt;
+  }
+
+  onAccept(): void {
+    if (this.isProcessing) {
+      return;
+    }
+
+    this.accept.emit(this.booking.id);
+  }
+
+  onReject(): void {
+    if (this.isProcessing) {
+      return;
+    }
+
+    this.reject.emit(this.booking.id);
+  }
+
+  onRemove(): void {
+    if (this.isProcessing) {
+      return;
+    }
+
+    this.remove.emit(this.booking.id);
+  }
+
+  onMessage(): void {
+    if (this.isProcessing) {
+      return;
+    }
+
+    this.message.emit(this.booking.id);
+  }
+
+  onConfirmDelivery(): void {
+    if (this.isProcessing) {
+      return;
+    }
+
+    const code = this.deliveryCode.trim();
+    if (!/^\d{6}$/.test(code)) {
+      return;
+    }
+
+    this.confirmDelivery.emit({ bookingId: this.booking.id, code });
+  }
+}

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.ts
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.ts
@@ -8,7 +8,7 @@ import { Trip } from '../../../models/trip.model';
   standalone: true,
   imports: [CommonModule],
   host: {
-    class: 'block h-full',
+    class: 'block xl:h-full',
   },
   templateUrl: './booking-request-card.component.html',
 })

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.ts
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.ts
@@ -7,6 +7,9 @@ import { Trip } from '../../../models/trip.model';
   selector: 'app-booking-request-card',
   standalone: true,
   imports: [CommonModule],
+  host: {
+    class: 'block h-full',
+  },
   templateUrl: './booking-request-card.component.html',
 })
 export class BookingRequestCardComponent {
@@ -23,6 +26,9 @@ export class BookingRequestCardComponent {
   @Output() confirmDelivery = new EventEmitter<{ bookingId: number; code: string }>();
 
   deliveryCode = '';
+  isDetailsOpen = false;
+  private senderPhotoLoadFailed = false;
+  private lastSenderPhotoUrl: string | null = null;
 
   statusLabel(status: BookingResponse['status']): string {
     return ({
@@ -34,14 +40,42 @@ export class BookingRequestCardComponent {
     } as Record<BookingResponse['status'], string>)[status];
   }
 
-  statusClass(status: BookingResponse['status']): string {
+  /**
+   * Returns Tailwind classes for the compact status badge in the card header.
+   * Maps each status to a pill-shaped badge matching the mockup palette.
+   */
+  statusBadgeClass(status: BookingResponse['status']): string {
     return ({
-      PENDING: 'border-warning/20 bg-warning/10 text-warning',
-      ACCEPTED: 'border-success/20 bg-success/10 text-success',
-      REJECTED: 'border-error/20 bg-error/10 text-error',
-      CANCELLED: 'border-error/20 bg-error/10 text-error',
-      REMOVED: 'border-text-muted/20 bg-background-primary text-text-muted',
+      PENDING: 'bg-border text-text-secondary',
+      ACCEPTED: 'bg-secondary/10 text-secondary',
+      REJECTED: 'bg-error/10 text-error',
+      CANCELLED: 'bg-error/10 text-error',
+      REMOVED: 'bg-background-primary text-text-muted',
     } as Record<BookingResponse['status'], string>)[status];
+  }
+
+  senderInitial(): string {
+    return this.booking.senderName?.trim().charAt(0).toUpperCase() || '?';
+  }
+
+  senderPhotoUrl(): string | null {
+    const photoUrl = this.booking.senderPhotoUrl?.trim() ?? null;
+    if (!photoUrl) {
+      this.senderPhotoLoadFailed = false;
+      this.lastSenderPhotoUrl = null;
+      return null;
+    }
+
+    if (photoUrl !== this.lastSenderPhotoUrl) {
+      this.senderPhotoLoadFailed = false;
+      this.lastSenderPhotoUrl = photoUrl;
+    }
+
+    return this.senderPhotoLoadFailed ? null : photoUrl;
+  }
+
+  onSenderPhotoError(): void {
+    this.senderPhotoLoadFailed = true;
   }
 
   validationChannelLabel(channel?: BookingResponse['validationDeliveryChannel']): string {
@@ -66,6 +100,10 @@ export class BookingRequestCardComponent {
       && this.booking.status === 'ACCEPTED'
       && this.booking.validationCodeActive
       && !this.booking.deliveredAt;
+  }
+
+  toggleDetails(): void {
+    this.isDetailsOpen = !this.isDetailsOpen;
   }
 
   onAccept(): void {

--- a/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.ts
+++ b/front-office/src/app/components/reservation-details/booking-request-card/booking-request-card.component.ts
@@ -14,6 +14,7 @@ export class BookingRequestCardComponent {
   @Input({ required: true }) tripStatus!: Trip['status'];
   @Input() isProcessing = false;
   @Input({ required: true }) tripId!: number;
+  @Input() pricePerKilo: number | null = null;
 
   @Output() accept = new EventEmitter<number>();
   @Output() reject = new EventEmitter<number>();
@@ -45,6 +46,19 @@ export class BookingRequestCardComponent {
 
   validationChannelLabel(channel?: BookingResponse['validationDeliveryChannel']): string {
     return channel === 'SMS' ? 'SMS' : 'e-mail';
+  }
+
+  reservationAmount(): number | null {
+    if (
+      this.pricePerKilo === null
+      || this.pricePerKilo === undefined
+      || Number.isNaN(this.pricePerKilo)
+      || Number.isNaN(this.booking.weight)
+    ) {
+      return null;
+    }
+
+    return this.booking.weight * this.pricePerKilo;
   }
 
   canShowConfirmDelivery(): boolean {

--- a/front-office/src/app/models/booking.model.ts
+++ b/front-office/src/app/models/booking.model.ts
@@ -15,6 +15,7 @@ export interface BookingResponse {
   tripId: number;
   senderId: number;
   senderName: string;
+  senderPhotoUrl?: string;
   title: string;
   weight: number;
   description?: string;

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.html
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.html
@@ -296,10 +296,22 @@
                 </a>
               </div>
             } @else {
+              @if (receivedTripsActionError) {
+                <div class="mb-4 rounded-lg bg-error/10 px-4 py-3 text-sm text-error" role="alert">
+                  {{ receivedTripsActionError }}
+                </div>
+              }
+
+              @if (shareCardError) {
+                <div class="mb-4 rounded-lg bg-error/10 px-4 py-3 text-sm text-error" role="alert">
+                  {{ shareCardError }}
+                </div>
+              }
+
               <app-traveler-trips-desktop-list
                 [trips]="myTrips"
                 [tripBookingsMap]="tripBookingsMap"
-                [selectedTripId]="selectedTripId"
+                [selectedTripId]="null"
                 [generatingShareCardTripId]="generatingShareCardTripId"
                 [isCancellingTrip]="isCancellingTrip"
                 [isDeletingTrip]="isDeletingTrip"
@@ -318,7 +330,7 @@
                   <app-dashboard-received-mobile-card
                     [trip]="trip"
                     [bookingCount]="(tripBookingsMap[trip.id] || []).length"
-                    [isSelected]="selectedTripId === trip.id"
+                    [isSelected]="false"
                     [isGeneratingShareCard]="generatingShareCardTripId === trip.id"
                     [isCompletingTrip]="completingTripId === trip.id"
                     (viewTrip)="selectTrip($event)"
@@ -329,141 +341,6 @@
                   />
                 }
               </div>
-
-              <!-- Bookings for the selected trip -->
-              @if (selectedTripId !== null) {
-                <div class="mt-6">
-                  <div class="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <h3 class="font-semibold text-text-primary text-sm">Demandes pour ce trajet</h3>
-                    @if (selectedTrip()?.status === 'ACTIVE') {
-                      <button
-                        type="button"
-                        (click)="downloadShareCardPng()"
-                        [disabled]="!canGenerateShareCard()"
-                        class="inline-flex items-center justify-center rounded-lg bg-accent px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50 lg:hidden"
-                      >
-                        {{ isGeneratingShareCard ? 'Génération…' : 'Télécharger la carte PNG' }}
-                      </button>
-                    }
-                  </div>
-
-                  @if (shareCardError) {
-                    <div class="mb-3 rounded-lg bg-error/10 px-4 py-3 text-sm text-error" role="alert">
-                      {{ shareCardError }}
-                    </div>
-                  }
-
-                  @if (bookingActionError) {
-                    <div class="bg-red-50 text-error text-sm px-4 py-3 rounded-lg mb-3" role="alert">
-                      {{ bookingActionError }}
-                    </div>
-                  }
-
-                  @if (isLoadingBookings) {
-                    <div class="flex justify-center py-6" aria-label="Chargement en cours">
-                      <div class="w-6 h-6 border-2 border-secondary border-t-transparent rounded-full animate-spin"></div>
-                    </div>
-                  } @else if (selectedTripBookings.length === 0) {
-                    <p class="text-text-secondary text-sm">Aucune demande reçue pour ce trajet.</p>
-                  } @else {
-                    <div class="space-y-3">
-                      @for (booking of selectedTripBookings; track booking.id) {
-                        <div class="bg-white border border-gray-100 rounded-xl p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                          <div>
-                            <p class="font-medium text-text-primary text-sm">{{ booking.senderName }}</p>
-                            <p class="text-text-secondary text-xs">{{ booking.title }} · {{ booking.weight }} kg</p>
-                            <p class="text-text-muted text-xs mt-1">Contact destinataire : {{ booking.recipientContact }}</p>
-                            @if (booking.description) {
-                              <p class="text-text-muted text-xs mt-1">{{ booking.description }}</p>
-                            }
-                            @if (booking.validationCodeActive && booking.validationDeliveryChannel && booking.validationCodeSentAt) {
-                              <p class="text-success text-xs mt-1">
-                                Code actif envoyé par {{ validationChannelLabel(booking.validationDeliveryChannel) }}
-                                le {{ booking.validationCodeSentAt | date:'dd/MM/yyyy HH:mm' }}
-                              </p>
-                            } @else if (booking.validationDeliveryStatus === 'FAILED' && booking.validationCodeDeliveryFailedAt) {
-                              <p class="text-warning text-xs mt-1">
-                                L'envoi du code a échoué le {{ booking.validationCodeDeliveryFailedAt | date:'dd/MM/yyyy HH:mm' }}.
-                              </p>
-                            } @else if (booking.validationCodeInvalidatedAt) {
-                              <p class="text-warning text-xs mt-1">
-                                Code invalidé le {{ booking.validationCodeInvalidatedAt | date:'dd/MM/yyyy HH:mm' }}
-                              </p>
-                            }
-                            @if (booking.deliveredAt) {
-                              <p class="text-success text-xs mt-1">
-                                Colis remis le {{ booking.deliveredAt | date:'dd/MM/yyyy HH:mm' }}
-                              </p>
-                            }
-                          </div>
-                          <div class="flex items-center gap-2 shrink-0">
-                            <!-- Status badge -->
-                            <span [class]="statusClass(booking.status) + ' text-xs font-medium px-2.5 py-1 rounded-full'">
-                              {{ statusLabel(booking.status) }}
-                            </span>
-                            <!-- Accept / Reject actions (only for pending bookings) -->
-                            @if (booking.status === 'PENDING') {
-                              <button
-                                (click)="acceptBooking(booking.id)"
-                                class="bg-success text-white text-xs font-semibold px-3 py-1.5 rounded-lg hover:bg-opacity-90 transition-colors"
-                              >
-                                Accepter
-                              </button>
-                              <button
-                                (click)="rejectBooking(booking.id)"
-                                class="bg-error text-white text-xs font-semibold px-3 py-1.5 rounded-lg hover:bg-opacity-90 transition-colors"
-                              >
-                                Refuser
-                              </button>
-                            }
-                            <!-- Remove action (only for accepted bookings) -->
-                            @if (booking.status === 'ACCEPTED') {
-                              <button
-                                (click)="removeBooking(booking.id)"
-                                class="bg-gray-500 text-white text-xs font-semibold px-3 py-1.5 rounded-lg hover:bg-opacity-90 transition-colors"
-                              >
-                                Retirer
-                              </button>
-                            }
-                          </div>
-                        </div>
-                        @if (booking.status === 'ACCEPTED') {
-                          <div class="mt-2 rounded-xl border border-gray-100 bg-background-secondary p-4">
-                            @if (selectedTrip()?.status !== 'COMPLETED') {
-                              <p class="text-xs text-text-muted">
-                                Marquez d'abord le trajet comme effectué pour confirmer la remise du colis.
-                              </p>
-                            } @else if (!booking.validationCodeActive) {
-                              <p class="text-xs text-text-muted">
-                                Aucun code actif n'est disponible pour cette réservation.
-                              </p>
-                            } @else {
-                              <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-                                <input
-                                  type="text"
-                                  inputmode="numeric"
-                                  maxlength="6"
-                                  [(ngModel)]="deliveryCodeByBookingId[booking.id]"
-                                  placeholder="Code à 6 chiffres"
-                                  class="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-secondary focus:border-secondary sm:max-w-xs"
-                                />
-                                <button
-                                  type="button"
-                                  (click)="confirmDelivery(booking)"
-                                  [disabled]="validatingDeliveryBookingId === booking.id"
-                                  class="btn-primary !px-5 !py-2.5 !text-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                                >
-                                  {{ validatingDeliveryBookingId === booking.id ? 'Validation…' : 'Confirmer la remise' }}
-                                </button>
-                              </div>
-                            }
-                          </div>
-                        }
-                      }
-                    </div>
-                  }
-                </div>
-              }
 
               @if (shareCardData) {
                 <div class="pointer-events-none fixed -left-[9999px] top-0 opacity-0" aria-hidden="true">
@@ -550,15 +427,3 @@
 
   </div>
 </div>
-
-<!-- ── Confirm remove booking modal ──────────────────────────────────────── -->
-<app-confirm-modal
-  [isOpen]="isRemoveModalOpen"
-  title="Retirer ce demandeur ?"
-  message="Cette action retirera définitivement ce demandeur de votre trajet. Il recevra une notification par email."
-  confirmLabel="Retirer"
-  variant="danger"
-  [isLoading]="isRemoving"
-  (confirmed)="confirmRemoveBooking()"
-  (cancelled)="cancelRemoveBooking()"
-/>

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.html
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.html
@@ -391,11 +391,7 @@
                         <p class="text-success text-xs mt-1">
                           Colis remis le {{ booking.deliveredAt | date:'dd/MM/yyyy HH:mm' }}
                         </p>
-                      } @else if (booking.validationCodeInvalidatedAt) {
-                        <p class="text-warning text-xs mt-1">
-                          Code invalidé le {{ booking.validationCodeInvalidatedAt | date:'dd/MM/yyyy HH:mm' }}
-                        </p>
-                      } @else if (booking.status === 'ACCEPTED') {
+                      } @else if (booking.status === 'ACCEPTED' && !booking.validationCodeInvalidatedAt) {
                         <p class="text-text-muted text-xs mt-1">
                           Le code de validation est en cours d’envoi au destinataire.
                         </p>

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.spec.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.spec.ts
@@ -182,7 +182,6 @@ describe('DashboardPageComponent', () => {
     component.activeTab = 'received';
     component.myTrips = [selectedTrip];
     component.tripBookingsMap = { [selectedTrip.id]: [] };
-    component.selectedTripId = selectedTrip.id;
 
     fixture.detectChanges();
 
@@ -246,7 +245,6 @@ describe('DashboardPageComponent', () => {
     component.activeTab = 'received';
     component.myTrips = [selectedTrip];
     component.tripBookingsMap = { [selectedTrip.id]: [] };
-    component.selectedTripId = selectedTrip.id;
     fixture.detectChanges();
 
     const requestAnimationFrameSpy = spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
@@ -272,32 +270,34 @@ describe('DashboardPageComponent', () => {
     expect(component.shareCardError).toBe('');
   });
 
-  it('selects the trip before downloading it from the desktop options menu', async () => {
+  it('downloads the requested trip share card from the desktop options menu', async () => {
     const selectedTrip = buildTrip();
     component.activeTab = 'received';
     component.myTrips = [selectedTrip];
     component.tripBookingsMap = { [selectedTrip.id]: [] };
-    spyOn(component, 'selectTrip').and.callThrough();
     spyOn(component, 'downloadShareCardPng').and.resolveTo();
 
     component.handleDesktopTripShareCardDownload(selectedTrip.id);
 
-    expect(component.selectTrip).toHaveBeenCalledWith(selectedTrip.id);
     expect(component.downloadShareCardPng).toHaveBeenCalledWith(selectedTrip.id);
   });
 
-  it('selects the trip before marking it as completed from the desktop options menu', () => {
+  it('marks the requested trip as completed from the desktop options menu', () => {
     const selectedTrip = buildTrip();
     component.activeTab = 'received';
     component.myTrips = [selectedTrip];
     component.tripBookingsMap = { [selectedTrip.id]: [] };
-    spyOn(component, 'selectTrip').and.callThrough();
     spyOn(component, 'completeTrip');
 
     component.handleDesktopTripCompletion(selectedTrip.id);
 
-    expect(component.selectTrip).toHaveBeenCalledWith(selectedTrip.id);
     expect(component.completeTrip).toHaveBeenCalledWith(selectedTrip.id);
+  });
+
+  it('navigates to the dedicated reservation details page when selecting a trip', () => {
+    component.selectTrip(12);
+
+    expect(router.navigate).toHaveBeenCalledWith(['/trips', 12, 'reservations']);
   });
 
   it('deletes a trip when deletion is possible', () => {
@@ -326,7 +326,7 @@ describe('DashboardPageComponent', () => {
 
     expect(window.confirm).not.toHaveBeenCalled();
     expect(tripServiceMock.cancelTrip).not.toHaveBeenCalled();
-    expect(component.bookingActionError).toContain('ne peut pas être supprimé');
+    expect(component.receivedTripsActionError).toContain('ne peut pas être supprimé');
   });
 
   it('uses the expected received-trip status mapping', () => {

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.ts
@@ -15,7 +15,6 @@ import { ShareCardMapperService } from '../../services/share-card-mapper.service
 import { ShareCardStoryComponent } from '../../components/share-card-story/share-card-story.component';
 import { TravelerTripsDesktopListComponent } from '../../components/dashboard/traveler-trips-desktop-list/traveler-trips-desktop-list.component';
 import { DashboardReceivedMobileCardComponent } from '../../components/dashboard/dashboard-received-mobile-card/dashboard-received-mobile-card.component';
-import { ConfirmModalComponent } from '../../shared/components/confirm-modal/confirm-modal.component';
 
 type Tab = 'profile' | 'chats' | 'received' | 'sent';
 
@@ -27,7 +26,6 @@ type Tab = 'profile' | 'chats' | 'received' | 'sent';
     FormsModule,
     ReactiveFormsModule,
     RouterLink,
-    ConfirmModalComponent,
     ShareCardStoryComponent,
     TravelerTripsDesktopListComponent,
     DashboardReceivedMobileCardComponent,
@@ -93,11 +91,8 @@ export class DashboardPageComponent implements OnInit {
   // ── Received reservations ─────────────────────────────────────────────────
   myTrips: Trip[] = [];
   tripBookingsMap: Record<number, BookingResponse[]> = {};
-  selectedTripBookings: BookingResponse[] = [];
-  selectedTripId: number | null = null;
   isLoadingTrips = false;
-  isLoadingBookings = false;
-  bookingActionError = '';
+  receivedTripsActionError = '';
   isCancellingTrip = false;
   isDeletingTrip = false;
   isCompletingTrip = false;
@@ -106,14 +101,6 @@ export class DashboardPageComponent implements OnInit {
   generatingShareCardTripId: number | null = null;
   shareCardError = '';
   shareCardData: ShareCardData | null = null;
-  deliveryCodeByBookingId: Record<number, string> = {};
-  validatingDeliveryBookingId: number | null = null;
-
-  // ── Remove booking confirmation modal ─────────────────────────────────────
-  isRemoveModalOpen = false;
-  pendingRemoveBookingId: number | null = null;
-  isRemoving = false;
-  pendingSelectTripId: number | null = null;
 
   // ── Sent requests ─────────────────────────────────────────────────────────
   myBookings: BookingResponse[] = [];
@@ -144,8 +131,6 @@ export class DashboardPageComponent implements OnInit {
     this.route.queryParamMap.subscribe((params) => {
       const tab = params.get('tab');
       if (this.isTab(tab)) this.setTab(tab);
-      const tripId = params.get('tripId');
-      if (tripId) this.pendingSelectTripId = Number(tripId);
     });
   }
 
@@ -303,6 +288,7 @@ export class DashboardPageComponent implements OnInit {
   // ── Received reservations ────────────────────────────────────────────────
   loadMyTrips(): void {
     this.isLoadingTrips = true;
+    this.receivedTripsActionError = '';
     this.tripService.getMyTrips().subscribe({
       next: (trips) => {
         this.myTrips = trips;
@@ -311,10 +297,6 @@ export class DashboardPageComponent implements OnInit {
         forkJoin(requests).subscribe((results) => {
           trips.forEach((t, i) => { this.tripBookingsMap[t.id] = results[i] as BookingResponse[]; });
           this.isLoadingTrips = false;
-          if (this.pendingSelectTripId) {
-            this.selectTrip(this.pendingSelectTripId);
-            this.pendingSelectTripId = null;
-          }
         });
       },
       error: () => { this.isLoadingTrips = false; },
@@ -322,16 +304,13 @@ export class DashboardPageComponent implements OnInit {
   }
 
   selectTrip(tripId: number): void {
-    this.selectedTripId = tripId;
-    this.bookingActionError = '';
-    this.shareCardError = '';
-    this.selectedTripBookings = this.tripBookingsMap[tripId] ?? [];
+    void this.router.navigate(['/trips', tripId, 'reservations']);
   }
 
   async downloadShareCardPng(tripId?: number): Promise<void> {
     const trip = typeof tripId === 'number'
       ? this.myTrips.find((currentTrip) => currentTrip.id === tripId)
-      : this.selectedTrip();
+      : undefined;
     const user = this.authService.getUser();
 
     if (!trip || trip.status !== 'ACTIVE' || !user) {
@@ -380,7 +359,7 @@ export class DashboardPageComponent implements OnInit {
 
     this.isCompletingTrip = true;
     this.completingTripId = tripId;
-    this.bookingActionError = '';
+    this.receivedTripsActionError = '';
     this.tripService.completeTrip(tripId).subscribe({
       next: (updatedTrip) => {
         const tripIndex = this.myTrips.findIndex((trip) => trip.id === updatedTrip.id);
@@ -391,7 +370,7 @@ export class DashboardPageComponent implements OnInit {
         this.completingTripId = null;
       },
       error: (err: { error?: { message?: string } }) => {
-        this.bookingActionError = err.error?.message || "Erreur lors du passage du trajet à l'état effectué.";
+        this.receivedTripsActionError = err.error?.message || "Erreur lors du passage du trajet à l'état effectué.";
         this.isCompletingTrip = false;
         this.completingTripId = null;
       },
@@ -399,12 +378,10 @@ export class DashboardPageComponent implements OnInit {
   }
 
   handleDesktopTripShareCardDownload(tripId: number): void {
-    this.selectTrip(tripId);
     void this.downloadShareCardPng(tripId);
   }
 
   handleDesktopTripCompletion(tripId: number): void {
-    this.selectTrip(tripId);
     this.completeTrip(tripId);
   }
 
@@ -420,112 +397,22 @@ export class DashboardPageComponent implements OnInit {
     this.cancelTrip(tripId);
   }
 
-  acceptBooking(bookingId: number): void {
-    if (!this.selectedTripId) return;
-    this.bookingActionError = '';
-    this.tripService.acceptBooking(this.selectedTripId, bookingId).subscribe({
-      next: (updated) => {
-        const idx = this.selectedTripBookings.findIndex((x) => x.id === updated.id);
-        if (idx >= 0) { this.selectedTripBookings[idx] = updated; this.tripBookingsMap[this.selectedTripId!][idx] = updated; }
-      },
-      error: () => { this.bookingActionError = "Erreur lors de l'acceptation."; },
-    });
-  }
-
-  rejectBooking(bookingId: number): void {
-    if (!this.selectedTripId) return;
-    this.bookingActionError = '';
-    this.tripService.rejectBooking(this.selectedTripId, bookingId).subscribe({
-      next: (updated) => {
-        const idx = this.selectedTripBookings.findIndex((x) => x.id === updated.id);
-        if (idx >= 0) { this.selectedTripBookings[idx] = updated; this.tripBookingsMap[this.selectedTripId!][idx] = updated; }
-      },
-      error: () => { this.bookingActionError = 'Erreur lors du refus.'; },
-    });
-  }
-
-  removeBooking(bookingId: number): void {
-    if (!this.selectedTripId) return;
-    this.pendingRemoveBookingId = bookingId;
-    this.isRemoveModalOpen = true;
-  }
-
-  confirmRemoveBooking(): void {
-    if (!this.selectedTripId || this.pendingRemoveBookingId === null) return;
-    this.isRemoving = true;
-    this.bookingActionError = '';
-    this.tripService.removeBooking(this.selectedTripId, this.pendingRemoveBookingId).subscribe({
-      next: () => {
-        this.selectedTripBookings = this.selectedTripBookings.filter(
-          (b) => b.id !== this.pendingRemoveBookingId
-        );
-        this.tripBookingsMap[this.selectedTripId!] = this.selectedTripBookings;
-        this.isRemoveModalOpen = false;
-        this.pendingRemoveBookingId = null;
-        this.isRemoving = false;
-      },
-      error: () => {
-        this.bookingActionError = 'Erreur lors du retrait du demandeur.';
-        this.isRemoveModalOpen = false;
-        this.pendingRemoveBookingId = null;
-        this.isRemoving = false;
-      },
-    });
-  }
-
-  cancelRemoveBooking(): void {
-    this.isRemoveModalOpen = false;
-    this.pendingRemoveBookingId = null;
-  }
-
-  confirmDelivery(booking: BookingResponse): void {
-    if (!this.selectedTripId || this.validatingDeliveryBookingId !== null) return;
-
-    const validationCode = (this.deliveryCodeByBookingId[booking.id] ?? '').trim();
-    if (!/^\d{6}$/.test(validationCode)) {
-      this.bookingActionError = 'Saisissez un code de validation à 6 chiffres.';
-      return;
-    }
-
-    this.validatingDeliveryBookingId = booking.id;
-    this.bookingActionError = '';
-    this.tripService.confirmBookingDelivery(this.selectedTripId, booking.id, { validationCode }).subscribe({
-      next: (updated) => {
-        const idx = this.selectedTripBookings.findIndex((x) => x.id === updated.id);
-        if (idx >= 0) {
-          this.selectedTripBookings[idx] = updated;
-          this.tripBookingsMap[this.selectedTripId!][idx] = updated;
-        }
-        const senderBookingIdx = this.myBookings.findIndex((x) => x.id === updated.id);
-        if (senderBookingIdx >= 0) {
-          this.myBookings[senderBookingIdx] = updated;
-        }
-        delete this.deliveryCodeByBookingId[booking.id];
-        this.validatingDeliveryBookingId = null;
-      },
-      error: (err: { error?: { message?: string } }) => {
-        this.bookingActionError = err.error?.message || 'Erreur lors de la validation de la remise.';
-        this.validatingDeliveryBookingId = null;
-      },
-    });
-  }
-
   deleteTrip(tripId: number): void {
     if ((this.tripBookingsMap[tripId] ?? []).length > 0) {
-      this.bookingActionError = 'Ce trajet ne peut pas être supprimé car il a déjà reçu des demandes.';
+      this.receivedTripsActionError = 'Ce trajet ne peut pas être supprimé car il a déjà reçu des demandes.';
       return;
     }
 
     if (!confirm('Êtes-vous sûr de vouloir supprimer ce trajet ?')) return;
     this.isDeletingTrip = true;
-    this.bookingActionError = '';
+    this.receivedTripsActionError = '';
     this.tripService.cancelTrip(tripId).subscribe({
       next: () => {
         this.removeTripFromState(tripId);
         this.isDeletingTrip = false;
       },
       error: () => {
-        this.bookingActionError = 'Erreur lors de la suppression du trajet.';
+        this.receivedTripsActionError = 'Erreur lors de la suppression du trajet.';
         this.isDeletingTrip = false;
       },
     });
@@ -534,13 +421,13 @@ export class DashboardPageComponent implements OnInit {
   cancelTrip(tripId: number): void {
     if (!confirm('Êtes-vous sûr de vouloir annuler ce trajet ? Tous les demandeurs seront notifiés.')) return;
     this.isCancellingTrip = true;
-    this.bookingActionError = '';
+    this.receivedTripsActionError = '';
     this.tripService.cancelTrip(tripId).subscribe({
       next: () => {
         this.removeTripFromState(tripId);
         this.isCancellingTrip = false;
       },
-      error: () => { this.bookingActionError = "Erreur lors de l'annulation du trajet."; this.isCancellingTrip = false; },
+      error: () => { this.receivedTripsActionError = "Erreur lors de l'annulation du trajet."; this.isCancellingTrip = false; },
     });
   }
 
@@ -583,20 +470,6 @@ export class DashboardPageComponent implements OnInit {
     return ({ ACTIVE: 'bg-accent/10 text-accent', COMPLETED: 'bg-success/10 text-success', CANCELLED: 'bg-background-primary text-text-muted' } as Record<Trip['status'], string>)[status];
   }
 
-  selectedTrip(): Trip | undefined {
-    return this.myTrips.find((trip) => trip.id === this.selectedTripId);
-  }
-
-  canValidateDelivery(booking: BookingResponse): boolean {
-    return this.selectedTrip()?.status === 'COMPLETED'
-      && booking.status === 'ACCEPTED'
-      && booking.validationCodeActive;
-  }
-
-  canGenerateShareCard(): boolean {
-    return this.selectedTrip()?.status === 'ACTIVE' && !this.isGeneratingShareCard;
-  }
-
   private generatePngFromElement(element: HTMLElement): Promise<string> {
     return htmlToImage.toPng(element, {
       cacheBust: true,
@@ -607,10 +480,5 @@ export class DashboardPageComponent implements OnInit {
   private removeTripFromState(tripId: number): void {
     this.myTrips = this.myTrips.filter((trip) => trip.id !== tripId);
     delete this.tripBookingsMap[tripId];
-
-    if (this.selectedTripId === tripId) {
-      this.selectedTripId = null;
-      this.selectedTripBookings = [];
-    }
   }
 }

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
@@ -1,0 +1,206 @@
+<div class="min-h-screen bg-background-primary pt-20 pb-12 font-['Poppins']">
+  <div class="mx-auto flex max-w-6xl flex-col gap-6 px-4 sm:px-6 lg:px-8">
+    <a
+      [routerLink]="['/dashboard']"
+      [queryParams]="{ tab: 'received' }"
+      class="inline-flex w-fit items-center gap-2 rounded-full border border-background-primary bg-background-secondary px-4 py-2 text-sm font-medium text-text-secondary transition hover:border-secondary hover:text-secondary focus:outline-none focus:ring-2 focus:ring-secondary/20"
+      aria-label="Retour aux réservations reçues"
+    >
+      <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+      </svg>
+      Retour aux réservations reçues
+    </a>
+
+    @if (isLoading && !trip) {
+      <section class="rounded-2xl border border-background-primary bg-background-secondary px-5 py-16 text-center shadow-sm" role="status" aria-live="polite">
+        <div class="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-secondary/20 border-t-secondary"></div>
+        <p class="mt-4 text-sm font-medium text-text-secondary">Chargement des demandes...</p>
+      </section>
+    } @else if (loadError && !trip) {
+      <section class="rounded-2xl border border-error/20 bg-error/10 px-5 py-12 text-center shadow-sm" role="alert">
+        <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-error/15 text-error">
+          <svg class="h-7 w-7" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3m0 4h.01M4.93 19h14.14c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.2 16c-.77 1.33.19 3 1.73 3Z" />
+          </svg>
+        </div>
+        <h1 class="mt-4 text-xl font-bold text-text-primary">Impossible d’afficher cette réservation</h1>
+        <p class="mt-2 text-sm text-error">{{ loadError }}</p>
+      </section>
+    } @else if (trip) {
+      <section class="overflow-hidden rounded-2xl border border-background-primary bg-background-secondary shadow-sm">
+        <div class="bg-primary px-5 py-6 text-white sm:px-6 lg:px-8">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div class="space-y-3">
+              <p class="text-xs font-semibold uppercase tracking-[0.18em] text-white/70">Détails du trajet</p>
+              <h1 class="text-2xl font-bold leading-tight sm:text-3xl">
+                {{ trip.departureAddress }} <span class="text-secondary">→</span> {{ trip.destination }}
+              </h1>
+              <div class="flex flex-wrap items-center gap-3 text-sm text-white/80">
+                <span class="inline-flex items-center gap-2">
+                  <svg class="h-4 w-4 text-secondary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z" />
+                  </svg>
+                  {{ trip.departureTime | date:'dd/MM/yyyy • HH:mm' }}
+                </span>
+              </div>
+            </div>
+
+            <span
+              class="inline-flex w-fit items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em]"
+              [class]="tripStatusClass(trip.status)"
+              role="status"
+            >
+              <span class="h-2 w-2 rounded-full bg-current"></span>
+              {{ tripStatusLabel(trip.status) }}
+            </span>
+          </div>
+        </div>
+
+        <div class="grid gap-3 px-5 py-5 sm:grid-cols-2 lg:grid-cols-4 sm:px-6 lg:px-8">
+          <div class="rounded-2xl bg-background-primary p-4">
+            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Poids max</p>
+            <p class="mt-2 text-lg font-bold text-text-primary">{{ trip.maxWeight | number:'1.0-2' }} kg</p>
+          </div>
+          <div class="rounded-2xl bg-background-primary p-4">
+            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Prix / kilo</p>
+            <p class="mt-2 text-lg font-bold text-secondary">{{ trip.pricePerKilo | number:'1.0-2' }} €</p>
+          </div>
+          <div class="rounded-2xl bg-background-primary p-4">
+            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Poids disponible</p>
+            <p class="mt-2 text-lg font-bold text-text-primary">{{ trip.availableWeight | number:'1.0-2' }} kg</p>
+          </div>
+          <div class="rounded-2xl bg-background-primary p-4">
+            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Réservations</p>
+            <p class="mt-2 text-lg font-bold text-text-primary">{{ bookings.length }}</p>
+          </div>
+        </div>
+      </section>
+
+      @if (trip.status === 'ACTIVE') {
+        <section class="rounded-2xl border border-background-primary bg-background-secondary p-4 shadow-sm sm:p-5">
+          <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            <button
+              type="button"
+              class="inline-flex items-center justify-center gap-2 rounded-xl bg-secondary px-4 py-3 text-sm font-semibold text-white transition hover:bg-secondary/90 focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-60"
+              [disabled]="isCompletingTrip || isCancellingTrip"
+              (click)="editTrip()"
+            >
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 20h4l10.5-10.5a2.121 2.121 0 1 0-3-3L5 17v3Z" />
+              </svg>
+              Modifier le trajet
+            </button>
+
+            <button
+              type="button"
+              class="inline-flex items-center justify-center gap-2 rounded-xl bg-success px-4 py-3 text-sm font-semibold text-white transition hover:bg-success/90 focus:outline-none focus:ring-2 focus:ring-success/20 disabled:cursor-not-allowed disabled:opacity-60"
+              [disabled]="isCompletingTrip || isCancellingTrip"
+              (click)="markTripCompleted()"
+            >
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m5 13 4 4L19 7" />
+              </svg>
+              {{ isCompletingTrip ? 'Validation...' : 'Marquer comme terminé' }}
+            </button>
+
+            <button
+              type="button"
+              class="inline-flex items-center justify-center gap-2 rounded-xl bg-error px-4 py-3 text-sm font-semibold text-white transition hover:bg-error/90 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-60"
+              [disabled]="isCompletingTrip || isCancellingTrip"
+              (click)="openCancelTripModal()"
+            >
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m6 6 12 12M18 6 6 18" />
+              </svg>
+              {{ isCancellingTrip ? 'Annulation...' : 'Annuler le trajet' }}
+            </button>
+          </div>
+        </section>
+      }
+
+      @if (actionError) {
+        <div class="rounded-2xl border border-error/20 bg-error/10 px-4 py-3 text-sm text-error shadow-sm" role="alert">
+          {{ actionError }}
+        </div>
+      }
+
+      <section class="rounded-2xl border border-background-primary bg-background-secondary p-5 shadow-sm sm:p-6" aria-labelledby="booking-requests-title">
+        <div class="mb-5 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 id="booking-requests-title" class="text-xl font-bold text-text-primary">Demandes de réservation</h2>
+            <p class="text-sm text-text-secondary">Consultez et gérez les colis liés à ce trajet.</p>
+          </div>
+          <span class="inline-flex w-fit items-center rounded-full bg-background-primary px-3 py-1 text-xs font-semibold text-text-secondary">
+            {{ bookings.length }} demande{{ bookings.length > 1 ? 's' : '' }}
+          </span>
+        </div>
+
+        @if (isLoading) {
+          <div class="flex flex-col items-center justify-center py-16 text-center" role="status" aria-live="polite">
+            <div class="h-12 w-12 animate-spin rounded-full border-4 border-secondary/20 border-t-secondary"></div>
+            <p class="mt-4 text-sm font-medium text-text-secondary">Chargement des demandes...</p>
+          </div>
+        } @else if (loadError) {
+          <div class="rounded-2xl border border-error/20 bg-error/10 px-5 py-6 text-center" role="alert">
+            <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-error/15 text-error">
+              <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3m0 4h.01M4.93 19h14.14c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.2 16c-.77 1.33.19 3 1.73 3Z" />
+              </svg>
+            </div>
+            <p class="mt-4 text-sm font-medium text-error">{{ loadError }}</p>
+          </div>
+        } @else if (!bookings || bookings.length === 0) {
+          <div class="rounded-2xl bg-background-primary px-5 py-12 text-center">
+            <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-secondary/10 text-secondary">
+              <svg class="h-7 w-7" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M20 13V7a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v6m16 0-2.59 0a1 1 0 0 0-.7.29l-1.42 1.42a1 1 0 0 1-.7.29h-3.18a1 1 0 0 1-.7-.29l-1.42-1.42a1 1 0 0 0-.7-.29H4" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 13v5a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-5" />
+              </svg>
+            </div>
+            <h3 class="mt-4 text-lg font-semibold text-text-primary">Aucune demande pour le moment</h3>
+            <p class="mt-2 text-sm text-text-secondary">Les nouvelles demandes de réservation apparaîtront ici dès qu'un expéditeur réservera ce trajet.</p>
+          </div>
+        } @else {
+          <div class="space-y-4">
+            @for (booking of bookings; track booking.id) {
+              <app-booking-request-card
+                [booking]="booking"
+                [tripStatus]="trip.status"
+                [isProcessing]="isBookingProcessing(booking.id)"
+                [tripId]="trip.id"
+                (accept)="acceptBooking($event)"
+                (reject)="rejectBooking($event)"
+                (remove)="openRemoveBookingModal($event)"
+                (message)="messageSender($event)"
+                (confirmDelivery)="confirmBookingDelivery($event)"
+              />
+            }
+          </div>
+        }
+      </section>
+    }
+  </div>
+</div>
+
+<app-confirm-modal
+  [isOpen]="isCancelTripModalOpen"
+  title="Annuler ce trajet ?"
+  message="Cette action annulera le trajet et notifiera tous les expéditeurs concernés."
+  confirmLabel="Annuler le trajet"
+  variant="danger"
+  [isLoading]="isCancellingTrip"
+  (confirmed)="confirmCancelTrip()"
+  (cancelled)="closeCancelTripModal()"
+/>
+
+<app-confirm-modal
+  [isOpen]="isRemoveBookingModalOpen"
+  title="Retirer cette réservation ?"
+  message="Cette action retirera définitivement l’expéditeur de ce trajet."
+  confirmLabel="Retirer"
+  variant="danger"
+  [isLoading]="isPendingRemoveBookingProcessing()"
+  (confirmed)="confirmRemoveBooking()"
+  (cancelled)="closeRemoveBookingModal()"
+/>

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
@@ -1,6 +1,6 @@
 <div class="min-h-screen bg-[#f9f9ff] font-['Inter'] text-[#181c22]">
   <header class="fixed inset-x-0 top-0 z-40 h-14 border-b border-[#c1c6d5] bg-white/90 backdrop-blur-md">
-    <div class="mx-auto flex h-full max-w-[1280px] items-center justify-between px-4 sm:px-6 lg:px-8">
+    <div class="flex h-full items-center justify-between px-4 sm:px-6 lg:px-8">
       <a routerLink="/" class="text-[2rem] font-bold leading-none tracking-[-0.02em] text-[#015ab4]">
         Colick
       </a>
@@ -211,11 +211,11 @@
 
         <section class="mb-6">
           <div class="mb-4 flex items-center justify-between gap-3">
-            <h2 class="text-[2rem] font-bold leading-tight tracking-[-0.02em] text-[#181c22]">Demandes en cours</h2>
+            <h2 class="text-[1.625rem] font-bold leading-[1.15] tracking-[-0.02em] text-[#181c22] sm:text-[2rem] sm:leading-tight">Demandes en cours</h2>
 
             <button
               type="button"
-              class="inline-flex items-center gap-2 rounded-xl border border-[#e0e2eb] bg-white px-4 py-2 text-sm text-[#414753] transition hover:bg-[#f1f3fc]"
+              class="inline-flex items-center gap-2 rounded-xl border border-[#e0e2eb] bg-white px-3 py-2 text-[13px] text-[#414753] transition hover:bg-[#f1f3fc] sm:px-4 sm:text-sm"
               (click)="toggleExtendedFilters()"
             >
               <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
@@ -230,7 +230,7 @@
               @for (tab of primaryStatusTabs; track tab.value) {
                 <button
                   type="button"
-                  class="rounded-xl px-4 py-3 text-sm font-bold transition"
+                  class="rounded-xl px-3 py-2.5 text-[13px] font-bold transition sm:px-4 sm:py-3 sm:text-sm"
                   [class]="selectedTab === tab.value
                     ? 'bg-white text-[#015ab4] shadow-sm'
                     : 'text-[#6B6B6B]'"
@@ -248,7 +248,7 @@
                 @if (bookingCountForStatus(tab.value) > 0 || tab.value === 'ALL') {
                   <button
                     type="button"
-                    class="rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.05em] transition"
+                    class="rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.05em] transition sm:text-xs"
                     [class]="selectedTab === tab.value
                       ? 'border-[#015ab4] bg-[#015ab4] text-white'
                       : 'border-[#c1c6d5] bg-white text-[#6B6B6B]'"
@@ -304,7 +304,7 @@
             </div>
 
             <div class="mt-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <p class="text-sm text-[#6B6B6B]">
+              <p class="text-[13px] text-[#6B6B6B] sm:text-sm">
                 {{ currentRangeEnd() }} sur {{ filteredBookings().length }} demandes
               </p>
 
@@ -324,7 +324,7 @@
                   @for (page of pageNumbers(); track page) {
                     <button
                       type="button"
-                      class="inline-flex h-10 min-w-10 items-center justify-center rounded-xl border text-sm font-bold transition"
+                      class="inline-flex h-10 min-w-10 items-center justify-center rounded-xl border text-[13px] font-bold transition sm:text-sm"
                       [class]="page === currentPage
                         ? 'border-[#015ab4] bg-[#015ab4] text-white'
                         : 'border-[#e0e2eb] bg-white text-[#414753] hover:bg-[#f1f3fc]'"

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
@@ -1,27 +1,21 @@
-<div class="min-h-screen bg-[#f9f9ff] font-['Inter'] text-[#181c22]">
-  <header class="fixed inset-x-0 top-0 z-40 h-14 border-b border-[#c1c6d5] bg-white/90 backdrop-blur-md">
+<div class="min-h-screen bg-background-primary font-['Inter'] text-text-primary">
+  <header class="fixed inset-x-0 top-0 z-40 h-14 border-b border-border bg-background-secondary/90 backdrop-blur-md">
     <div class="flex h-full items-center justify-between px-4 sm:px-6 lg:px-8">
-      <a routerLink="/" class="text-[2rem] font-bold leading-none tracking-[-0.02em] text-[#015ab4]">
-        Colick
+      <a routerLink="/" class="text-[2rem] font-bold leading-none tracking-[-0.02em] text-primary">
+        <span class="text-accent">Co</span>lick
       </a>
 
       <div class="flex items-center gap-3">
+        <!-- Hamburger – mobile only -->
         <button
           type="button"
-          class="hidden h-8 w-8 items-center justify-center rounded-full text-[#465f88] transition hover:bg-[#f1f3fc] sm:inline-flex"
-          aria-label="Notifications"
+          class="inline-flex h-9 w-9 items-center justify-center rounded-xl text-text-secondary transition hover:bg-background-primary hover:text-primary md:hidden"
+          aria-label="Ouvrir le menu"
+          [attr.aria-expanded]="isMobileMenuOpen"
+          (click)="openMobileMenu()"
         >
           <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0 1 18 14.158V11a6.002 6.002 0 0 0-4-5.659V5a2 2 0 1 0-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0a3 3 0 1 1-6 0m6 0H9" />
-          </svg>
-        </button>
-        <button
-          type="button"
-          class="hidden h-8 w-8 items-center justify-center rounded-full text-[#465f88] transition hover:bg-[#f1f3fc] sm:inline-flex"
-          aria-label="Aide"
-        >
-          <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M8.228 9A3.5 3.5 0 1 1 15 10.5c-.35.7-.972 1.118-1.55 1.525-.936.658-1.7 1.32-1.7 2.975M12 17h.01" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
 
@@ -30,10 +24,10 @@
             [src]="userPhotoUrl()!"
             (error)="onUserPhotoError()"
             [alt]="'Photo de profil de ' + currentUserName()"
-            class="h-8 w-8 rounded-full border border-[#c1c6d5] object-cover"
+            class="h-8 w-8 rounded-full border border-border object-cover"
           />
         } @else {
-          <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#1f3346] text-xs font-semibold text-white">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary text-xs font-semibold text-white">
             {{ userInitials() }}
           </span>
         }
@@ -41,7 +35,7 @@
     </div>
   </header>
 
-  <aside class="fixed left-0 top-14 hidden h-[calc(100vh-56px)] w-64 flex-col border-r border-[#c1c6d5] bg-white px-2 py-4 md:flex">
+  <aside class="fixed left-0 top-14 hidden h-[calc(100vh-56px)] w-64 flex-col border-r border-border bg-background-secondary px-2 py-4 md:flex">
     <div class="mb-8 flex items-center gap-3 px-3">
       @if (hasUserPhoto()) {
         <img
@@ -51,17 +45,17 @@
           class="h-10 w-10 rounded-xl object-cover"
         />
       } @else {
-        <span class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-[#1f3346] text-sm font-semibold text-white">
+        <span class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-primary text-sm font-semibold text-white">
           {{ userInitials() }}
         </span>
       }
-      <p class="min-w-0 truncate text-sm font-bold text-[#015ab4]">{{ currentUserName() }}</p>
+      <p class="min-w-0 truncate text-sm font-bold text-primary">{{ currentUserName() }}</p>
     </div>
 
     <nav class="flex-1 space-y-1 px-1" aria-label="Navigation réservation">
       <a
         [routerLink]="['/dashboard']"
-        class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-[#465f88] transition hover:bg-[#f8f9ff]"
+        class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-text-secondary transition hover:bg-background-primary hover:text-primary"
       >
         <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 13h8V3H3v10Zm10 8h8V11h-8v10Zm0-18v4h8V3h-8ZM3 21h8v-6H3v6Z" />
@@ -70,7 +64,7 @@
       </a>
       <a
         [routerLink]="['/trips']"
-        class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-[#465f88] transition hover:bg-[#f8f9ff]"
+        class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-text-secondary transition hover:bg-background-primary hover:text-primary"
       >
         <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 7h18M6 3h12M6 21h12M4 10l2 8m14-8-2 8" />
@@ -80,7 +74,7 @@
       <a
         [routerLink]="['/dashboard']"
         [queryParams]="{ tab: 'received' }"
-        class="flex items-center gap-3 rounded-xl bg-[#f1f3fc] px-3 py-3 text-sm font-bold text-[#015ab4]"
+        class="flex items-center gap-3 rounded-xl bg-primary/10 px-3 py-3 text-sm font-bold text-primary"
         aria-current="page"
       >
         <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
@@ -90,7 +84,7 @@
       </a>
       <a
         [routerLink]="['/messages']"
-        class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-[#465f88] transition hover:bg-[#f8f9ff]"
+        class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-text-secondary transition hover:bg-background-primary hover:text-primary"
       >
         <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 0 1-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8Z" />
@@ -99,11 +93,11 @@
       </a>
     </nav>
 
-    <div class="space-y-1 border-t border-[#c1c6d5] pt-4">
+    <div class="space-y-1 border-t border-border pt-4">
       <a
         [routerLink]="['/dashboard']"
         [queryParams]="{ tab: 'profile' }"
-        class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-[#465f88] transition hover:bg-[#f8f9ff]"
+        class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-text-secondary transition hover:bg-background-primary hover:text-primary"
       >
         <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065Z" />
@@ -113,7 +107,7 @@
       </a>
       <button
         type="button"
-        class="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-sm text-[#465f88] transition hover:bg-[#f8f9ff] hover:text-error"
+        class="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-sm text-text-secondary transition hover:bg-error/5 hover:text-error"
         (click)="logout()"
       >
         <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
@@ -124,7 +118,7 @@
       </button>
       <a
         [routerLink]="['/propose']"
-        class="mt-4 inline-flex w-full items-center justify-center rounded-xl bg-[#015ab4] px-4 py-3 text-sm font-bold text-white transition hover:opacity-90"
+        class="mt-4 inline-flex w-full items-center justify-center rounded-xl bg-secondary px-4 py-3 text-sm font-bold text-white transition hover:opacity-90"
       >
         Publier un trajet
       </a>
@@ -134,23 +128,23 @@
   <main class="min-h-screen pb-32 pt-14 md:ml-64">
     <div class="mx-auto max-w-[1280px] px-4 py-6 sm:px-6 lg:px-8">
       @if (isLoading && !trip) {
-        <section class="rounded-2xl border border-[#c1c6d5] bg-white px-5 py-16 text-center shadow-[0_8px_30px_rgba(0,0,0,0.04)]" role="status" aria-live="polite">
-          <div class="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-[#e0e2eb] border-t-[#015ab4]"></div>
-          <p class="mt-4 text-sm font-medium text-[#6B6B6B]">Chargement des demandes...</p>
+        <section class="rounded-2xl border border-border bg-background-secondary px-5 py-16 text-center shadow-card" role="status" aria-live="polite">
+          <div class="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-border border-t-primary"></div>
+          <p class="mt-4 text-sm font-medium text-text-secondary">Chargement des demandes...</p>
         </section>
       } @else if (loadError && !trip) {
-        <section class="rounded-2xl border border-error/20 bg-white px-5 py-12 text-center shadow-[0_8px_30px_rgba(0,0,0,0.04)]" role="alert">
+        <section class="rounded-2xl border border-error/20 bg-background-secondary px-5 py-12 text-center shadow-card" role="alert">
           <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-error/10 text-error">
             <svg class="h-7 w-7" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3m0 4h.01M4.93 19h14.14c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.2 16c-.77 1.33.19 3 1.73 3Z" />
             </svg>
           </div>
-          <h1 class="mt-4 text-xl font-bold text-[#181c22]">Impossible d’afficher cette réservation</h1>
-          <p class="mt-2 text-sm text-[#6B6B6B]">{{ loadError }}</p>
+          <h1 class="mt-4 text-xl font-bold text-text-primary">Impossible d’afficher cette réservation</h1>
+          <p class="mt-2 text-sm text-text-secondary">{{ loadError }}</p>
         </section>
       } @else if (trip) {
         <section class="mb-6">
-          <div class="overflow-hidden rounded-2xl border border-[#c1c6d5] bg-white shadow-[0_8px_30px_rgba(0,0,0,0.04)]">
+          <div class="overflow-hidden rounded-2xl border border-border bg-background-secondary shadow-card">
             <button
               type="button"
               class="flex w-full items-center justify-between p-4 text-left sm:p-5"
@@ -158,19 +152,19 @@
               (click)="toggleTripSummary()"
             >
               <div class="flex items-center gap-4">
-                <div class="rounded-2xl bg-[#f1f3fc] p-3 text-[#015ab4]">
+                <div class="rounded-2xl bg-primary/10 p-3 text-primary">
                   <span class="material-symbols-outlined block text-[20px] leading-none" aria-hidden="true">directions_transit</span>
                 </div>
                 <div>
-                  <h1 class="text-base font-bold text-[#181c22]">
+                  <h1 class="text-base font-bold text-text-primary">
                     {{ trip.departureAddress }} → {{ trip.destination }}
                   </h1>
-                  <p class="text-sm text-[#6B6B6B]">{{ trip.departureTime | date:'dd/MM • HH:mm' }}</p>
+                  <p class="text-sm text-text-secondary">{{ trip.departureTime | date:'dd/MM • HH:mm' }}</p>
                 </div>
               </div>
 
               <svg
-                class="h-5 w-5 shrink-0 text-[#181c22] transition-transform duration-200"
+                class="h-5 w-5 shrink-0 text-text-primary transition-transform duration-200"
                 [class.rotate-180]="tripSummaryExpanded"
                 fill="none"
                 stroke="currentColor"
@@ -183,25 +177,25 @@
             </button>
 
             @if (tripSummaryExpanded) {
-              <div class="space-y-4 border-t border-[#c1c6d5] px-4 pb-4 pt-0 sm:px-5 sm:pb-5">
+              <div class="space-y-4 border-t border-border px-4 pb-4 pt-0 sm:px-5 sm:pb-5">
                 <div class="mt-2">
-                  <div class="mb-2 flex items-center justify-between text-sm text-[#6B6B6B]">
+                  <div class="mb-2 flex items-center justify-between text-sm text-text-secondary">
                     <span>Capacité</span>
-                    <span class="font-bold text-[#181c22]">{{ usedWeight() | number:'1.0-2' }} / {{ trip.maxWeight | number:'1.0-2' }} kg</span>
+                    <span class="font-bold text-text-primary">{{ usedWeight() | number:'1.0-2' }} / {{ trip.maxWeight | number:'1.0-2' }} kg</span>
                   </div>
-                  <div class="h-2 w-full rounded-full bg-[#e0e2eb]">
-                    <div class="h-2 rounded-full bg-[#015ab4]" [style.width.%]="usedWeightPercentage()"></div>
+                  <div class="h-2 w-full rounded-full bg-border">
+                    <div class="h-2 rounded-full bg-primary" [style.width.%]="usedWeightPercentage()"></div>
                   </div>
                 </div>
 
                 <div class="grid grid-cols-2 gap-4">
-                  <div class="rounded-2xl bg-[#f1f3fc] p-3 text-center">
-                    <p class="text-[11px] font-semibold uppercase tracking-[0.05em] text-[#9C9C9C]">Poids disponible</p>
-                    <p class="mt-1 font-bold text-[#015ab4]">{{ remainingWeight() | number:'1.0-2' }} kg</p>
+                  <div class="rounded-2xl bg-background-primary p-3 text-center">
+                    <p class="text-[11px] font-semibold uppercase tracking-[0.05em] text-text-muted">Poids disponible</p>
+                    <p class="mt-1 font-bold text-primary">{{ remainingWeight() | number:'1.0-2' }} kg</p>
                   </div>
-                  <div class="rounded-2xl bg-[#f1f3fc] p-3 text-center">
-                    <p class="text-[11px] font-semibold uppercase tracking-[0.05em] text-[#9C9C9C]">Demandes</p>
-                    <p class="mt-1 font-bold text-[#181c22]">{{ bookings.length }} total</p>
+                  <div class="rounded-2xl bg-background-primary p-3 text-center">
+                    <p class="text-[11px] font-semibold uppercase tracking-[0.05em] text-text-muted">Demandes</p>
+                    <p class="mt-1 font-bold text-text-primary">{{ bookings.length }} total</p>
                   </div>
                 </div>
               </div>
@@ -210,30 +204,19 @@
         </section>
 
         <section class="mb-6">
-          <div class="mb-4 flex items-center justify-between gap-3">
-            <h2 class="text-[1.625rem] font-bold leading-[1.15] tracking-[-0.02em] text-[#181c22] sm:text-[2rem] sm:leading-tight">Demandes en cours</h2>
-
-            <button
-              type="button"
-              class="inline-flex items-center gap-2 rounded-xl border border-[#e0e2eb] bg-white px-3 py-2 text-[13px] text-[#414753] transition hover:bg-[#f1f3fc] sm:px-4 sm:text-sm"
-              (click)="toggleExtendedFilters()"
-            >
-              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M3 6h18M6 12h12m-9 6h6" />
-              </svg>
-              Filter
-            </button>
+          <div class="mb-4">
+            <h2 class="text-[1.625rem] font-bold leading-[1.15] tracking-[-0.02em] text-text-primary sm:text-[2rem] sm:leading-tight">Demandes en cours</h2>
           </div>
 
-          <div class="w-full max-w-md rounded-2xl bg-[#f1f3fc] p-1">
+          <div class="w-full max-w-md rounded-2xl bg-background-primary p-1">
             <div class="grid grid-cols-2 gap-1">
               @for (tab of primaryStatusTabs; track tab.value) {
                 <button
                   type="button"
                   class="rounded-xl px-3 py-2.5 text-[13px] font-bold transition sm:px-4 sm:py-3 sm:text-sm"
                   [class]="selectedTab === tab.value
-                    ? 'bg-white text-[#015ab4] shadow-sm'
-                    : 'text-[#6B6B6B]'"
+                    ? 'bg-background-secondary text-primary shadow-sm'
+                    : 'text-text-secondary hover:text-primary'"
                   (click)="selectTab(tab.value)"
                 >
                   {{ tab.label }} ({{ bookingCountForStatus(tab.value) }})
@@ -242,24 +225,6 @@
             </div>
           </div>
 
-          @if (showExtendedFilters && hasExtendedStatuses()) {
-            <div class="mt-3 flex flex-wrap gap-2">
-              @for (tab of extendedStatusTabs; track tab.value) {
-                @if (bookingCountForStatus(tab.value) > 0 || tab.value === 'ALL') {
-                  <button
-                    type="button"
-                    class="rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.05em] transition sm:text-xs"
-                    [class]="selectedTab === tab.value
-                      ? 'border-[#015ab4] bg-[#015ab4] text-white'
-                      : 'border-[#c1c6d5] bg-white text-[#6B6B6B]'"
-                    (click)="selectTab(tab.value)"
-                  >
-                    {{ tab.label }} ({{ bookingCountForStatus(tab.value) }})
-                  </button>
-                }
-              }
-            </div>
-          }
         </section>
 
         @if (actionError) {
@@ -269,20 +234,20 @@
         }
 
         @if (isLoading) {
-          <section class="rounded-2xl border border-[#c1c6d5] bg-white px-5 py-16 text-center shadow-[0_8px_30px_rgba(0,0,0,0.04)]" role="status" aria-live="polite">
-            <div class="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-[#e0e2eb] border-t-[#015ab4]"></div>
-            <p class="mt-4 text-sm font-medium text-[#6B6B6B]">Chargement des demandes...</p>
+          <section class="rounded-2xl border border-border bg-background-secondary px-5 py-16 text-center shadow-card" role="status" aria-live="polite">
+            <div class="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-border border-t-primary"></div>
+            <p class="mt-4 text-sm font-medium text-text-secondary">Chargement des demandes...</p>
           </section>
         } @else if (!filteredBookings().length) {
-          <section class="rounded-2xl border border-[#c1c6d5] bg-white px-5 py-16 text-center shadow-[0_8px_30px_rgba(0,0,0,0.04)]">
-            <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-[#f1f3fc] text-[#015ab4]">
+          <section class="rounded-2xl border border-border bg-background-secondary px-5 py-16 text-center shadow-card">
+            <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
               <svg class="h-7 w-7" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M20 13V7a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v6m16 0-2.59 0a1 1 0 0 0-.7.29l-1.42 1.42a1 1 0 0 1-.7.29h-3.18a1 1 0 0 1-.7-.29l-1.42-1.42a1 1 0 0 0-.7-.29H4" />
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 13v5a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-5" />
               </svg>
             </div>
-            <h3 class="mt-4 text-lg font-bold text-[#181c22]">Aucune réservation dans cet onglet</h3>
-            <p class="mt-2 text-sm text-[#6B6B6B]">Changez de filtre pour voir les autres demandes de ce trajet.</p>
+            <h3 class="mt-4 text-lg font-bold text-text-primary">Aucune réservation dans cet onglet</h3>
+            <p class="mt-2 text-sm text-text-secondary">Changez de filtre pour voir les autres demandes de ce trajet.</p>
           </section>
         } @else {
           <section>
@@ -304,7 +269,7 @@
             </div>
 
             <div class="mt-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <p class="text-[13px] text-[#6B6B6B] sm:text-sm">
+              <p class="text-[13px] text-text-secondary sm:text-sm">
                 {{ currentRangeEnd() }} sur {{ filteredBookings().length }} demandes
               </p>
 
@@ -312,7 +277,7 @@
                 <nav class="flex items-center gap-2" aria-label="Pagination des réservations">
                   <button
                     type="button"
-                    class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-[#e0e2eb] bg-white text-[#6B6B6B] transition hover:bg-[#f1f3fc] disabled:opacity-50"
+                    class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-background-secondary text-text-secondary transition hover:bg-background-primary hover:text-primary disabled:opacity-50"
                     [disabled]="currentPage === 1"
                     (click)="goToPage(currentPage - 1)"
                   >
@@ -326,8 +291,8 @@
                       type="button"
                       class="inline-flex h-10 min-w-10 items-center justify-center rounded-xl border text-[13px] font-bold transition sm:text-sm"
                       [class]="page === currentPage
-                        ? 'border-[#015ab4] bg-[#015ab4] text-white'
-                        : 'border-[#e0e2eb] bg-white text-[#414753] hover:bg-[#f1f3fc]'"
+                        ? 'border-secondary bg-secondary text-white'
+                        : 'border-border bg-background-secondary text-text-secondary hover:bg-background-primary hover:text-primary'"
                       (click)="goToPage(page)"
                     >
                       {{ page }}
@@ -336,7 +301,7 @@
 
                   <button
                     type="button"
-                    class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-[#e0e2eb] bg-white text-[#414753] transition hover:bg-[#f1f3fc] disabled:opacity-50"
+                    class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-background-secondary text-text-secondary transition hover:bg-background-primary hover:text-primary disabled:opacity-50"
                     [disabled]="currentPage === totalPages()"
                     (click)="goToPage(currentPage + 1)"
                   >
@@ -354,11 +319,11 @@
   </main>
 
   @if (trip?.status === 'ACTIVE') {
-    <div class="fixed bottom-0 right-0 z-40 hidden border-t border-[#c1c6d5] bg-white/90 p-4 backdrop-blur-md md:flex md:w-[calc(100%-256px)] md:justify-end">
+    <div class="fixed bottom-0 right-0 z-40 hidden border-t border-border bg-background-secondary/90 p-4 backdrop-blur-md md:flex md:w-[calc(100%-256px)] md:justify-end">
       <div class="mr-4 flex gap-4">
         <button
           type="button"
-          class="inline-flex items-center justify-center gap-2 rounded-xl border border-[#717785] px-6 py-3 text-sm font-bold text-[#465f88] transition hover:bg-[#f1f3fc]"
+          class="inline-flex items-center justify-center gap-2 rounded-xl border border-error/30 px-6 py-3 text-sm font-bold text-error transition hover:bg-error/5"
           [disabled]="isCompletingTrip || isCancellingTrip"
           (click)="openCancelTripModal()"
         >
@@ -370,7 +335,7 @@
 
         <button
           type="button"
-          class="inline-flex items-center justify-center gap-2 rounded-xl bg-[#015ab4] px-6 py-3 text-sm font-bold text-white transition hover:opacity-90"
+          class="inline-flex items-center justify-center gap-2 rounded-xl bg-secondary px-6 py-3 text-sm font-bold text-white transition hover:opacity-90"
           [disabled]="isCompletingTrip || isCancellingTrip"
           (click)="markTripCompleted()"
         >
@@ -382,11 +347,11 @@
       </div>
     </div>
 
-    <div class="fixed bottom-0 left-0 right-0 z-40 border-t border-[#c1c6d5] bg-white/90 p-2 backdrop-blur-md md:hidden">
+    <div class="fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-background-secondary/90 p-2 backdrop-blur-md md:hidden">
       <div class="flex gap-2">
         <button
           type="button"
-          class="flex-1 rounded-full border border-[#717785] px-4 py-2.5 text-sm font-bold text-[#465f88]"
+          class="flex-1 rounded-full border border-error/30 px-4 py-2.5 text-sm font-bold text-error"
           [disabled]="isCompletingTrip || isCancellingTrip"
           (click)="openCancelTripModal()"
         >
@@ -394,7 +359,7 @@
         </button>
         <button
           type="button"
-          class="flex-1 rounded-full bg-[#015ab4] px-4 py-2.5 text-sm font-bold text-white"
+          class="flex-1 rounded-full bg-secondary px-4 py-2.5 text-sm font-bold text-white"
           [disabled]="isCompletingTrip || isCancellingTrip"
           (click)="markTripCompleted()"
         >
@@ -404,6 +369,143 @@
     </div>
   }
 </div>
+
+<!-- ─── Mobile navigation drawer ─────────────────────────────────────────── -->
+@if (isMobileMenuOpen) {
+  <div class="fixed inset-0 z-50 md:hidden" role="dialog" aria-modal="true" aria-label="Menu de navigation">
+    <!-- Backdrop -->
+    <div
+      class="absolute inset-0 bg-text-primary/40 backdrop-blur-sm"
+      aria-hidden="true"
+      (click)="closeMobileMenu()"
+    ></div>
+
+    <!-- Drawer panel -->
+    <aside class="absolute left-0 top-0 flex h-full w-72 flex-col border-r border-border bg-background-secondary px-2 py-4 shadow-xl">
+
+      <!-- Header row: close button -->
+      <div class="mb-6 flex items-center justify-between px-3">
+        <a
+          routerLink="/"
+          class="text-[1.5rem] font-bold leading-none tracking-[-0.02em] text-primary"
+          (click)="closeMobileMenu()"
+        >
+          <span class="text-accent">Co</span>lick
+        </a>
+        <button
+          type="button"
+          class="inline-flex h-8 w-8 items-center justify-center rounded-xl text-text-secondary transition hover:bg-background-primary hover:text-primary"
+          aria-label="Fermer le menu"
+          (click)="closeMobileMenu()"
+        >
+          <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Profile block -->
+      <div class="mb-6 flex items-center gap-3 rounded-xl bg-background-primary px-3 py-3">
+        @if (hasUserPhoto()) {
+          <img
+            [src]="userPhotoUrl()!"
+            (error)="onUserPhotoError()"
+            [alt]="'Photo de profil de ' + currentUserName()"
+            class="h-10 w-10 shrink-0 rounded-xl object-cover"
+          />
+        } @else {
+          <span class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary text-sm font-semibold text-white">
+            {{ userInitials() }}
+          </span>
+        }
+        <div class="min-w-0">
+          <p class="truncate text-sm font-bold text-text-primary">{{ currentUserName() }}</p>
+          <p class="truncate text-[11px] text-text-secondary">{{ currentUserEmail() }}</p>
+        </div>
+      </div>
+
+      <!-- Navigation links -->
+      <nav class="flex-1 space-y-1 px-1" aria-label="Navigation mobile">
+        <a
+          [routerLink]="['/dashboard']"
+          class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-text-secondary transition hover:bg-background-primary hover:text-primary"
+          (click)="closeMobileMenu()"
+        >
+          <svg class="h-5 w-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 13h8V3H3v10Zm10 8h8V11h-8v10Zm0-18v4h8V3h-8ZM3 21h8v-6H3v6Z" />
+          </svg>
+          Tableau de board
+        </a>
+        <a
+          [routerLink]="['/trips']"
+          class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-text-secondary transition hover:bg-background-primary hover:text-primary"
+          (click)="closeMobileMenu()"
+        >
+          <svg class="h-5 w-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 7h18M6 3h12M6 21h12M4 10l2 8m14-8-2 8" />
+          </svg>
+          Mes trajets
+        </a>
+        <a
+          [routerLink]="['/dashboard']"
+          [queryParams]="{ tab: 'received' }"
+          class="flex items-center gap-3 rounded-xl bg-primary/10 px-3 py-3 text-sm font-bold text-primary"
+          aria-current="page"
+          (click)="closeMobileMenu()"
+        >
+          <svg class="h-5 w-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z" />
+          </svg>
+          Mes demandes
+        </a>
+        <a
+          [routerLink]="['/messages']"
+          class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-text-secondary transition hover:bg-background-primary hover:text-primary"
+          (click)="closeMobileMenu()"
+        >
+          <svg class="h-5 w-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 0 1-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8Z" />
+          </svg>
+          Messages
+        </a>
+      </nav>
+
+      <!-- Settings, logout and CTA -->
+      <div class="space-y-1 border-t border-border px-1 pt-4">
+        <a
+          [routerLink]="['/dashboard']"
+          [queryParams]="{ tab: 'profile' }"
+          class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-text-secondary transition hover:bg-background-primary hover:text-primary"
+          (click)="closeMobileMenu()"
+        >
+          <svg class="h-5 w-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065Z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+          </svg>
+          Réglages
+        </a>
+        <button
+          type="button"
+          class="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-sm text-text-secondary transition hover:bg-error/5 hover:text-error"
+          (click)="logout(); closeMobileMenu()"
+        >
+          <svg class="h-5 w-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-7.5a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 6 21h7.5a2.25 2.25 0 0 0 2.25-2.25V15" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M18 12H9m0 0 3-3m-3 3 3 3" />
+          </svg>
+          Déconnexion
+        </button>
+        <a
+          [routerLink]="['/propose']"
+          class="mt-4 inline-flex w-full items-center justify-center rounded-xl bg-secondary px-4 py-3 text-sm font-bold text-white transition hover:opacity-90"
+          (click)="closeMobileMenu()"
+        >
+          Publier un trajet
+        </a>
+      </div>
+    </aside>
+  </div>
+}
 
 <app-confirm-modal
   [isOpen]="isCancelTripModalOpen"

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
@@ -82,7 +82,7 @@
           <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
             <button
               type="button"
-              class="inline-flex items-center justify-center gap-2 rounded-xl bg-secondary px-4 py-3 text-sm font-semibold text-white transition hover:bg-secondary/90 focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-60"
+              class="inline-flex items-center justify-center gap-2 rounded-xl border border-secondary/20 bg-background-primary px-4 py-3 text-sm font-semibold text-primary transition hover:border-secondary hover:bg-secondary/10 hover:text-secondary focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-60"
               [disabled]="isCompletingTrip || isCancellingTrip"
               (click)="editTrip()"
             >
@@ -94,7 +94,7 @@
 
             <button
               type="button"
-              class="inline-flex items-center justify-center gap-2 rounded-xl bg-success px-4 py-3 text-sm font-semibold text-white transition hover:bg-success/90 focus:outline-none focus:ring-2 focus:ring-success/20 disabled:cursor-not-allowed disabled:opacity-60"
+              class="inline-flex items-center justify-center gap-2 rounded-xl bg-accent px-4 py-3 text-sm font-semibold text-white transition hover:bg-accent/90 focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:cursor-not-allowed disabled:opacity-60"
               [disabled]="isCompletingTrip || isCancellingTrip"
               (click)="markTripCompleted()"
             >
@@ -106,7 +106,7 @@
 
             <button
               type="button"
-              class="inline-flex items-center justify-center gap-2 rounded-xl bg-error px-4 py-3 text-sm font-semibold text-white transition hover:bg-error/90 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-60"
+              class="inline-flex items-center justify-center gap-2 rounded-xl border border-error/20 bg-background-secondary px-4 py-3 text-sm font-semibold text-error transition hover:border-error/30 hover:bg-error/10 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-60"
               [disabled]="isCompletingTrip || isCancellingTrip"
               (click)="openCancelTripModal()"
             >

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
@@ -169,6 +169,7 @@
                 [tripStatus]="trip.status"
                 [isProcessing]="isBookingProcessing(booking.id)"
                 [tripId]="trip.id"
+                [pricePerKilo]="trip.pricePerKilo"
                 (accept)="acceptBooking($event)"
                 (reject)="rejectBooking($event)"
                 (remove)="openRemoveBookingModal($event)"

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
@@ -1,187 +1,408 @@
-<div class="min-h-screen bg-background-primary pt-20 pb-12 font-['Poppins']">
-  <div class="mx-auto flex max-w-6xl flex-col gap-6 px-4 sm:px-6 lg:px-8">
-    <a
-      [routerLink]="['/dashboard']"
-      [queryParams]="{ tab: 'received' }"
-      class="inline-flex w-fit items-center gap-2 rounded-full border border-background-primary bg-background-secondary px-4 py-2 text-sm font-medium text-text-secondary transition hover:border-secondary hover:text-secondary focus:outline-none focus:ring-2 focus:ring-secondary/20"
-      aria-label="Retour aux réservations reçues"
-    >
-      <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-      </svg>
-      Retour aux réservations reçues
-    </a>
+<div class="min-h-screen bg-[#f9f9ff] font-['Inter'] text-[#181c22]">
+  <header class="fixed inset-x-0 top-0 z-40 h-14 border-b border-[#c1c6d5] bg-white/90 backdrop-blur-md">
+    <div class="mx-auto flex h-full max-w-[1280px] items-center justify-between px-4 sm:px-6 lg:px-8">
+      <a routerLink="/" class="text-[2rem] font-bold leading-none tracking-[-0.02em] text-[#015ab4]">
+        Colick
+      </a>
 
-    @if (isLoading && !trip) {
-      <section class="rounded-2xl border border-background-primary bg-background-secondary px-5 py-16 text-center shadow-sm" role="status" aria-live="polite">
-        <div class="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-secondary/20 border-t-secondary"></div>
-        <p class="mt-4 text-sm font-medium text-text-secondary">Chargement des demandes...</p>
-      </section>
-    } @else if (loadError && !trip) {
-      <section class="rounded-2xl border border-error/20 bg-error/10 px-5 py-12 text-center shadow-sm" role="alert">
-        <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-error/15 text-error">
-          <svg class="h-7 w-7" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3m0 4h.01M4.93 19h14.14c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.2 16c-.77 1.33.19 3 1.73 3Z" />
+      <div class="flex items-center gap-3">
+        <button
+          type="button"
+          class="hidden h-8 w-8 items-center justify-center rounded-full text-[#465f88] transition hover:bg-[#f1f3fc] sm:inline-flex"
+          aria-label="Notifications"
+        >
+          <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0 1 18 14.158V11a6.002 6.002 0 0 0-4-5.659V5a2 2 0 1 0-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0a3 3 0 1 1-6 0m6 0H9" />
           </svg>
-        </div>
-        <h1 class="mt-4 text-xl font-bold text-text-primary">Impossible d’afficher cette réservation</h1>
-        <p class="mt-2 text-sm text-error">{{ loadError }}</p>
-      </section>
-    } @else if (trip) {
-      <section class="overflow-hidden rounded-2xl border border-background-primary bg-background-secondary shadow-sm">
-        <div class="bg-primary px-5 py-6 text-white sm:px-6 lg:px-8">
-          <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-            <div class="space-y-3">
-              <p class="text-xs font-semibold uppercase tracking-[0.18em] text-white/70">Détails du trajet</p>
-              <h1 class="text-2xl font-bold leading-tight sm:text-3xl">
-                {{ trip.departureAddress }} <span class="text-secondary">→</span> {{ trip.destination }}
-              </h1>
-              <div class="flex flex-wrap items-center gap-3 text-sm text-white/80">
-                <span class="inline-flex items-center gap-2">
-                  <svg class="h-4 w-4 text-secondary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z" />
-                  </svg>
-                  {{ trip.departureTime | date:'dd/MM/yyyy • HH:mm' }}
-                </span>
+        </button>
+        <button
+          type="button"
+          class="hidden h-8 w-8 items-center justify-center rounded-full text-[#465f88] transition hover:bg-[#f1f3fc] sm:inline-flex"
+          aria-label="Aide"
+        >
+          <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M8.228 9A3.5 3.5 0 1 1 15 10.5c-.35.7-.972 1.118-1.55 1.525-.936.658-1.7 1.32-1.7 2.975M12 17h.01" />
+          </svg>
+        </button>
+
+        @if (hasUserPhoto()) {
+          <img
+            [src]="userPhotoUrl()!"
+            (error)="onUserPhotoError()"
+            [alt]="'Photo de profil de ' + currentUserName()"
+            class="h-8 w-8 rounded-full border border-[#c1c6d5] object-cover"
+          />
+        } @else {
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#1f3346] text-xs font-semibold text-white">
+            {{ userInitials() }}
+          </span>
+        }
+      </div>
+    </div>
+  </header>
+
+  <aside class="fixed left-0 top-14 hidden h-[calc(100vh-56px)] w-64 flex-col border-r border-[#c1c6d5] bg-white px-2 py-4 md:flex">
+    <div class="mb-8 flex items-center gap-3 px-3">
+      @if (hasUserPhoto()) {
+        <img
+          [src]="userPhotoUrl()!"
+          (error)="onUserPhotoError()"
+          [alt]="'Photo de profil de ' + currentUserName()"
+          class="h-10 w-10 rounded-xl object-cover"
+        />
+      } @else {
+        <span class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-[#1f3346] text-sm font-semibold text-white">
+          {{ userInitials() }}
+        </span>
+      }
+      <p class="min-w-0 truncate text-sm font-bold text-[#015ab4]">{{ currentUserName() }}</p>
+    </div>
+
+    <nav class="flex-1 space-y-1 px-1" aria-label="Navigation réservation">
+      <a
+        [routerLink]="['/dashboard']"
+        class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-[#465f88] transition hover:bg-[#f8f9ff]"
+      >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3 13h8V3H3v10Zm10 8h8V11h-8v10Zm0-18v4h8V3h-8ZM3 21h8v-6H3v6Z" />
+        </svg>
+        Tableau de board
+      </a>
+      <a
+        [routerLink]="['/trips']"
+        class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-[#465f88] transition hover:bg-[#f8f9ff]"
+      >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3 7h18M6 3h12M6 21h12M4 10l2 8m14-8-2 8" />
+        </svg>
+        Mes trajets
+      </a>
+      <a
+        [routerLink]="['/dashboard']"
+        [queryParams]="{ tab: 'received' }"
+        class="flex items-center gap-3 rounded-xl bg-[#f1f3fc] px-3 py-3 text-sm font-bold text-[#015ab4]"
+        aria-current="page"
+      >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z" />
+        </svg>
+        Mes demandes
+      </a>
+      <a
+        [routerLink]="['/messages']"
+        class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-[#465f88] transition hover:bg-[#f8f9ff]"
+      >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 0 1-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8Z" />
+        </svg>
+        Messages
+      </a>
+    </nav>
+
+    <div class="space-y-1 border-t border-[#c1c6d5] pt-4">
+      <a
+        [routerLink]="['/dashboard']"
+        [queryParams]="{ tab: 'profile' }"
+        class="flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-[#465f88] transition hover:bg-[#f8f9ff]"
+      >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065Z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+        </svg>
+        Réglages
+      </a>
+      <button
+        type="button"
+        class="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-sm text-[#465f88] transition hover:bg-[#f8f9ff] hover:text-error"
+        (click)="logout()"
+      >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-7.5a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 6 21h7.5a2.25 2.25 0 0 0 2.25-2.25V15" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M18 12H9m0 0 3-3m-3 3 3 3" />
+        </svg>
+        Deconnexion
+      </button>
+      <a
+        [routerLink]="['/propose']"
+        class="mt-4 inline-flex w-full items-center justify-center rounded-xl bg-[#015ab4] px-4 py-3 text-sm font-bold text-white transition hover:opacity-90"
+      >
+        Publier un trajet
+      </a>
+    </div>
+  </aside>
+
+  <main class="min-h-screen pb-32 pt-14 md:ml-64">
+    <div class="mx-auto max-w-[1280px] px-4 py-6 sm:px-6 lg:px-8">
+      @if (isLoading && !trip) {
+        <section class="rounded-2xl border border-[#c1c6d5] bg-white px-5 py-16 text-center shadow-[0_8px_30px_rgba(0,0,0,0.04)]" role="status" aria-live="polite">
+          <div class="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-[#e0e2eb] border-t-[#015ab4]"></div>
+          <p class="mt-4 text-sm font-medium text-[#6B6B6B]">Chargement des demandes...</p>
+        </section>
+      } @else if (loadError && !trip) {
+        <section class="rounded-2xl border border-error/20 bg-white px-5 py-12 text-center shadow-[0_8px_30px_rgba(0,0,0,0.04)]" role="alert">
+          <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-error/10 text-error">
+            <svg class="h-7 w-7" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3m0 4h.01M4.93 19h14.14c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.2 16c-.77 1.33.19 3 1.73 3Z" />
+            </svg>
+          </div>
+          <h1 class="mt-4 text-xl font-bold text-[#181c22]">Impossible d’afficher cette réservation</h1>
+          <p class="mt-2 text-sm text-[#6B6B6B]">{{ loadError }}</p>
+        </section>
+      } @else if (trip) {
+        <section class="mb-6">
+          <div class="overflow-hidden rounded-2xl border border-[#c1c6d5] bg-white shadow-[0_8px_30px_rgba(0,0,0,0.04)]">
+            <button
+              type="button"
+              class="flex w-full items-center justify-between p-4 text-left sm:p-5"
+              [attr.aria-expanded]="tripSummaryExpanded"
+              (click)="toggleTripSummary()"
+            >
+              <div class="flex items-center gap-4">
+                <div class="rounded-2xl bg-[#f1f3fc] p-3 text-[#015ab4]">
+                  <span class="material-symbols-outlined block text-[20px] leading-none" aria-hidden="true">directions_transit</span>
+                </div>
+                <div>
+                  <h1 class="text-base font-bold text-[#181c22]">
+                    {{ trip.departureAddress }} → {{ trip.destination }}
+                  </h1>
+                  <p class="text-sm text-[#6B6B6B]">{{ trip.departureTime | date:'dd/MM • HH:mm' }}</p>
+                </div>
               </div>
-            </div>
 
-            <span
-              class="inline-flex w-fit items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em]"
-              [class]="tripStatusClass(trip.status)"
-              role="status"
-            >
-              <span class="h-2 w-2 rounded-full bg-current"></span>
-              {{ tripStatusLabel(trip.status) }}
-            </span>
-          </div>
-        </div>
-
-        <div class="grid gap-3 px-5 py-5 sm:grid-cols-2 lg:grid-cols-4 sm:px-6 lg:px-8">
-          <div class="rounded-2xl bg-background-primary p-4">
-            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Poids max</p>
-            <p class="mt-2 text-lg font-bold text-text-primary">{{ trip.maxWeight | number:'1.0-2' }} kg</p>
-          </div>
-          <div class="rounded-2xl bg-background-primary p-4">
-            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Prix / kilo</p>
-            <p class="mt-2 text-lg font-bold text-secondary">{{ trip.pricePerKilo | number:'1.0-2' }} €</p>
-          </div>
-          <div class="rounded-2xl bg-background-primary p-4">
-            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Poids disponible</p>
-            <p class="mt-2 text-lg font-bold text-text-primary">{{ trip.availableWeight | number:'1.0-2' }} kg</p>
-          </div>
-          <div class="rounded-2xl bg-background-primary p-4">
-            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">Réservations</p>
-            <p class="mt-2 text-lg font-bold text-text-primary">{{ bookings.length }}</p>
-          </div>
-        </div>
-      </section>
-
-      @if (trip.status === 'ACTIVE') {
-        <section class="rounded-2xl border border-background-primary bg-background-secondary p-4 shadow-sm sm:p-5">
-          <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
-            <button
-              type="button"
-              class="inline-flex items-center justify-center gap-2 rounded-xl border border-secondary/20 bg-background-primary px-4 py-3 text-sm font-semibold text-primary transition hover:border-secondary hover:bg-secondary/10 hover:text-secondary focus:outline-none focus:ring-2 focus:ring-secondary/20 disabled:cursor-not-allowed disabled:opacity-60"
-              [disabled]="isCompletingTrip || isCancellingTrip"
-              (click)="editTrip()"
-            >
-              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M4 20h4l10.5-10.5a2.121 2.121 0 1 0-3-3L5 17v3Z" />
+              <svg
+                class="h-5 w-5 shrink-0 text-[#181c22] transition-transform duration-200"
+                [class.rotate-180]="tripSummaryExpanded"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="m19 9-7 7-7-7" />
               </svg>
-              Modifier le trajet
             </button>
 
-            <button
-              type="button"
-              class="inline-flex items-center justify-center gap-2 rounded-xl bg-accent px-4 py-3 text-sm font-semibold text-white transition hover:bg-accent/90 focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:cursor-not-allowed disabled:opacity-60"
-              [disabled]="isCompletingTrip || isCancellingTrip"
-              (click)="markTripCompleted()"
-            >
-              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="m5 13 4 4L19 7" />
-              </svg>
-              {{ isCompletingTrip ? 'Validation...' : 'Marquer comme terminé' }}
-            </button>
+            @if (tripSummaryExpanded) {
+              <div class="space-y-4 border-t border-[#c1c6d5] px-4 pb-4 pt-0 sm:px-5 sm:pb-5">
+                <div class="mt-2">
+                  <div class="mb-2 flex items-center justify-between text-sm text-[#6B6B6B]">
+                    <span>Capacité</span>
+                    <span class="font-bold text-[#181c22]">{{ usedWeight() | number:'1.0-2' }} / {{ trip.maxWeight | number:'1.0-2' }} kg</span>
+                  </div>
+                  <div class="h-2 w-full rounded-full bg-[#e0e2eb]">
+                    <div class="h-2 rounded-full bg-[#015ab4]" [style.width.%]="usedWeightPercentage()"></div>
+                  </div>
+                </div>
 
-            <button
-              type="button"
-              class="inline-flex items-center justify-center gap-2 rounded-xl border border-error/20 bg-background-secondary px-4 py-3 text-sm font-semibold text-error transition hover:border-error/30 hover:bg-error/10 focus:outline-none focus:ring-2 focus:ring-error/20 disabled:cursor-not-allowed disabled:opacity-60"
-              [disabled]="isCompletingTrip || isCancellingTrip"
-              (click)="openCancelTripModal()"
-            >
-              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="m6 6 12 12M18 6 6 18" />
-              </svg>
-              {{ isCancellingTrip ? 'Annulation...' : 'Annuler le trajet' }}
-            </button>
+                <div class="grid grid-cols-2 gap-4">
+                  <div class="rounded-2xl bg-[#f1f3fc] p-3 text-center">
+                    <p class="text-[11px] font-semibold uppercase tracking-[0.05em] text-[#9C9C9C]">Poids disponible</p>
+                    <p class="mt-1 font-bold text-[#015ab4]">{{ remainingWeight() | number:'1.0-2' }} kg</p>
+                  </div>
+                  <div class="rounded-2xl bg-[#f1f3fc] p-3 text-center">
+                    <p class="text-[11px] font-semibold uppercase tracking-[0.05em] text-[#9C9C9C]">Demandes</p>
+                    <p class="mt-1 font-bold text-[#181c22]">{{ bookings.length }} total</p>
+                  </div>
+                </div>
+              </div>
+            }
           </div>
         </section>
-      }
 
-      @if (actionError) {
-        <div class="rounded-2xl border border-error/20 bg-error/10 px-4 py-3 text-sm text-error shadow-sm" role="alert">
-          {{ actionError }}
-        </div>
-      }
+        <section class="mb-6">
+          <div class="mb-4 flex items-center justify-between gap-3">
+            <h2 class="text-[2rem] font-bold leading-tight tracking-[-0.02em] text-[#181c22]">Demandes en cours</h2>
 
-      <section class="rounded-2xl border border-background-primary bg-background-secondary p-5 shadow-sm sm:p-6" aria-labelledby="booking-requests-title">
-        <div class="mb-5 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 id="booking-requests-title" class="text-xl font-bold text-text-primary">Demandes de réservation</h2>
-            <p class="text-sm text-text-secondary">Consultez et gérez les colis liés à ce trajet.</p>
+            <button
+              type="button"
+              class="inline-flex items-center gap-2 rounded-xl border border-[#e0e2eb] bg-white px-4 py-2 text-sm text-[#414753] transition hover:bg-[#f1f3fc]"
+              (click)="toggleExtendedFilters()"
+            >
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3 6h18M6 12h12m-9 6h6" />
+              </svg>
+              Filter
+            </button>
           </div>
-          <span class="inline-flex w-fit items-center rounded-full bg-background-primary px-3 py-1 text-xs font-semibold text-text-secondary">
-            {{ bookings.length }} demande{{ bookings.length > 1 ? 's' : '' }}
-          </span>
-        </div>
+
+          <div class="w-full max-w-md rounded-2xl bg-[#f1f3fc] p-1">
+            <div class="grid grid-cols-2 gap-1">
+              @for (tab of primaryStatusTabs; track tab.value) {
+                <button
+                  type="button"
+                  class="rounded-xl px-4 py-3 text-sm font-bold transition"
+                  [class]="selectedTab === tab.value
+                    ? 'bg-white text-[#015ab4] shadow-sm'
+                    : 'text-[#6B6B6B]'"
+                  (click)="selectTab(tab.value)"
+                >
+                  {{ tab.label }} ({{ bookingCountForStatus(tab.value) }})
+                </button>
+              }
+            </div>
+          </div>
+
+          @if (showExtendedFilters && hasExtendedStatuses()) {
+            <div class="mt-3 flex flex-wrap gap-2">
+              @for (tab of extendedStatusTabs; track tab.value) {
+                @if (bookingCountForStatus(tab.value) > 0 || tab.value === 'ALL') {
+                  <button
+                    type="button"
+                    class="rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.05em] transition"
+                    [class]="selectedTab === tab.value
+                      ? 'border-[#015ab4] bg-[#015ab4] text-white'
+                      : 'border-[#c1c6d5] bg-white text-[#6B6B6B]'"
+                    (click)="selectTab(tab.value)"
+                  >
+                    {{ tab.label }} ({{ bookingCountForStatus(tab.value) }})
+                  </button>
+                }
+              }
+            </div>
+          }
+        </section>
+
+        @if (actionError) {
+          <div class="mb-6 rounded-2xl border border-error/20 bg-error/10 px-4 py-3 text-sm text-error" role="alert">
+            {{ actionError }}
+          </div>
+        }
 
         @if (isLoading) {
-          <div class="flex flex-col items-center justify-center py-16 text-center" role="status" aria-live="polite">
-            <div class="h-12 w-12 animate-spin rounded-full border-4 border-secondary/20 border-t-secondary"></div>
-            <p class="mt-4 text-sm font-medium text-text-secondary">Chargement des demandes...</p>
-          </div>
-        } @else if (loadError) {
-          <div class="rounded-2xl border border-error/20 bg-error/10 px-5 py-6 text-center" role="alert">
-            <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-error/15 text-error">
-              <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3m0 4h.01M4.93 19h14.14c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.2 16c-.77 1.33.19 3 1.73 3Z" />
-              </svg>
-            </div>
-            <p class="mt-4 text-sm font-medium text-error">{{ loadError }}</p>
-          </div>
-        } @else if (!bookings || bookings.length === 0) {
-          <div class="rounded-2xl bg-background-primary px-5 py-12 text-center">
-            <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-secondary/10 text-secondary">
+          <section class="rounded-2xl border border-[#c1c6d5] bg-white px-5 py-16 text-center shadow-[0_8px_30px_rgba(0,0,0,0.04)]" role="status" aria-live="polite">
+            <div class="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-[#e0e2eb] border-t-[#015ab4]"></div>
+            <p class="mt-4 text-sm font-medium text-[#6B6B6B]">Chargement des demandes...</p>
+          </section>
+        } @else if (!filteredBookings().length) {
+          <section class="rounded-2xl border border-[#c1c6d5] bg-white px-5 py-16 text-center shadow-[0_8px_30px_rgba(0,0,0,0.04)]">
+            <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-[#f1f3fc] text-[#015ab4]">
               <svg class="h-7 w-7" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M20 13V7a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v6m16 0-2.59 0a1 1 0 0 0-.7.29l-1.42 1.42a1 1 0 0 1-.7.29h-3.18a1 1 0 0 1-.7-.29l-1.42-1.42a1 1 0 0 0-.7-.29H4" />
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 13v5a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-5" />
               </svg>
             </div>
-            <h3 class="mt-4 text-lg font-semibold text-text-primary">Aucune demande pour le moment</h3>
-            <p class="mt-2 text-sm text-text-secondary">Les nouvelles demandes de réservation apparaîtront ici dès qu'un expéditeur réservera ce trajet.</p>
-          </div>
+            <h3 class="mt-4 text-lg font-bold text-[#181c22]">Aucune réservation dans cet onglet</h3>
+            <p class="mt-2 text-sm text-[#6B6B6B]">Changez de filtre pour voir les autres demandes de ce trajet.</p>
+          </section>
         } @else {
-          <div class="space-y-4">
-            @for (booking of bookings; track booking.id) {
-              <app-booking-request-card
-                [booking]="booking"
-                [tripStatus]="trip.status"
-                [isProcessing]="isBookingProcessing(booking.id)"
-                [tripId]="trip.id"
-                [pricePerKilo]="trip.pricePerKilo"
-                (accept)="acceptBooking($event)"
-                (reject)="rejectBooking($event)"
-                (remove)="openRemoveBookingModal($event)"
-                (message)="messageSender($event)"
-                (confirmDelivery)="confirmBookingDelivery($event)"
-              />
-            }
-          </div>
+          <section>
+            <div class="grid grid-cols-1 gap-4 xl:auto-rows-fr xl:grid-cols-2 xl:gap-6">
+              @for (booking of paginatedBookings(); track booking.id) {
+                <app-booking-request-card
+                  [booking]="booking"
+                  [tripStatus]="trip.status"
+                  [isProcessing]="isBookingProcessing(booking.id)"
+                  [tripId]="trip.id"
+                  [pricePerKilo]="trip.pricePerKilo"
+                  (accept)="acceptBooking($event)"
+                  (reject)="rejectBooking($event)"
+                  (remove)="openRemoveBookingModal($event)"
+                  (message)="messageSender($event)"
+                  (confirmDelivery)="confirmBookingDelivery($event)"
+                />
+              }
+            </div>
+
+            <div class="mt-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <p class="text-sm text-[#6B6B6B]">
+                {{ currentRangeEnd() }} sur {{ filteredBookings().length }} demandes
+              </p>
+
+              @if (totalPages() > 1) {
+                <nav class="flex items-center gap-2" aria-label="Pagination des réservations">
+                  <button
+                    type="button"
+                    class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-[#e0e2eb] bg-white text-[#6B6B6B] transition hover:bg-[#f1f3fc] disabled:opacity-50"
+                    [disabled]="currentPage === 1"
+                    (click)="goToPage(currentPage - 1)"
+                  >
+                    <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m15 19-7-7 7-7" />
+                    </svg>
+                  </button>
+
+                  @for (page of pageNumbers(); track page) {
+                    <button
+                      type="button"
+                      class="inline-flex h-10 min-w-10 items-center justify-center rounded-xl border text-sm font-bold transition"
+                      [class]="page === currentPage
+                        ? 'border-[#015ab4] bg-[#015ab4] text-white'
+                        : 'border-[#e0e2eb] bg-white text-[#414753] hover:bg-[#f1f3fc]'"
+                      (click)="goToPage(page)"
+                    >
+                      {{ page }}
+                    </button>
+                  }
+
+                  <button
+                    type="button"
+                    class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-[#e0e2eb] bg-white text-[#414753] transition hover:bg-[#f1f3fc] disabled:opacity-50"
+                    [disabled]="currentPage === totalPages()"
+                    (click)="goToPage(currentPage + 1)"
+                  >
+                    <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m9 5 7 7-7 7" />
+                    </svg>
+                  </button>
+                </nav>
+              }
+            </div>
+          </section>
         }
-      </section>
-    }
-  </div>
+      }
+    </div>
+  </main>
+
+  @if (trip?.status === 'ACTIVE') {
+    <div class="fixed bottom-0 right-0 z-40 hidden border-t border-[#c1c6d5] bg-white/90 p-4 backdrop-blur-md md:flex md:w-[calc(100%-256px)] md:justify-end">
+      <div class="mr-4 flex gap-4">
+        <button
+          type="button"
+          class="inline-flex items-center justify-center gap-2 rounded-xl border border-[#717785] px-6 py-3 text-sm font-bold text-[#465f88] transition hover:bg-[#f1f3fc]"
+          [disabled]="isCompletingTrip || isCancellingTrip"
+          (click)="openCancelTripModal()"
+        >
+          <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+          </svg>
+          {{ isCancellingTrip ? 'Annulation...' : 'Annuler le voyage' }}
+        </button>
+
+        <button
+          type="button"
+          class="inline-flex items-center justify-center gap-2 rounded-xl bg-[#015ab4] px-6 py-3 text-sm font-bold text-white transition hover:opacity-90"
+          [disabled]="isCompletingTrip || isCancellingTrip"
+          (click)="markTripCompleted()"
+        >
+          <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m5 13 4 4L19 7" />
+          </svg>
+          {{ isCompletingTrip ? 'Validation...' : 'Terminer le voyage' }}
+        </button>
+      </div>
+    </div>
+
+    <div class="fixed bottom-0 left-0 right-0 z-40 border-t border-[#c1c6d5] bg-white/90 p-2 backdrop-blur-md md:hidden">
+      <div class="flex gap-2">
+        <button
+          type="button"
+          class="flex-1 rounded-full border border-[#717785] px-4 py-2.5 text-sm font-bold text-[#465f88]"
+          [disabled]="isCompletingTrip || isCancellingTrip"
+          (click)="openCancelTripModal()"
+        >
+          Annuler
+        </button>
+        <button
+          type="button"
+          class="flex-1 rounded-full bg-[#015ab4] px-4 py-2.5 text-sm font-bold text-white"
+          [disabled]="isCompletingTrip || isCancellingTrip"
+          (click)="markTripCompleted()"
+        >
+          Terminer
+        </button>
+      </div>
+    </div>
+  }
 </div>
 
 <app-confirm-modal

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.spec.ts
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.spec.ts
@@ -1,0 +1,218 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
+import { BehaviorSubject, Subject, of, throwError } from 'rxjs';
+import { BookingResponse } from '../../models/booking.model';
+import { Trip } from '../../models/trip.model';
+import { MessagingService } from '../../services/messaging.service';
+import { TripService } from '../../services/trip.service';
+import { ReservationDetailsPageComponent } from './reservation-details-page.component';
+
+describe('ReservationDetailsPageComponent', () => {
+  let fixture: ComponentFixture<ReservationDetailsPageComponent>;
+  let component: ReservationDetailsPageComponent;
+  let router: Router;
+
+  const tripParamMap$ = new BehaviorSubject(convertToParamMap({ tripId: '12' }));
+
+  const tripServiceMock = {
+    getTripById: jasmine.createSpy('getTripById'),
+    getTripBookings: jasmine.createSpy('getTripBookings'),
+    acceptBooking: jasmine.createSpy('acceptBooking'),
+    rejectBooking: jasmine.createSpy('rejectBooking'),
+    removeBooking: jasmine.createSpy('removeBooking'),
+    completeTrip: jasmine.createSpy('completeTrip'),
+    cancelTrip: jasmine.createSpy('cancelTrip'),
+    confirmBookingDelivery: jasmine.createSpy('confirmBookingDelivery'),
+  };
+
+  const messagingServiceMock = {
+    startConversation: jasmine.createSpy('startConversation'),
+  };
+
+  beforeEach(async () => {
+    tripParamMap$.next(convertToParamMap({ tripId: '12' }));
+    tripServiceMock.getTripById.calls.reset();
+    tripServiceMock.getTripBookings.calls.reset();
+    tripServiceMock.acceptBooking.calls.reset();
+    tripServiceMock.rejectBooking.calls.reset();
+    tripServiceMock.removeBooking.calls.reset();
+    tripServiceMock.completeTrip.calls.reset();
+    tripServiceMock.cancelTrip.calls.reset();
+    tripServiceMock.confirmBookingDelivery.calls.reset();
+    messagingServiceMock.startConversation.calls.reset();
+
+    tripServiceMock.getTripById.and.returnValue(of(buildTrip()));
+    tripServiceMock.getTripBookings.and.returnValue(of([buildBooking()]));
+    tripServiceMock.acceptBooking.and.returnValue(of({ ...buildBooking(), status: 'ACCEPTED' }));
+    tripServiceMock.rejectBooking.and.returnValue(of({ ...buildBooking(), status: 'REJECTED' }));
+    tripServiceMock.removeBooking.and.returnValue(of(void 0));
+    tripServiceMock.completeTrip.and.returnValue(of({ ...buildTrip(), status: 'COMPLETED' }));
+    tripServiceMock.cancelTrip.and.returnValue(of(void 0));
+    tripServiceMock.confirmBookingDelivery.and.returnValue(of({
+      ...buildBooking(),
+      status: 'ACCEPTED',
+      validationCodeActive: false,
+      deliveredAt: '2025-07-15T10:00:00',
+    }));
+    messagingServiceMock.startConversation.and.returnValue(of({
+      id: 1,
+      tripId: 12,
+      tripRoute: 'Paris → Abidjan',
+      otherParticipantId: 55,
+      otherParticipantName: 'Grace Hopper',
+      lastMessage: 'Bonjour',
+      unreadCount: 0,
+      createdAt: '2025-07-15T09:00:00',
+    }));
+
+    await TestBed.configureTestingModule({
+      imports: [ReservationDetailsPageComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: tripParamMap$.asObservable(),
+          },
+        },
+        { provide: TripService, useValue: tripServiceMock },
+        { provide: MessagingService, useValue: messagingServiceMock },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate').and.resolveTo(true);
+  });
+
+  function createComponent(): void {
+    fixture = TestBed.createComponent(ReservationDetailsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('shows a loading state while reservation details are being fetched', () => {
+    const tripSubject = new Subject<Trip>();
+    const bookingsSubject = new Subject<BookingResponse[]>();
+    tripServiceMock.getTripById.and.returnValue(tripSubject.asObservable());
+    tripServiceMock.getTripBookings.and.returnValue(bookingsSubject.asObservable());
+
+    createComponent();
+
+    expect(fixture.nativeElement.textContent).toContain('Chargement des demandes');
+  });
+
+  it('shows an error state when the reservation details request fails', () => {
+    tripServiceMock.getTripById.and.returnValue(throwError(() => new Error('boom')));
+    tripServiceMock.getTripBookings.and.returnValue(throwError(() => new Error('boom')));
+
+    createComponent();
+
+    expect(fixture.nativeElement.textContent).toContain('Impossible de charger les détails de cette réservation.');
+  });
+
+  it('accepts a booking and updates it in the page state', () => {
+    createComponent();
+
+    component.acceptBooking(7);
+
+    expect(tripServiceMock.acceptBooking).toHaveBeenCalledWith(12, 7);
+    expect(component.bookings[0].status).toBe('ACCEPTED');
+  });
+
+  it('rejects a booking and updates it in the page state', () => {
+    createComponent();
+
+    component.rejectBooking(7);
+
+    expect(tripServiceMock.rejectBooking).toHaveBeenCalledWith(12, 7);
+    expect(component.bookings[0].status).toBe('REJECTED');
+  });
+
+  it('removes a booking after confirmation', () => {
+    createComponent();
+
+    component.openRemoveBookingModal(7);
+    component.confirmRemoveBooking();
+
+    expect(tripServiceMock.removeBooking).toHaveBeenCalledWith(12, 7);
+    expect(component.bookings).toEqual([]);
+    expect(component.isRemoveBookingModalOpen).toBeFalse();
+  });
+
+  it('starts a conversation with the sender and navigates to messages', () => {
+    createComponent();
+
+    component.messageSender(7);
+
+    expect(messagingServiceMock.startConversation).toHaveBeenCalledWith({
+      tripId: 12,
+      recipientId: 55,
+      content: 'Bonjour, je vous contacte au sujet de votre réservation "Documents" pour mon trajet Paris, France vers Abidjan, Côte d\'Ivoire.',
+    });
+    expect(router.navigate).toHaveBeenCalledWith(['/messages']);
+  });
+
+  it('marks the trip as completed', () => {
+    createComponent();
+
+    component.markTripCompleted();
+
+    expect(tripServiceMock.completeTrip).toHaveBeenCalledWith(12);
+    expect(component.trip?.status).toBe('COMPLETED');
+  });
+
+  it('cancels the trip and navigates back to the dashboard received tab', () => {
+    createComponent();
+
+    component.openCancelTripModal();
+    component.confirmCancelTrip();
+
+    expect(tripServiceMock.cancelTrip).toHaveBeenCalledWith(12);
+    expect(router.navigate).toHaveBeenCalledWith(['/dashboard'], {
+      queryParams: { tab: 'received' },
+    });
+  });
+
+  it('confirms a booking delivery with the provided validation code', () => {
+    createComponent();
+
+    component.confirmBookingDelivery({ bookingId: 7, code: '123456' });
+
+    expect(tripServiceMock.confirmBookingDelivery).toHaveBeenCalledWith(12, 7, {
+      validationCode: '123456',
+    });
+    expect(component.bookings[0].deliveredAt).toBe('2025-07-15T10:00:00');
+  });
+});
+
+function buildTrip(): Trip {
+  return {
+    id: 12,
+    travelerId: 1,
+    travelerName: 'Ada Lovelace',
+    departureAddress: 'Paris, France',
+    destination: "Abidjan, Côte d'Ivoire",
+    departureTime: '2025-07-14T08:00:00',
+    arrivalTime: '2025-07-14T16:00:00',
+    maxWeight: 20,
+    pricePerKilo: 15,
+    instantAcceptance: true,
+    status: 'ACTIVE',
+    availableWeight: 8,
+  };
+}
+
+function buildBooking(): BookingResponse {
+  return {
+    id: 7,
+    tripId: 12,
+    senderId: 55,
+    senderName: 'Grace Hopper',
+    title: 'Documents',
+    weight: 2,
+    description: 'Dossier important',
+    recipientContact: '+22501020304',
+    status: 'PENDING',
+    validationCodeActive: false,
+  };
+}

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.spec.ts
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.spec.ts
@@ -172,6 +172,16 @@ describe('ReservationDetailsPageComponent', () => {
     expect(component.usedWeightPercentage()).toBe(35);
   });
 
+  it('opens and closes the mobile menu', () => {
+    createComponent();
+
+    component.openMobileMenu();
+    expect(component.isMobileMenuOpen).toBeTrue();
+
+    component.closeMobileMenu();
+    expect(component.isMobileMenuOpen).toBeFalse();
+  });
+
   it('accepts a booking and updates it in the page state', () => {
     createComponent();
 

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.spec.ts
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.spec.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, Subject, of, throwError } from 'rxjs';
 import { BookingResponse } from '../../models/booking.model';
 import { Trip } from '../../models/trip.model';
 import { MessagingService } from '../../services/messaging.service';
+import { AuthService } from '../../services/auth.service';
 import { TripService } from '../../services/trip.service';
 import { ReservationDetailsPageComponent } from './reservation-details-page.component';
 
@@ -29,6 +30,18 @@ describe('ReservationDetailsPageComponent', () => {
     startConversation: jasmine.createSpy('startConversation'),
   };
 
+  const authServiceMock = {
+    getUser: jasmine.createSpy('getUser').and.returnValue({
+      id: 1,
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'ada@example.com',
+      hasPassword: true,
+      photoUrl: null,
+    }),
+    logout: jasmine.createSpy('logout'),
+  };
+
   beforeEach(async () => {
     tripParamMap$.next(convertToParamMap({ tripId: '12' }));
     tripServiceMock.getTripById.calls.reset();
@@ -40,6 +53,8 @@ describe('ReservationDetailsPageComponent', () => {
     tripServiceMock.cancelTrip.calls.reset();
     tripServiceMock.confirmBookingDelivery.calls.reset();
     messagingServiceMock.startConversation.calls.reset();
+    authServiceMock.getUser.calls.reset();
+    authServiceMock.logout.calls.reset();
 
     tripServiceMock.getTripById.and.returnValue(of(buildTrip()));
     tripServiceMock.getTripBookings.and.returnValue(of([buildBooking()]));
@@ -77,6 +92,7 @@ describe('ReservationDetailsPageComponent', () => {
         },
         { provide: TripService, useValue: tripServiceMock },
         { provide: MessagingService, useValue: messagingServiceMock },
+        { provide: AuthService, useValue: authServiceMock },
       ],
     }).compileComponents();
 
@@ -108,6 +124,52 @@ describe('ReservationDetailsPageComponent', () => {
     createComponent();
 
     expect(fixture.nativeElement.textContent).toContain('Impossible de charger les détails de cette réservation.');
+  });
+
+  it('defaults to the pending tab when pending bookings are available', () => {
+    createComponent();
+
+    expect(component.selectedTab).toBe('PENDING');
+    expect(component.filteredBookings().length).toBe(1);
+  });
+
+  it('filters bookings by status and paginates the current tab', () => {
+    tripServiceMock.getTripBookings.and.returnValue(of([
+      buildBooking({ id: 1, status: 'PENDING', title: 'A' }),
+      buildBooking({ id: 2, status: 'PENDING', title: 'B' }),
+      buildBooking({ id: 3, status: 'PENDING', title: 'C' }),
+      buildBooking({ id: 4, status: 'PENDING', title: 'D' }),
+      buildBooking({ id: 5, status: 'PENDING', title: 'E' }),
+      buildBooking({ id: 6, status: 'ACCEPTED', title: 'F' }),
+    ]));
+
+    createComponent();
+
+    expect(component.filteredBookings().length).toBe(5);
+    expect(component.paginatedBookings().map((booking) => booking.id)).toEqual([1, 2, 3, 4]);
+
+    component.goToPage(2);
+
+    expect(component.paginatedBookings().map((booking) => booking.id)).toEqual([5]);
+
+    component.selectTab('ACCEPTED');
+
+    expect(component.currentPage).toBe(1);
+    expect(component.paginatedBookings().map((booking) => booking.id)).toEqual([6]);
+  });
+
+  it('computes the demanded and remaining weight from active bookings', () => {
+    tripServiceMock.getTripBookings.and.returnValue(of([
+      buildBooking({ id: 1, status: 'PENDING', weight: 3 }),
+      buildBooking({ id: 2, status: 'ACCEPTED', weight: 4 }),
+      buildBooking({ id: 3, status: 'REJECTED', weight: 6 }),
+    ]));
+
+    createComponent();
+
+    expect(component.demandedWeight()).toBe(7);
+    expect(component.remainingWeight()).toBe(13);
+    expect(component.usedWeightPercentage()).toBe(35);
   });
 
   it('accepts a booking and updates it in the page state', () => {
@@ -202,7 +264,7 @@ function buildTrip(): Trip {
   };
 }
 
-function buildBooking(): BookingResponse {
+function buildBooking(overrides: Partial<BookingResponse> = {}): BookingResponse {
   return {
     id: 7,
     tripId: 12,
@@ -214,5 +276,6 @@ function buildBooking(): BookingResponse {
     recipientContact: '+22501020304',
     status: 'PENDING',
     validationCodeActive: false,
+    ...overrides,
   };
 }

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.ts
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.ts
@@ -1,0 +1,307 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { forkJoin } from 'rxjs';
+import { BookingResponse } from '../../models/booking.model';
+import { Trip } from '../../models/trip.model';
+import { BookingRequestCardComponent } from '../../components/reservation-details/booking-request-card/booking-request-card.component';
+import { TripService } from '../../services/trip.service';
+import { MessagingService } from '../../services/messaging.service';
+import { ConfirmModalComponent } from '../../shared/components/confirm-modal/confirm-modal.component';
+
+@Component({
+  selector: 'app-reservation-details-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterLink,
+    BookingRequestCardComponent,
+    ConfirmModalComponent,
+  ],
+  templateUrl: './reservation-details-page.component.html',
+})
+export class ReservationDetailsPageComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly tripService = inject(TripService);
+  private readonly messagingService = inject(MessagingService);
+
+  trip: Trip | null = null;
+  bookings: BookingResponse[] = [];
+  isLoading = true;
+  loadError = '';
+  actionError = '';
+  isCompletingTrip = false;
+  isCancellingTrip = false;
+  processingBookingId: number | null = null;
+  isCancelTripModalOpen = false;
+  isRemoveBookingModalOpen = false;
+  pendingRemoveBookingId: number | null = null;
+
+  ngOnInit(): void {
+    this.route.paramMap.subscribe((params) => {
+      const tripId = Number(params.get('tripId'));
+
+      if (!Number.isInteger(tripId) || tripId <= 0) {
+        this.trip = null;
+        this.bookings = [];
+        this.loadError = 'Impossible de charger les détails de cette réservation.';
+        this.isLoading = false;
+        return;
+      }
+
+      this.loadReservationDetails(tripId);
+    });
+  }
+
+  tripStatusLabel(status: Trip['status']): string {
+    return ({
+      ACTIVE: 'Actif',
+      COMPLETED: 'Terminé',
+      CANCELLED: 'Annulé',
+    } as Record<Trip['status'], string>)[status];
+  }
+
+  tripStatusClass(status: Trip['status']): string {
+    return ({
+      ACTIVE: 'border-accent/20 bg-accent/10 text-accent',
+      COMPLETED: 'border-success/20 bg-success/10 text-success',
+      CANCELLED: 'border-error/20 bg-error/10 text-error',
+    } as Record<Trip['status'], string>)[status];
+  }
+
+  editTrip(): void {
+    if (!this.trip) {
+      return;
+    }
+
+    void this.router.navigate(['/propose', this.trip.id]);
+  }
+
+  markTripCompleted(): void {
+    if (!this.trip || this.isCompletingTrip || this.isCancellingTrip) {
+      return;
+    }
+
+    this.isCompletingTrip = true;
+    this.actionError = '';
+    this.tripService.completeTrip(this.trip.id).subscribe({
+      next: (updatedTrip) => {
+        this.trip = updatedTrip;
+        this.isCompletingTrip = false;
+      },
+      error: (error: { error?: { message?: string } }) => {
+        this.actionError = error.error?.message || 'Impossible de marquer ce trajet comme terminé.';
+        this.isCompletingTrip = false;
+      },
+    });
+  }
+
+  openCancelTripModal(): void {
+    if (!this.trip || this.isCompletingTrip || this.isCancellingTrip) {
+      return;
+    }
+
+    this.isCancelTripModalOpen = true;
+  }
+
+  closeCancelTripModal(): void {
+    this.isCancelTripModalOpen = false;
+  }
+
+  confirmCancelTrip(): void {
+    if (!this.trip || this.isCancellingTrip) {
+      return;
+    }
+
+    this.isCancellingTrip = true;
+    this.actionError = '';
+    this.tripService.cancelTrip(this.trip.id).subscribe({
+      next: () => {
+        this.isCancellingTrip = false;
+        this.isCancelTripModalOpen = false;
+        this.navigateBackToDashboard();
+      },
+      error: (error: { error?: { message?: string } }) => {
+        this.actionError = error.error?.message || 'Impossible d’annuler ce trajet pour le moment.';
+        this.isCancellingTrip = false;
+        this.isCancelTripModalOpen = false;
+      },
+    });
+  }
+
+  acceptBooking(bookingId: number): void {
+    if (!this.trip || this.processingBookingId !== null) {
+      return;
+    }
+
+    this.processingBookingId = bookingId;
+    this.actionError = '';
+    this.tripService.acceptBooking(this.trip.id, bookingId).subscribe({
+      next: (updatedBooking) => {
+        this.updateBooking(updatedBooking);
+        this.processingBookingId = null;
+      },
+      error: (error: { error?: { message?: string } }) => {
+        this.actionError = error.error?.message || 'Impossible d’accepter cette réservation.';
+        this.processingBookingId = null;
+      },
+    });
+  }
+
+  rejectBooking(bookingId: number): void {
+    if (!this.trip || this.processingBookingId !== null) {
+      return;
+    }
+
+    this.processingBookingId = bookingId;
+    this.actionError = '';
+    this.tripService.rejectBooking(this.trip.id, bookingId).subscribe({
+      next: (updatedBooking) => {
+        this.updateBooking(updatedBooking);
+        this.processingBookingId = null;
+      },
+      error: (error: { error?: { message?: string } }) => {
+        this.actionError = error.error?.message || 'Impossible de refuser cette réservation.';
+        this.processingBookingId = null;
+      },
+    });
+  }
+
+  openRemoveBookingModal(bookingId: number): void {
+    if (this.processingBookingId !== null) {
+      return;
+    }
+
+    this.pendingRemoveBookingId = bookingId;
+    this.isRemoveBookingModalOpen = true;
+  }
+
+  closeRemoveBookingModal(): void {
+    this.pendingRemoveBookingId = null;
+    this.isRemoveBookingModalOpen = false;
+  }
+
+  confirmRemoveBooking(): void {
+    if (!this.trip || this.pendingRemoveBookingId === null || this.processingBookingId !== null) {
+      return;
+    }
+
+    const bookingId = this.pendingRemoveBookingId;
+    this.processingBookingId = bookingId;
+    this.actionError = '';
+    this.tripService.removeBooking(this.trip.id, bookingId).subscribe({
+      next: () => {
+        this.bookings = this.bookings.filter((booking) => booking.id !== bookingId);
+        this.processingBookingId = null;
+        this.closeRemoveBookingModal();
+      },
+      error: (error: { error?: { message?: string } }) => {
+        this.actionError = error.error?.message || 'Impossible de retirer cette réservation.';
+        this.processingBookingId = null;
+        this.closeRemoveBookingModal();
+      },
+    });
+  }
+
+  messageSender(bookingId: number): void {
+    if (!this.trip || this.processingBookingId !== null) {
+      return;
+    }
+
+    const booking = this.bookings.find((currentBooking) => currentBooking.id === bookingId);
+    if (!booking) {
+      return;
+    }
+
+    this.processingBookingId = bookingId;
+    this.actionError = '';
+    this.messagingService.startConversation({
+      tripId: this.trip.id,
+      recipientId: booking.senderId,
+      content:
+        `Bonjour, je vous contacte au sujet de votre réservation "${booking.title}" `
+        + `pour mon trajet ${this.trip.departureAddress} vers ${this.trip.destination}.`,
+    }).subscribe({
+      next: () => {
+        this.processingBookingId = null;
+        void this.router.navigate(['/messages']);
+      },
+      error: () => {
+        this.actionError = 'Impossible de démarrer la conversation.';
+        this.processingBookingId = null;
+      },
+    });
+  }
+
+  confirmBookingDelivery(payload: { bookingId: number; code: string }): void {
+    if (!this.trip || this.processingBookingId !== null) {
+      return;
+    }
+
+    const validationCode = payload.code.trim();
+    if (!/^\d{6}$/.test(validationCode)) {
+      this.actionError = 'Saisissez un code de validation à 6 chiffres.';
+      return;
+    }
+
+    this.processingBookingId = payload.bookingId;
+    this.actionError = '';
+    this.tripService.confirmBookingDelivery(this.trip.id, payload.bookingId, { validationCode }).subscribe({
+      next: (updatedBooking) => {
+        this.updateBooking(updatedBooking);
+        this.processingBookingId = null;
+      },
+      error: (error: { error?: { message?: string } }) => {
+        this.actionError = error.error?.message || 'Impossible de confirmer la remise du colis.';
+        this.processingBookingId = null;
+      },
+    });
+  }
+
+  isBookingProcessing(bookingId: number): boolean {
+    return this.processingBookingId === bookingId;
+  }
+
+  isPendingRemoveBookingProcessing(): boolean {
+    return this.pendingRemoveBookingId !== null && this.isBookingProcessing(this.pendingRemoveBookingId);
+  }
+
+  private loadReservationDetails(tripId: number): void {
+    this.isLoading = true;
+    this.loadError = '';
+    this.actionError = '';
+    this.processingBookingId = null;
+    this.closeRemoveBookingModal();
+    this.closeCancelTripModal();
+
+    forkJoin({
+      trip: this.tripService.getTripById(tripId),
+      bookings: this.tripService.getTripBookings(tripId),
+    }).subscribe({
+      next: ({ trip, bookings }) => {
+        this.trip = trip;
+        this.bookings = bookings;
+        this.isLoading = false;
+      },
+      error: () => {
+        this.trip = null;
+        this.bookings = [];
+        this.loadError = 'Impossible de charger les détails de cette réservation.';
+        this.isLoading = false;
+      },
+    });
+  }
+
+  private updateBooking(updatedBooking: BookingResponse): void {
+    this.bookings = this.bookings.map((booking) =>
+      booking.id === updatedBooking.id ? updatedBooking : booking
+    );
+  }
+
+  private navigateBackToDashboard(): void {
+    void this.router.navigate(['/dashboard'], {
+      queryParams: { tab: 'received' },
+    });
+  }
+}

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.ts
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.ts
@@ -5,9 +5,12 @@ import { forkJoin } from 'rxjs';
 import { BookingResponse } from '../../models/booking.model';
 import { Trip } from '../../models/trip.model';
 import { BookingRequestCardComponent } from '../../components/reservation-details/booking-request-card/booking-request-card.component';
+import { AuthService } from '../../services/auth.service';
 import { TripService } from '../../services/trip.service';
 import { MessagingService } from '../../services/messaging.service';
 import { ConfirmModalComponent } from '../../shared/components/confirm-modal/confirm-modal.component';
+
+type ReservationStatusTab = 'ALL' | BookingResponse['status'];
 
 @Component({
   selector: 'app-reservation-details-page',
@@ -23,6 +26,7 @@ import { ConfirmModalComponent } from '../../shared/components/confirm-modal/con
 export class ReservationDetailsPageComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly authService = inject(AuthService);
   private readonly tripService = inject(TripService);
   private readonly messagingService = inject(MessagingService);
 
@@ -37,6 +41,25 @@ export class ReservationDetailsPageComponent implements OnInit {
   isCancelTripModalOpen = false;
   isRemoveBookingModalOpen = false;
   pendingRemoveBookingId: number | null = null;
+  selectedTab: ReservationStatusTab = 'ALL';
+  currentPage = 1;
+  tripSummaryExpanded = false;
+  showExtendedFilters = false;
+
+  private profilePhotoLoadFailed = false;
+  private lastProfilePhotoUrl: string | null = null;
+
+  readonly pageSize = 4;
+  readonly primaryStatusTabs: ReadonlyArray<{ value: ReservationStatusTab; label: string }> = [
+    { value: 'PENDING', label: 'En attentes' },
+    { value: 'ACCEPTED', label: 'Acceptées' },
+  ];
+  readonly extendedStatusTabs: ReadonlyArray<{ value: ReservationStatusTab; label: string }> = [
+    { value: 'REJECTED', label: 'Refusées' },
+    { value: 'CANCELLED', label: 'Annulées' },
+    { value: 'REMOVED', label: 'Retirées' },
+    { value: 'ALL', label: 'Toutes' },
+  ];
 
   ngOnInit(): void {
     this.route.paramMap.subscribe((params) => {
@@ -54,6 +77,73 @@ export class ReservationDetailsPageComponent implements OnInit {
     });
   }
 
+  currentUserName(): string {
+    const user = this.authService.getUser();
+    const name = [user?.firstName?.trim(), user?.lastName?.trim()]
+      .filter((value): value is string => !!value)
+      .join(' ')
+      .trim();
+
+    return name || 'Mon espace';
+  }
+
+  currentUserEmail(): string {
+    return this.authService.getUser()?.email ?? '';
+  }
+
+  hasUserPhoto(): boolean {
+    return !!this.userPhotoUrl();
+  }
+
+  userPhotoUrl(): string | null {
+    const photoUrl = this.authService.getUser()?.photoUrl?.trim() ?? null;
+    if (!photoUrl) {
+      this.profilePhotoLoadFailed = false;
+      this.lastProfilePhotoUrl = null;
+      return null;
+    }
+
+    if (photoUrl !== this.lastProfilePhotoUrl) {
+      this.profilePhotoLoadFailed = false;
+      this.lastProfilePhotoUrl = photoUrl;
+    }
+
+    return this.profilePhotoLoadFailed ? null : photoUrl;
+  }
+
+  userInitials(): string {
+    const user = this.authService.getUser();
+    const firstInitial = user?.firstName?.trim().charAt(0) ?? '';
+    const lastInitial = user?.lastName?.trim().charAt(0) ?? '';
+    const initials = `${firstInitial}${lastInitial}`.toUpperCase();
+
+    if (initials) {
+      return initials;
+    }
+
+    return user?.email?.trim().charAt(0).toUpperCase() ?? 'U';
+  }
+
+  onUserPhotoError(): void {
+    this.profilePhotoLoadFailed = true;
+  }
+
+  logout(): void {
+    this.authService.logout();
+  }
+
+  toggleTripSummary(): void {
+    this.tripSummaryExpanded = !this.tripSummaryExpanded;
+  }
+
+  toggleExtendedFilters(): void {
+    this.showExtendedFilters = !this.showExtendedFilters;
+  }
+
+  hasExtendedStatuses(): boolean {
+    return this.extendedStatusTabs.some((tab) => this.bookingCountForStatus(tab.value) > 0);
+  }
+
   tripStatusLabel(status: Trip['status']): string {
     return ({
       ACTIVE: 'Actif',
@@ -64,10 +154,78 @@ export class ReservationDetailsPageComponent implements OnInit {
 
   tripStatusClass(status: Trip['status']): string {
     return ({
-      ACTIVE: 'border-accent/20 bg-accent/10 text-accent',
-      COMPLETED: 'border-success/20 bg-success/10 text-success',
+      ACTIVE: 'border-[#c1c6d5] bg-[#e0e2eb] text-[#414753]',
+      COMPLETED: 'border-[#b6d0ff] bg-[#b6d0ff]/30 text-[#3f5881]',
       CANCELLED: 'border-error/20 bg-error/10 text-error',
     } as Record<Trip['status'], string>)[status];
+  }
+
+  selectTab(tab: ReservationStatusTab): void {
+    this.selectedTab = tab;
+    this.currentPage = 1;
+  }
+
+  filteredBookings(): BookingResponse[] {
+    if (this.selectedTab === 'ALL') {
+      return this.bookings;
+    }
+
+    return this.bookings.filter((booking) => booking.status === this.selectedTab);
+  }
+
+  paginatedBookings(): BookingResponse[] {
+    const start = (this.currentPage - 1) * this.pageSize;
+    return this.filteredBookings().slice(start, start + this.pageSize);
+  }
+
+  totalPages(): number {
+    return Math.max(1, Math.ceil(this.filteredBookings().length / this.pageSize));
+  }
+
+  pageNumbers(): number[] {
+    return Array.from({ length: this.totalPages() }, (_, index) => index + 1);
+  }
+
+  goToPage(page: number): void {
+    this.currentPage = Math.min(Math.max(page, 1), this.totalPages());
+  }
+
+  currentRangeEnd(): number {
+    return Math.min(this.currentPage * this.pageSize, this.filteredBookings().length);
+  }
+
+  bookingCountForStatus(status: ReservationStatusTab): number {
+    if (status === 'ALL') {
+      return this.bookings.length;
+    }
+
+    return this.bookings.filter((booking) => booking.status === status).length;
+  }
+
+  demandedWeight(): number {
+    return this.bookings
+      .filter((booking) => booking.status === 'PENDING' || booking.status === 'ACCEPTED')
+      .reduce((total, booking) => total + (Number.isFinite(booking.weight) ? booking.weight : 0), 0);
+  }
+
+  remainingWeight(): number {
+    if (!this.trip) {
+      return 0;
+    }
+
+    return Math.max(this.trip.maxWeight - this.demandedWeight(), 0);
+  }
+
+  usedWeight(): number {
+    return this.demandedWeight();
+  }
+
+  usedWeightPercentage(): number {
+    if (!this.trip || this.trip.maxWeight <= 0) {
+      return 0;
+    }
+
+    return Math.min((this.usedWeight() / this.trip.maxWeight) * 100, 100);
   }
 
   editTrip(): void {
@@ -123,7 +281,7 @@ export class ReservationDetailsPageComponent implements OnInit {
         this.navigateBackToDashboard();
       },
       error: (error: { error?: { message?: string } }) => {
-        this.actionError = error.error?.message || 'Impossible d’annuler ce trajet pour le moment.';
+        this.actionError = error.error?.message || "Impossible d'annuler ce trajet pour le moment.";
         this.isCancellingTrip = false;
         this.isCancelTripModalOpen = false;
       },
@@ -143,7 +301,7 @@ export class ReservationDetailsPageComponent implements OnInit {
         this.processingBookingId = null;
       },
       error: (error: { error?: { message?: string } }) => {
-        this.actionError = error.error?.message || 'Impossible d’accepter cette réservation.';
+        this.actionError = error.error?.message || "Impossible d'accepter cette réservation.";
         this.processingBookingId = null;
       },
     });
@@ -193,6 +351,7 @@ export class ReservationDetailsPageComponent implements OnInit {
     this.tripService.removeBooking(this.trip.id, bookingId).subscribe({
       next: () => {
         this.bookings = this.bookings.filter((booking) => booking.id !== bookingId);
+        this.clampCurrentPage();
         this.processingBookingId = null;
         this.closeRemoveBookingModal();
       },
@@ -272,6 +431,8 @@ export class ReservationDetailsPageComponent implements OnInit {
     this.loadError = '';
     this.actionError = '';
     this.processingBookingId = null;
+    this.tripSummaryExpanded = false;
+    this.showExtendedFilters = false;
     this.closeRemoveBookingModal();
     this.closeCancelTripModal();
 
@@ -282,6 +443,8 @@ export class ReservationDetailsPageComponent implements OnInit {
       next: ({ trip, bookings }) => {
         this.trip = trip;
         this.bookings = bookings;
+        this.selectedTab = this.getDefaultStatusTab(bookings);
+        this.currentPage = 1;
         this.isLoading = false;
       },
       error: () => {
@@ -297,11 +460,29 @@ export class ReservationDetailsPageComponent implements OnInit {
     this.bookings = this.bookings.map((booking) =>
       booking.id === updatedBooking.id ? updatedBooking : booking
     );
+    this.clampCurrentPage();
   }
 
   private navigateBackToDashboard(): void {
     void this.router.navigate(['/dashboard'], {
       queryParams: { tab: 'received' },
     });
+  }
+
+  private clampCurrentPage(): void {
+    this.currentPage = Math.min(this.currentPage, this.totalPages());
+    this.currentPage = Math.max(this.currentPage, 1);
+  }
+
+  private getDefaultStatusTab(bookings: BookingResponse[]): ReservationStatusTab {
+    if (bookings.some((booking) => booking.status === 'PENDING')) {
+      return 'PENDING';
+    }
+
+    if (bookings.some((booking) => booking.status === 'ACCEPTED')) {
+      return 'ACCEPTED';
+    }
+
+    return 'ALL';
   }
 }

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.ts
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.ts
@@ -44,7 +44,7 @@ export class ReservationDetailsPageComponent implements OnInit {
   selectedTab: ReservationStatusTab = 'ALL';
   currentPage = 1;
   tripSummaryExpanded = false;
-  showExtendedFilters = false;
+  isMobileMenuOpen = false;
 
   private profilePhotoLoadFailed = false;
   private lastProfilePhotoUrl: string | null = null;
@@ -53,12 +53,6 @@ export class ReservationDetailsPageComponent implements OnInit {
   readonly primaryStatusTabs: ReadonlyArray<{ value: ReservationStatusTab; label: string }> = [
     { value: 'PENDING', label: 'En attentes' },
     { value: 'ACCEPTED', label: 'Acceptées' },
-  ];
-  readonly extendedStatusTabs: ReadonlyArray<{ value: ReservationStatusTab; label: string }> = [
-    { value: 'REJECTED', label: 'Refusées' },
-    { value: 'CANCELLED', label: 'Annulées' },
-    { value: 'REMOVED', label: 'Retirées' },
-    { value: 'ALL', label: 'Toutes' },
   ];
 
   ngOnInit(): void {
@@ -136,12 +130,12 @@ export class ReservationDetailsPageComponent implements OnInit {
     this.tripSummaryExpanded = !this.tripSummaryExpanded;
   }
 
-  toggleExtendedFilters(): void {
-    this.showExtendedFilters = !this.showExtendedFilters;
+  openMobileMenu(): void {
+    this.isMobileMenuOpen = true;
   }
 
-  hasExtendedStatuses(): boolean {
-    return this.extendedStatusTabs.some((tab) => this.bookingCountForStatus(tab.value) > 0);
+  closeMobileMenu(): void {
+    this.isMobileMenuOpen = false;
   }
 
   tripStatusLabel(status: Trip['status']): string {
@@ -166,11 +160,7 @@ export class ReservationDetailsPageComponent implements OnInit {
   }
 
   filteredBookings(): BookingResponse[] {
-    if (this.selectedTab === 'ALL') {
-      return this.bookings;
-    }
-
-    return this.bookings.filter((booking) => booking.status === this.selectedTab);
+    return this.bookings.filter((booking) => this.matchesStatusFilter(booking));
   }
 
   paginatedBookings(): BookingResponse[] {
@@ -432,7 +422,6 @@ export class ReservationDetailsPageComponent implements OnInit {
     this.actionError = '';
     this.processingBookingId = null;
     this.tripSummaryExpanded = false;
-    this.showExtendedFilters = false;
     this.closeRemoveBookingModal();
     this.closeCancelTripModal();
 
@@ -484,5 +473,9 @@ export class ReservationDetailsPageComponent implements OnInit {
     }
 
     return 'ALL';
+  }
+
+  private matchesStatusFilter(booking: BookingResponse): boolean {
+    return this.selectedTab === 'ALL' || booking.status === this.selectedTab;
   }
 }

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.spec.ts
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.spec.ts
@@ -219,15 +219,15 @@ describe('TripsManagementPageComponent', () => {
     });
 
     it('should return correct dot class for each status', () => {
-      expect(component.tripStatusDotClass('ACTIVE')).toBe('bg-success');
-      expect(component.tripStatusDotClass('COMPLETED')).toBe('bg-text-muted');
-      expect(component.tripStatusDotClass('CANCELLED')).toBe('bg-error');
+      expect(component.tripStatusDotClass('ACTIVE')).toBe('bg-accent');
+      expect(component.tripStatusDotClass('COMPLETED')).toBe('bg-success');
+      expect(component.tripStatusDotClass('CANCELLED')).toBe('bg-text-muted');
     });
 
     it('should return correct text class for each status', () => {
-      expect(component.tripStatusTextClass('ACTIVE')).toBe('text-success');
-      expect(component.tripStatusTextClass('COMPLETED')).toBe('text-text-muted');
-      expect(component.tripStatusTextClass('CANCELLED')).toBe('text-error');
+      expect(component.tripStatusTextClass('ACTIVE')).toBe('text-accent');
+      expect(component.tripStatusTextClass('COMPLETED')).toBe('text-success');
+      expect(component.tripStatusTextClass('CANCELLED')).toBe('text-text-muted');
     });
   });
 

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.ts
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.ts
@@ -157,7 +157,7 @@ export class TripsManagementPageComponent implements OnInit {
 
   /** Navigate to trip bookings/details. */
   viewTripDetails(tripId: number): void {
-    void this.router.navigate(['/dashboard'], { queryParams: { tab: 'received', tripId } });
+    void this.router.navigate(['/trips', tripId, 'reservations']);
   }
 
   /** Navigate to edit a trip. */

--- a/front-office/src/app/services/trip.service.spec.ts
+++ b/front-office/src/app/services/trip.service.spec.ts
@@ -184,4 +184,30 @@ describe('TripService', () => {
     expect(req.request.body).toEqual({ validationCode: '123456' });
     req.flush({});
   });
+
+  it('normalizes sender and package photo URLs in trip bookings', () => {
+    service.getTripBookings(12).subscribe((bookings) => {
+      expect(bookings).toHaveSize(1);
+      expect(bookings[0].senderPhotoUrl).toBe('/api/uploads/sender.png');
+      expect(bookings[0].packagePhotoUrl).toBe('/api/uploads/package.png');
+    });
+
+    const req = httpMock.expectOne('/api/trips/12/bookings');
+    expect(req.request.method).toBe('GET');
+    req.flush([
+      {
+        id: 4,
+        tripId: 12,
+        senderId: 2,
+        senderName: 'Alice Martin',
+        senderPhotoUrl: 'uploads/sender.png',
+        title: 'Valise',
+        weight: 2,
+        packagePhotoUrl: '/uploads/package.png',
+        recipientContact: '+22501020304',
+        status: 'PENDING',
+        validationCodeActive: false,
+      },
+    ]);
+  });
 });

--- a/front-office/src/app/services/trip.service.ts
+++ b/front-office/src/app/services/trip.service.ts
@@ -60,7 +60,9 @@ export class TripService {
 
   /** Create a booking request for a specific trip. */
   createBooking(tripId: number, request: CreateBookingRequest): Observable<BookingResponse> {
-    return this.http.post<BookingResponse>(`${this.baseUrl}/${tripId}/bookings`, request);
+    return this.http.post<BookingResponse>(`${this.baseUrl}/${tripId}/bookings`, request).pipe(
+      map((booking) => this.normalizeBooking(booking))
+    );
   }
 
   /** Get trips published by the current user. */
@@ -72,17 +74,23 @@ export class TripService {
 
   /** Get booking requests sent by the current user. */
   getMyBookings(): Observable<BookingResponse[]> {
-    return this.http.get<BookingResponse[]>(`${this.baseUrl}/bookings/mine`);
+    return this.http.get<BookingResponse[]>(`${this.baseUrl}/bookings/mine`).pipe(
+      map((bookings) => bookings.map((booking) => this.normalizeBooking(booking)))
+    );
   }
 
   /** Get bookings for a specific trip (received reservations). */
   getTripBookings(tripId: number): Observable<BookingResponse[]> {
-    return this.http.get<BookingResponse[]>(`${this.baseUrl}/${tripId}/bookings`);
+    return this.http.get<BookingResponse[]>(`${this.baseUrl}/${tripId}/bookings`).pipe(
+      map((bookings) => bookings.map((booking) => this.normalizeBooking(booking)))
+    );
   }
 
   /** Accept a booking. */
   acceptBooking(tripId: number, bookingId: number): Observable<BookingResponse> {
-    return this.http.put<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/accept`, {});
+    return this.http.put<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/accept`, {}).pipe(
+      map((booking) => this.normalizeBooking(booking))
+    );
   }
 
   /** Confirm parcel handoff by validating the recipient code. */
@@ -91,12 +99,16 @@ export class TripService {
     bookingId: number,
     request: ConfirmBookingDeliveryRequest,
   ): Observable<BookingResponse> {
-    return this.http.put<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/deliver`, request);
+    return this.http.put<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/deliver`, request).pipe(
+      map((booking) => this.normalizeBooking(booking))
+    );
   }
 
   /** Reject a booking. */
   rejectBooking(tripId: number, bookingId: number): Observable<BookingResponse> {
-    return this.http.put<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/reject`, {});
+    return this.http.put<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/reject`, {}).pipe(
+      map((booking) => this.normalizeBooking(booking))
+    );
   }
 
   /** Remove an accepted booking (traveler only). Sends notification to sender. */
@@ -111,7 +123,9 @@ export class TripService {
 
   /** Cancel a booking (sender only). */
   cancelBooking(tripId: number, bookingId: number): Observable<BookingResponse> {
-    return this.http.put<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/cancel`, {});
+    return this.http.put<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/cancel`, {}).pipe(
+      map((booking) => this.normalizeBooking(booking))
+    );
   }
 
   private normalizeTrip(
@@ -133,6 +147,14 @@ export class TripService {
       availableWeight: normalizedAvailableWeight,
       travelerPhotoUrl: this.photoUrlService.normalizePhotoUrl(trip.travelerPhotoUrl),
       travelerRatingCount: trip.travelerRatingCount ?? 0,
+    };
+  }
+
+  private normalizeBooking(booking: BookingResponse): BookingResponse {
+    return {
+      ...booking,
+      senderPhotoUrl: this.photoUrlService.normalizePhotoUrl(booking.senderPhotoUrl),
+      packagePhotoUrl: this.photoUrlService.normalizePhotoUrl(booking.packagePhotoUrl),
     };
   }
 }

--- a/front-office/src/styles.css
+++ b/front-office/src/styles.css
@@ -1,5 +1,7 @@
-/* Google Fonts - Poppins (must be first) */
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&display=swap');
+/* Shared font imports */
+@import url('https://api.fontshare.com/v2/css?f[]=general-sans@400,500,600,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:FILL@0;1&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Poppins:wght@300;400;500;600;700;800&display=swap');
 
 /* Tailwind CSS imports */
 @tailwind base;
@@ -13,6 +15,14 @@ html {
 
 body {
   font-family: 'Poppins', sans-serif;
+}
+
+.material-symbols-outlined {
+  font-variation-settings:
+    'FILL' 0,
+    'wght' 400,
+    'GRAD' 0,
+    'opsz' 24;
 }
 
 /* Custom utility classes */

--- a/front-office/tailwind.config.js
+++ b/front-office/tailwind.config.js
@@ -24,6 +24,7 @@ module.exports = {
         primary: '#023047',
         'primary-hover': '#4F46E5',
         secondary: '#219ebc',
+        accent: '#FB8500',
         neutral: '#9C9C9C',
         border: '#E8E8EC',
         surface: '#FFFFFF',

--- a/front-office/tailwind.config.js
+++ b/front-office/tailwind.config.js
@@ -20,24 +20,51 @@ module.exports = {
         'slide-up': 'slideUp 300ms ease-out',
       },
       colors: {
-        // Brand colors
+        // Colick design system tokens
         primary: '#023047',
+        'primary-hover': '#4F46E5',
         secondary: '#219ebc',
-        accent: '#fb8500',
+        neutral: '#9C9C9C',
+        border: '#E8E8EC',
+        surface: '#FFFFFF',
         error: '#EF4444',
-        success: '#22C55E',
-        warning: '#F97316',
-        // Background colors
-        'bg-primary': '#f5f5f5',
-        'bg-secondary': '#F9FAFB',
+        success: '#10B981',
+        warning: '#F59E0B',
+        background: {
+          primary: '#FAFAFA',
+          secondary: '#FFFFFF',
+          dark: '#111827',
+        },
+        text: {
+          primary: '#0A0A0A',
+          secondary: '#6B6B6B',
+          muted: '#9C9C9C',
+        },
+        // Legacy background aliases kept for existing bg-bg-* utilities.
+        'bg-primary': '#FAFAFA',
+        'bg-secondary': '#FFFFFF',
         'bg-dark': '#111827',
-        // Text colors
-        'text-primary': '#111827',
-        'text-secondary': '#6B7280',
-        'text-muted': '#9CA3AF',
       },
       fontFamily: {
-        sans: ['Poppins', 'sans-serif'],
+        display: ['General Sans', 'sans-serif'],
+        sans: ['DM Sans', 'sans-serif'],
+        body: ['DM Sans', 'sans-serif'],
+        mono: ['JetBrains Mono', 'monospace'],
+      },
+      borderRadius: {
+        sm: '4px',
+        DEFAULT: '6px',
+        md: '8px',
+        lg: '12px',
+      },
+      boxShadow: {
+        // Hover elevation for cards
+        card: '0 8px 30px rgba(0,0,0,0.08)',
+        // Tinted hover glow for primary actions
+        'primary-glow': '0 4px 12px rgba(99,102,241,0.35)',
+      },
+      ringColor: {
+        primary: 'rgba(99,102,241,0.12)',
       },
     },
   },

--- a/mockup/landing.html
+++ b/mockup/landing.html
@@ -74,9 +74,6 @@
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 lg:py-28">
         <div class="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
           <div class="text-white">
-            <span class="inline-block bg-white/20 text-white text-sm font-medium px-4 py-1.5 rounded-full mb-6">
-              Nouveau : Réservation instantanée disponible
-            </span>
             <h1 id="hero-title" class="text-4xl sm:text-5xl lg:text-6xl font-extrabold leading-tight mb-6">
               Envoyez vos colis avec des <span class="text-accent">voyageurs</span> de confiance
             </h1>


### PR DESCRIPTION
## Summary
- add a dedicated reservations details page for trips from the received reservations dashboard flow
- move booking request details and actions out of the dashboard inline panel into focused reservation detail components
- add sender messaging, trip action wiring, and tests for the new route and components

Closes #81