### PR TITLE
Refactor propose trip page to a compact centered layout

### DIFF
--- a/front-office/src/app/pages/propose-trip/propose-trip-page.component.html
+++ b/front-office/src/app/pages/propose-trip/propose-trip-page.component.html
@@ -1,60 +1,43 @@
 <!-- Propose / Edit Trip Page -->
 <div class="min-h-screen bg-bg-primary font-['Poppins']" aria-labelledby="propose-title">
-
-  <!-- ============================================================
-       PAGE HEADER — gradient banner with dynamic title and back link
-       ============================================================ -->
-  <section class="hero-gradient pt-24 pb-32 md:pb-40 relative overflow-hidden">
-    <!-- Decorative background blurs -->
-    <div
-      class="absolute top-10 right-0 w-72 h-72 bg-accent/20 rounded-full blur-3xl pointer-events-none"
-      aria-hidden="true"
-    ></div>
-    <div
-      class="absolute bottom-0 left-10 w-64 h-64 bg-secondary/30 rounded-full blur-3xl pointer-events-none"
-      aria-hidden="true"
-    ></div>
-
-    <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
-      <!-- Back link — adapts to create vs edit context -->
-      <a
-        [routerLink]="isEditMode ? '/dashboard' : '/'"
-        [queryParams]="isEditMode ? { tab: 'received' } : {}"
-        class="inline-flex items-center gap-2 text-white/80 hover:text-white transition-colors text-sm font-medium mb-6 group"
-        [attr.aria-label]="isEditMode ? 'Retour au tableau de bord' : 'Retour à l\'accueil'"
+  <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+    <!-- Back link — adapts to create vs edit context -->
+    <a
+      [routerLink]="isEditMode ? '/dashboard' : '/'"
+      [queryParams]="isEditMode ? { tab: 'received' } : {}"
+      class="group inline-flex items-center gap-2 text-sm font-medium text-text-secondary transition-colors hover:text-primary"
+      [attr.aria-label]="isEditMode ? 'Retour au tableau de bord' : 'Retour à l\'accueil'"
+    >
+      <svg
+        class="w-4 h-4 transition-transform group-hover:-translate-x-1"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
       >
-        <svg
-          class="w-4 h-4 transition-transform group-hover:-translate-x-1"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-        >
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-        </svg>
-        {{ isEditMode ? 'Retour au tableau de bord' : 'Retour à l\'accueil' }}
-      </a>
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+      </svg>
+      {{ isEditMode ? 'Retour au tableau de bord' : 'Retour à l\'accueil' }}
+    </a>
 
-      <!-- Dynamic page title -->
+    <!-- Compact page header -->
+    <section data-testid="propose-trip-header" class="mt-5 max-w-2xl">
       <h1
         id="propose-title"
-        class="text-3xl sm:text-4xl lg:text-5xl font-extrabold text-white leading-tight mb-3"
+        class="text-[2rem] font-bold leading-tight tracking-[-0.02em] text-text-primary sm:text-[2.5rem]"
       >
         {{ pageTitle }}
       </h1>
-      <p class="text-white/80 text-base sm:text-lg max-w-xl">
+      <p class="mt-3 text-sm leading-6 text-text-secondary sm:text-base">
         {{ pageDescription }}
       </p>
-    </div>
-  </section>
+    </section>
 
-  <!-- ============================================================
-       FORM CARD — overlapping the header banner
-       ============================================================ -->
-  <section class="pb-16 -mt-20 relative z-10">
-    <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="bg-white rounded-2xl shadow-lg p-6 sm:p-8">
+    <!-- Centered form card -->
+    <section data-testid="propose-trip-form-region" class="pt-6 pb-16">
+      <div data-testid="propose-trip-form-wrapper" class="mx-auto max-w-3xl">
+        <div data-testid="propose-trip-form-card" class="rounded-3xl bg-white p-6 shadow-lg sm:p-8">
 
         <!-- ── Page loading skeleton (edit mode: fetching trip details) ── -->
         @if (isPageLoading) {
@@ -298,8 +281,8 @@
           </div><!-- /form wrapper -->
 
         }<!-- /isPageLoading @else -->
+        </div>
       </div>
-    </div>
-  </section>
-
+    </section>
+  </div>
 </div>

--- a/front-office/src/app/pages/propose-trip/propose-trip-page.component.spec.ts
+++ b/front-office/src/app/pages/propose-trip/propose-trip-page.component.spec.ts
@@ -155,6 +155,33 @@ describe('ProposeTripPageComponent', () => {
     });
   });
 
+  it('renders a compact centered layout without the hero banner', () => {
+    setRouteId();
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const header = host.querySelector('[data-testid="propose-trip-header"]') as HTMLElement | null;
+    const formRegion = host.querySelector('[data-testid="propose-trip-form-region"]') as HTMLElement | null;
+    const formWrapper = host.querySelector('[data-testid="propose-trip-form-wrapper"]') as HTMLElement | null;
+    const formCard = host.querySelector('[data-testid="propose-trip-form-card"]') as HTMLElement | null;
+
+    expect(host.querySelector('section.hero-gradient')).toBeNull();
+    expect(header).not.toBeNull();
+    expect(header?.textContent).toContain('Proposer un voyage');
+    expect(header?.className).toContain('max-w-2xl');
+    expect(header?.className).not.toContain('rounded-3xl');
+    expect(header?.className).not.toContain('bg-white');
+    expect(host.textContent).toContain('Retour à l\'accueil');
+    expect(host.textContent).not.toContain('Nouveau trajet');
+    expect(formRegion).not.toBeNull();
+    expect(formWrapper).not.toBeNull();
+    expect(formCard).not.toBeNull();
+    expect(formWrapper?.className).toContain('mx-auto');
+    expect(formWrapper?.className).toContain('max-w-3xl');
+    expect(host.textContent).toContain('Ville de départ *');
+    expect(host.textContent).toContain('Destination *');
+  });
+
   it('blocks editing when the loaded trip is not active', () => {
     tripServiceMock.getTripById.and.returnValue(of({
       id: 15,


### PR DESCRIPTION
## Summary
- Replace the hero-style propose trip header with a compact centered layout on the page
- Wrap the form in a simpler, more focused card structure with updated spacing and visual hierarchy
- Add coverage for the new layout, including the absence of the hero banner and the presence of the new wrapper regions

## Testing
- Updated component specs to assert the compact layout structure and key content
- Not run (not requested)