### PR TITLE
Ajouter un footer compact au dashboard

### DIFF
--- a/front-office/src/app/app.component.spec.ts
+++ b/front-office/src/app/app.component.spec.ts
@@ -1,0 +1,57 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NavigationEnd, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { AppComponent } from './app.component';
+
+describe('AppComponent', () => {
+  let fixture: ComponentFixture<AppComponent>;
+  let routerEvents: Subject<NavigationEnd>;
+  let routerMock: { url: string; events: Subject<NavigationEnd> };
+
+  beforeEach(async () => {
+    routerEvents = new Subject<NavigationEnd>();
+    routerMock = {
+      url: '/',
+      events: routerEvents,
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [AppComponent],
+      providers: [{ provide: Router, useValue: routerMock }],
+    })
+      .overrideComponent(AppComponent, {
+        set: { template: '' },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+  });
+
+  it('keeps shared marketing chrome on public pages', () => {
+    expect(fixture.componentInstance.showSharedChrome).toBeTrue();
+
+    routerEvents.next(new NavigationEnd(1, '/search', '/search'));
+
+    expect(fixture.componentInstance.showSharedChrome).toBeTrue();
+  });
+
+  it('hides shared marketing chrome on dashboard shell routes', () => {
+    const dashboardRoutes = [
+      '/dashboard',
+      '/trips',
+      '/trips/42/reservations/7/profile',
+      '/propose',
+      '/propose/42',
+      '/messages',
+      '/settings',
+      '/received-bookings',
+    ];
+
+    for (const route of dashboardRoutes) {
+      routerEvents.next(new NavigationEnd(1, route, route));
+
+      expect(fixture.componentInstance.showSharedChrome).withContext(route).toBeFalse();
+    }
+  });
+});

--- a/front-office/src/app/app.component.ts
+++ b/front-office/src/app/app.component.ts
@@ -18,6 +18,14 @@ import { filter } from 'rxjs';
 export class AppComponent {
   private readonly router = inject(Router);
   private readonly reservationShellRoutePattern = /^\/trips\/\d+\/reservations(?:\/[^?#]*)?(?:[?#].*)?$/;
+  private readonly dashboardShellRoutePatterns = [
+    /^\/dashboard(?:[?#].*)?$/,
+    /^\/trips(?:\/[^?#]*)?(?:[?#].*)?$/,
+    /^\/propose(?:\/[^?#]*)?(?:[?#].*)?$/,
+    /^\/messages(?:[?#].*)?$/,
+    /^\/settings(?:[?#].*)?$/,
+    /^\/received-bookings(?:[?#].*)?$/,
+  ];
   /**
    * Application title
    */
@@ -34,6 +42,8 @@ export class AppComponent {
   }
 
   private updateSharedChrome(url: string): void {
-    this.showSharedChrome = !this.reservationShellRoutePattern.test(url);
+    this.showSharedChrome =
+      !this.reservationShellRoutePattern.test(url) &&
+      !this.dashboardShellRoutePatterns.some((pattern) => pattern.test(url));
   }
 }

--- a/front-office/src/app/shared/components/dashboard-shell/dashboard-shell.component.html
+++ b/front-office/src/app/shared/components/dashboard-shell/dashboard-shell.component.html
@@ -131,8 +131,21 @@
     </div>
   </aside>
 
-  <div class="min-h-screen pt-14 md:ml-64">
-    <ng-content />
+  <div class="flex min-h-screen flex-col pt-14 md:ml-64">
+    <div class="flex-1">
+      <ng-content />
+    </div>
+
+    <footer class="border-t border-border bg-background-secondary px-4 py-5 text-xs text-text-secondary sm:px-6 lg:px-8" role="contentinfo">
+      <div class="mx-auto flex max-w-7xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p>© {{ currentYear }} Colick. Tous droits réservés.</p>
+        <nav class="flex flex-wrap items-center gap-x-4 gap-y-2" aria-label="Liens légaux du dashboard">
+          <a href="/privacy" class="transition hover:text-primary">Confidentialité</a>
+          <a href="/terms" class="transition hover:text-primary">CGU</a>
+          <a href="/contact" class="transition hover:text-primary">Contact/support</a>
+        </nav>
+      </div>
+    </footer>
   </div>
 </div>
 

--- a/front-office/src/app/shared/components/dashboard-shell/dashboard-shell.component.spec.ts
+++ b/front-office/src/app/shared/components/dashboard-shell/dashboard-shell.component.spec.ts
@@ -1,0 +1,47 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { AuthService } from '../../../services/auth.service';
+import { DashboardShellComponent } from './dashboard-shell.component';
+
+describe('DashboardShellComponent', () => {
+  let fixture: ComponentFixture<DashboardShellComponent>;
+
+  const authServiceMock = {
+    getUser: jasmine.createSpy('getUser').and.returnValue({
+      id: 1,
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'ada@example.com',
+      role: 'USER',
+    }),
+    logout: jasmine.createSpy('logout'),
+  };
+
+  beforeEach(async () => {
+    authServiceMock.getUser.calls.reset();
+    authServiceMock.logout.calls.reset();
+
+    await TestBed.configureTestingModule({
+      imports: [DashboardShellComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DashboardShellComponent);
+  });
+
+  it('renders a compact dashboard footer with legal links', () => {
+    fixture.detectChanges();
+
+    const footer = fixture.nativeElement.querySelector('footer[role="contentinfo"]') as HTMLElement | null;
+    const text = footer?.textContent ?? '';
+
+    expect(footer).not.toBeNull();
+    expect(text).toContain('Colick. Tous droits réservés.');
+    expect(text).toContain('Confidentialité');
+    expect(text).toContain('CGU');
+    expect(text).toContain('Contact/support');
+  });
+});

--- a/front-office/src/app/shared/components/dashboard-shell/dashboard-shell.component.ts
+++ b/front-office/src/app/shared/components/dashboard-shell/dashboard-shell.component.ts
@@ -11,6 +11,7 @@ import { AuthService } from '../../../services/auth.service';
 export class DashboardShellComponent {
   private readonly authService = inject(AuthService);
 
+  currentYear = new Date().getFullYear();
   isMobileMenuOpen = false;
   private profilePhotoLoadFailed = false;
   private lastProfilePhotoUrl: string | null = null;


### PR DESCRIPTION
## Summary
- Ajoute un footer compact directement dans le shell du dashboard avec les liens légaux essentiels.
- Masque le chrome marketing global sur les routes authentifiées du dashboard pour éviter le doublon.
- Couvre le comportement avec des tests unitaires dédiés pour `AppComponent` et `DashboardShellComponent`.

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` côté `front-office`.
- Validation des nouveaux tests unitaires sur le rendu du footer dashboard et le masquage du chrome partagé.