### PR TITLE
[codex] Fix booking detail unauthorized access with 404

### DIFF
--- a/back-office/src/main/java/com/colick/backoffice/trip/controller/TripController.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/controller/TripController.java
@@ -120,6 +120,16 @@ public class TripController {
         return ResponseEntity.ok(tripService.getBookings(id, currentUser));
     }
 
+    /** Returns a single booking request for a trip. */
+    @GetMapping("/{id}/bookings/{bookingId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<TripBookingResponse> getBookingById(
+            @PathVariable Long id,
+            @PathVariable Long bookingId,
+            @AuthenticationPrincipal User currentUser) {
+        return ResponseEntity.ok(tripService.getBookingById(id, bookingId, currentUser));
+    }
+
     /** Returns the sender profile data associated with a booking. */
     @GetMapping("/{id}/bookings/{bookingId}/sender-profile")
     @PreAuthorize("isAuthenticated()")

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripService.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripService.java
@@ -33,6 +33,9 @@ public interface TripService {
     /** Returns all booking requests for a trip. */
     List<TripBookingResponse> getBookings(Long tripId, User requester);
 
+    /** Returns a single booking for a trip when visible to the requester. */
+    TripBookingResponse getBookingById(Long tripId, Long bookingId, User requester);
+
     /** Returns sender profile data for the selected booking. */
     TripBookingSenderProfileResponse getBookingSenderProfile(Long tripId, Long bookingId, User requester);
 

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
@@ -165,7 +165,10 @@ public class TripServiceImpl implements TripService {
     @Transactional(readOnly = true)
     public List<TripBookingResponse> getBookings(Long tripId, User requester) {
         Trip trip = findTripOrThrow(tripId);
-        assertTripOwner(trip, requester);
+        if (!trip.getTraveler().getId().equals(requester.getId())
+                && requester.getRole() != User.Role.ADMIN) {
+            throw new ResourceNotFoundException(localizedMessages.get("error.trip.notFound", tripId));
+        }
         return toTripBookingResponses(bookingRepository.findByTrip(trip).stream()
                 .filter(booking -> booking.getStatus() != TripBooking.BookingStatus.REMOVED)
                 .toList());

--- a/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
+++ b/back-office/src/main/java/com/colick/backoffice/trip/service/TripServiceImpl.java
@@ -173,9 +173,14 @@ public class TripServiceImpl implements TripService {
 
     @Override
     @Transactional(readOnly = true)
+    public TripBookingResponse getBookingById(Long tripId, Long bookingId, User requester) {
+        return toTripBookingResponse(findVisibleBookingOrThrow(tripId, bookingId, requester));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public TripBookingSenderProfileResponse getBookingSenderProfile(Long tripId, Long bookingId, User requester) {
-        TripBooking booking = findBookingOrThrow(tripId, bookingId);
-        assertTripOwner(booking.getTrip(), requester);
+        TripBooking booking = findVisibleBookingOrThrow(tripId, bookingId, requester);
 
         User sender = booking.getSender();
         TravelerRatingSummary summary = travelerReviewService.getTravelerRatingSummaries(Set.of(sender.getId()))
@@ -396,6 +401,21 @@ public class TripServiceImpl implements TripService {
         return bookingRepository.findById(bookingId)
                 .filter(b -> b.getTrip().getId().equals(tripId))
                 .orElseThrow(() -> new ResourceNotFoundException(localizedMessages.get("error.booking.notFound", bookingId)));
+    }
+
+    private TripBooking findVisibleBookingOrThrow(Long tripId, Long bookingId, User requester) {
+        TripBooking booking = findBookingOrThrow(tripId, bookingId);
+
+        if (booking.getStatus() == TripBooking.BookingStatus.REMOVED) {
+            throw new ResourceNotFoundException(localizedMessages.get("error.booking.notFound", bookingId));
+        }
+
+        if (!booking.getTrip().getTraveler().getId().equals(requester.getId())
+                && requester.getRole() != User.Role.ADMIN) {
+            throw new ResourceNotFoundException(localizedMessages.get("error.booking.notFound", bookingId));
+        }
+
+        return booking;
     }
 
     private void assertTripOwner(Trip trip, User requester) {

--- a/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
@@ -356,7 +356,7 @@ class TripServiceImplTest {
         when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
 
         assertThatThrownBy(() -> tripService.getBookings(10L, sender))
-                .isInstanceOf(AccessDeniedException.class);
+                .isInstanceOf(ResourceNotFoundException.class);
         verify(bookingRepository, never()).findByTrip(any());
     }
 

--- a/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
+++ b/back-office/src/test/java/com/colick/backoffice/trip/TripServiceImplTest.java
@@ -85,6 +85,7 @@ class TripServiceImplTest {
 
     private User traveler;
     private User sender;
+    private User admin;
     private Trip sampleTrip;
 
     @BeforeEach
@@ -105,6 +106,14 @@ class TripServiceImplTest {
                 .email("bob@example.com")
                 .photoUrl("/uploads/bob.png")
                 .role(User.Role.USER)
+                .build();
+
+        admin = User.builder()
+                .id(99L)
+                .firstName("Admin")
+                .lastName("User")
+                .email("admin@example.com")
+                .role(User.Role.ADMIN)
                 .build();
 
         sampleTrip = Trip.builder()
@@ -352,6 +361,94 @@ class TripServiceImplTest {
     }
 
     @Test
+    void getBookingById_shouldReturnBooking_whenRequesterOwnsTrip() {
+        TripBooking pending = TripBooking.builder()
+                .id(12L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.PENDING).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(12L)).thenReturn(Optional.of(pending));
+        when(travelerReviewService.getTravelerRatingSummaries(anyCollection()))
+                .thenReturn(Map.of(sender.getId(), new TravelerRatingSummary(4.8, 24L)));
+
+        TripBookingResponse booking = tripService.getBookingById(10L, 12L, traveler);
+
+        assertThat(booking.getId()).isEqualTo(12L);
+        assertThat(booking.getSenderName()).isEqualTo("Bob Martin");
+    }
+
+    @Test
+    void getBookingById_shouldReturnBooking_whenRequesterIsAdmin() {
+        TripBooking pending = TripBooking.builder()
+                .id(12L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.PENDING).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(12L)).thenReturn(Optional.of(pending));
+
+        TripBookingResponse booking = tripService.getBookingById(10L, 12L, admin);
+
+        assertThat(booking.getId()).isEqualTo(12L);
+    }
+
+    @Test
+    void getBookingById_shouldThrowNotFound_whenBookingDoesNotExist() {
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(12L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tripService.getBookingById(10L, 12L, traveler))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("12");
+    }
+
+    @Test
+    void getBookingById_shouldThrowNotFound_whenBookingBelongsToAnotherTrip() {
+        Trip anotherTrip = Trip.builder()
+                .id(42L)
+                .traveler(traveler)
+                .status(Trip.TripStatus.ACTIVE)
+                .build();
+        TripBooking pending = TripBooking.builder()
+                .id(12L).trip(anotherTrip).sender(sender)
+                .status(TripBooking.BookingStatus.PENDING).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(12L)).thenReturn(Optional.of(pending));
+
+        assertThatThrownBy(() -> tripService.getBookingById(10L, 12L, traveler))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("12");
+    }
+
+    @Test
+    void getBookingById_shouldThrowNotFound_whenBookingIsRemoved() {
+        TripBooking removed = TripBooking.builder()
+                .id(12L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.REMOVED).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(12L)).thenReturn(Optional.of(removed));
+
+        assertThatThrownBy(() -> tripService.getBookingById(10L, 12L, traveler))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("12");
+    }
+
+    @Test
+    void getBookingById_shouldThrowNotFound_whenRequesterIsNotTripOwner() {
+        TripBooking pending = TripBooking.builder()
+                .id(12L).trip(sampleTrip).sender(sender)
+                .status(TripBooking.BookingStatus.PENDING).build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(12L)).thenReturn(Optional.of(pending));
+
+        assertThatThrownBy(() -> tripService.getBookingById(10L, 12L, sender))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("12");
+    }
+
+    @Test
     void getBookingSenderProfile_shouldReturnRealCountsAndReviews() {
         TripBooking booking = TripBooking.builder()
                 .id(12L)
@@ -383,6 +480,23 @@ class TripServiceImplTest {
         assertThat(response.getReviewCount()).isEqualTo(2L);
         assertThat(response.getReviews()).hasSize(1);
         assertThat(response.getReviews().get(0).getReviewerName()).isEqualTo("Claire Bernard");
+    }
+
+    @Test
+    void getBookingSenderProfile_shouldThrowNotFound_whenRequesterIsNotTripOwner() {
+        TripBooking booking = TripBooking.builder()
+                .id(12L)
+                .trip(sampleTrip)
+                .sender(sender)
+                .status(TripBooking.BookingStatus.PENDING)
+                .build();
+
+        when(tripRepository.findById(10L)).thenReturn(Optional.of(sampleTrip));
+        when(bookingRepository.findById(12L)).thenReturn(Optional.of(booking));
+
+        assertThatThrownBy(() -> tripService.getBookingSenderProfile(10L, 12L, sender))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("12");
     }
 
     @Test

--- a/front-office/src/app/app.routes.spec.ts
+++ b/front-office/src/app/app.routes.spec.ts
@@ -15,4 +15,13 @@ describe('app routes', () => {
     expect(childRoute).toBeDefined();
     expect(childRoute?.loadComponent).toBeDefined();
   });
+
+  it('defines a public 404 route and a wildcard redirect', () => {
+    const notFoundRoute = routes.find((currentRoute) => currentRoute.path === '404');
+    const wildcardRoute = routes.find((currentRoute) => currentRoute.path === '**');
+
+    expect(notFoundRoute).toBeDefined();
+    expect(notFoundRoute?.loadComponent).toBeDefined();
+    expect(wildcardRoute).toEqual(jasmine.objectContaining({ redirectTo: '/404' }));
+  });
 });

--- a/front-office/src/app/app.routes.ts
+++ b/front-office/src/app/app.routes.ts
@@ -74,6 +74,13 @@ export const routes: Routes = [
         (m) => m.ResetPasswordPageComponent
       ),
   },
+  {
+    path: '404',
+    loadComponent: () =>
+      import('./pages/not-found/not-found-page.component').then(
+        (m) => m.NotFoundPageComponent
+      ),
+  },
   // ── Authenticated pages with dashboard shell layout ──────────────────────
   {
     path: '',
@@ -182,5 +189,9 @@ export const routes: Routes = [
           ),
       },
     ],
+  },
+  {
+    path: '**',
+    redirectTo: '/404',
   },
 ];

--- a/front-office/src/app/pages/not-found/not-found-page.component.html
+++ b/front-office/src/app/pages/not-found/not-found-page.component.html
@@ -1,0 +1,30 @@
+<main class="min-h-[70vh] bg-background-primary">
+  <div class="mx-auto flex max-w-[960px] flex-col items-center justify-center px-4 py-20 text-center sm:px-6 lg:px-8">
+    <span class="rounded-full border border-border bg-background-secondary px-4 py-1 text-xs font-bold uppercase tracking-[0.2em] text-text-muted">
+      Erreur 404
+    </span>
+
+    <h1 class="mt-6 text-4xl font-bold tracking-[-0.03em] text-text-primary sm:text-5xl">
+      Cette page est introuvable
+    </h1>
+
+    <p class="mt-4 max-w-xl text-base leading-7 text-text-secondary sm:text-lg">
+      Le contenu que vous cherchez n’existe pas ou vous n’êtes pas autorisé à y accéder.
+    </p>
+
+    <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+      <a
+        routerLink="/dashboard"
+        class="inline-flex items-center justify-center rounded-xl bg-primary px-5 py-3 text-sm font-bold text-white transition hover:opacity-90"
+      >
+        Retour au tableau de bord
+      </a>
+      <a
+        routerLink="/"
+        class="inline-flex items-center justify-center rounded-xl border border-border bg-background-secondary px-5 py-3 text-sm font-bold text-text-primary transition hover:text-primary"
+      >
+        Aller à l’accueil
+      </a>
+    </div>
+  </div>
+</main>

--- a/front-office/src/app/pages/not-found/not-found-page.component.ts
+++ b/front-office/src/app/pages/not-found/not-found-page.component.ts
@@ -1,0 +1,11 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-not-found-page',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './not-found-page.component.html',
+})
+export class NotFoundPageComponent {}

--- a/front-office/src/app/pages/reservation-booking-detail/reservation-booking-detail-page.component.spec.ts
+++ b/front-office/src/app/pages/reservation-booking-detail/reservation-booking-detail-page.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
 import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
 import { BehaviorSubject, of, throwError } from 'rxjs';
 import { BookingResponse } from '../../models/booking.model';
@@ -17,7 +18,7 @@ describe('ReservationBookingDetailPageComponent', () => {
 
   const tripServiceMock = {
     getTripById: jasmine.createSpy('getTripById'),
-    getTripBookings: jasmine.createSpy('getTripBookings'),
+    getTripBookingById: jasmine.createSpy('getTripBookingById'),
     acceptBooking: jasmine.createSpy('acceptBooking'),
     rejectBooking: jasmine.createSpy('rejectBooking'),
     removeBooking: jasmine.createSpy('removeBooking'),
@@ -44,7 +45,7 @@ describe('ReservationBookingDetailPageComponent', () => {
   beforeEach(async () => {
     tripParamMap$.next(convertToParamMap({ tripId: '12', bookingId: '7' }));
     tripServiceMock.getTripById.calls.reset();
-    tripServiceMock.getTripBookings.calls.reset();
+    tripServiceMock.getTripBookingById.calls.reset();
     tripServiceMock.acceptBooking.calls.reset();
     tripServiceMock.rejectBooking.calls.reset();
     tripServiceMock.removeBooking.calls.reset();
@@ -55,7 +56,7 @@ describe('ReservationBookingDetailPageComponent', () => {
     authServiceMock.logout.calls.reset();
 
     tripServiceMock.getTripById.and.returnValue(of(buildTrip()));
-    tripServiceMock.getTripBookings.and.returnValue(of([buildBooking()]));
+    tripServiceMock.getTripBookingById.and.returnValue(of(buildBooking()));
     tripServiceMock.acceptBooking.and.returnValue(of({ ...buildBooking(), status: 'ACCEPTED' }));
     tripServiceMock.rejectBooking.and.returnValue(of({ ...buildBooking(), status: 'REJECTED' }));
     tripServiceMock.removeBooking.and.returnValue(of(void 0));
@@ -133,13 +134,15 @@ describe('ReservationBookingDetailPageComponent', () => {
     expect(profileLink?.getAttribute('href')).toContain('/trips/12/reservations/7/profile');
   });
 
-  it('shows an error state when the targeted booking cannot be found', () => {
-    tripServiceMock.getTripBookings.and.returnValue(of([buildBooking({ id: 99 })]));
+  it('redirects to 404 when the targeted booking cannot be found', () => {
+    tripServiceMock.getTripBookingById.and.returnValue(
+      throwError(() => new HttpErrorResponse({ status: 404 }))
+    );
 
     createComponent();
 
     expect(component.booking).toBeNull();
-    expect(fixture.nativeElement.textContent).toContain('Impossible de retrouver cette réservation pour ce trajet.');
+    expect(router.navigate).toHaveBeenCalledWith(['/404']);
   });
 
   it('starts a conversation with the sender and navigates to messages', () => {
@@ -164,12 +167,10 @@ describe('ReservationBookingDetailPageComponent', () => {
   });
 
   it('confirms the booking delivery with the entered code', () => {
-    tripServiceMock.getTripBookings.and.returnValue(of([
-      buildBooking({
-        status: 'ACCEPTED',
-        validationCodeActive: true,
-      }),
-    ]));
+    tripServiceMock.getTripBookingById.and.returnValue(of(buildBooking({
+      status: 'ACCEPTED',
+      validationCodeActive: true,
+    })));
 
     createComponent();
     component.deliveryCode = '123456';
@@ -183,11 +184,9 @@ describe('ReservationBookingDetailPageComponent', () => {
   });
 
   it('removes the booking and navigates back to the reservations list', () => {
-    tripServiceMock.getTripBookings.and.returnValue(of([
-      buildBooking({
-        status: 'ACCEPTED',
-      }),
-    ]));
+    tripServiceMock.getTripBookingById.and.returnValue(of(buildBooking({
+      status: 'ACCEPTED',
+    })));
 
     createComponent();
     component.openRemoveBookingModal();
@@ -199,7 +198,7 @@ describe('ReservationBookingDetailPageComponent', () => {
 
   it('shows an error state when the booking detail request fails', () => {
     tripServiceMock.getTripById.and.returnValue(throwError(() => new Error('boom')));
-    tripServiceMock.getTripBookings.and.returnValue(throwError(() => new Error('boom')));
+    tripServiceMock.getTripBookingById.and.returnValue(throwError(() => new Error('boom')));
 
     createComponent();
 

--- a/front-office/src/app/pages/reservation-booking-detail/reservation-booking-detail-page.component.ts
+++ b/front-office/src/app/pages/reservation-booking-detail/reservation-booking-detail-page.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit, inject } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { forkJoin } from 'rxjs';
 import { ConfirmModalComponent } from '../../shared/components/confirm-modal/confirm-modal.component';
@@ -310,18 +311,19 @@ export class ReservationBookingDetailPageComponent implements OnInit {
 
     forkJoin({
       trip: this.tripService.getTripById(tripId),
-      bookings: this.tripService.getTripBookings(tripId),
+      booking: this.tripService.getTripBookingById(tripId, bookingId),
     }).subscribe({
-      next: ({ trip, bookings }) => {
+      next: ({ trip, booking }) => {
         this.trip = trip;
-        this.booking = bookings.find((currentBooking) => currentBooking.id === bookingId) ?? null;
+        this.booking = booking;
         this.isLoading = false;
-
-        if (!this.booking) {
-          this.loadError = 'Impossible de retrouver cette réservation pour ce trajet.';
-        }
       },
-      error: () => {
+      error: (error: HttpErrorResponse) => {
+        if (error.status === 404) {
+          void this.router.navigate(['/404']);
+          return;
+        }
+
         this.trip = null;
         this.booking = null;
         this.loadError = 'Impossible de charger les détails de cette réservation.';

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.spec.ts
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
 import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
 import { BehaviorSubject, Subject, of, throwError } from 'rxjs';
 import { BookingResponse } from '../../models/booking.model';
@@ -136,6 +137,16 @@ describe('ReservationDetailsPageComponent', () => {
     createComponent();
 
     expect(fixture.nativeElement.textContent).toContain('Impossible de charger les détails de cette réservation.');
+  });
+
+  it('redirects to 404 when the reservation details request returns not found', () => {
+    tripServiceMock.getTripBookings.and.returnValue(
+      throwError(() => new HttpErrorResponse({ status: 404 }))
+    );
+
+    createComponent();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/404']);
   });
 
   it('defaults to the pending tab when pending bookings are available', () => {

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.ts
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit, inject } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { ActivatedRoute, Router } from '@angular/router';
 import { forkJoin } from 'rxjs';
 import { BookingResponse } from '../../models/booking.model';
@@ -382,7 +383,12 @@ export class ReservationDetailsPageComponent implements OnInit {
         this.currentPage = 1;
         this.isLoading = false;
       },
-      error: () => {
+      error: (error: HttpErrorResponse) => {
+        if (error.status === 404) {
+          void this.router.navigate(['/404']);
+          return;
+        }
+
         this.trip = null;
         this.bookings = [];
         this.loadError = 'Impossible de charger les détails de cette réservation.';

--- a/front-office/src/app/pages/reservation-sender-profile/reservation-sender-profile-page.component.spec.ts
+++ b/front-office/src/app/pages/reservation-sender-profile/reservation-sender-profile-page.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
 import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
 import { BehaviorSubject, of, throwError } from 'rxjs';
 import { BookingResponse, BookingSenderProfileResponse } from '../../models/booking.model';
@@ -17,7 +18,7 @@ describe('ReservationSenderProfilePageComponent', () => {
 
   const tripServiceMock = {
     getTripById: jasmine.createSpy('getTripById'),
-    getTripBookings: jasmine.createSpy('getTripBookings'),
+    getTripBookingById: jasmine.createSpy('getTripBookingById'),
     getBookingSenderProfile: jasmine.createSpy('getBookingSenderProfile'),
   };
 
@@ -41,7 +42,7 @@ describe('ReservationSenderProfilePageComponent', () => {
   beforeEach(async () => {
     tripParamMap$.next(convertToParamMap({ tripId: '12', bookingId: '7' }));
     tripServiceMock.getTripById.calls.reset();
-    tripServiceMock.getTripBookings.calls.reset();
+    tripServiceMock.getTripBookingById.calls.reset();
     tripServiceMock.getBookingSenderProfile.calls.reset();
     messagingServiceMock.startConversation.calls.reset();
     messagingServiceMock.createConversationDraft.calls.reset();
@@ -49,7 +50,7 @@ describe('ReservationSenderProfilePageComponent', () => {
     authServiceMock.logout.calls.reset();
 
     tripServiceMock.getTripById.and.returnValue(of(buildTrip()));
-    tripServiceMock.getTripBookings.and.returnValue(of([buildBooking()]));
+    tripServiceMock.getTripBookingById.and.returnValue(of(buildBooking()));
     tripServiceMock.getBookingSenderProfile.and.returnValue(of(buildSenderProfile()));
     messagingServiceMock.startConversation.and.returnValue(of({
       id: 1,
@@ -122,23 +123,34 @@ describe('ReservationSenderProfilePageComponent', () => {
     expect(router.navigate).toHaveBeenCalledWith(['/messages'], { queryParams: { conversationId: 1 } });
   });
 
-  it('shows an error state when booking cannot be found', () => {
-    tripServiceMock.getTripBookings.and.returnValue(of([buildBooking({ id: 99 })]));
+  it('redirects to 404 when booking cannot be found', () => {
+    tripServiceMock.getTripBookingById.and.returnValue(
+      throwError(() => new HttpErrorResponse({ status: 404 }))
+    );
 
     createComponent();
 
-    expect(component.booking).toBeNull();
-    expect(fixture.nativeElement.textContent).toContain('Impossible de retrouver ce profil pour cette réservation.');
+    expect(router.navigate).toHaveBeenCalledWith(['/404']);
   });
 
   it('shows an error state when profile request fails', () => {
     tripServiceMock.getTripById.and.returnValue(throwError(() => new Error('boom')));
-    tripServiceMock.getTripBookings.and.returnValue(throwError(() => new Error('boom')));
+    tripServiceMock.getTripBookingById.and.returnValue(throwError(() => new Error('boom')));
     tripServiceMock.getBookingSenderProfile.and.returnValue(throwError(() => new Error('boom')));
 
     createComponent();
 
     expect(fixture.nativeElement.textContent).toContain('Impossible de charger ce profil utilisateur.');
+  });
+
+  it('redirects to 404 when the sender profile request fails with 404', () => {
+    tripServiceMock.getBookingSenderProfile.and.returnValue(
+      throwError(() => new HttpErrorResponse({ status: 404 }))
+    );
+
+    createComponent();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/404']);
   });
 
   it('shows a message when the sender has no reviews', () => {

--- a/front-office/src/app/pages/reservation-sender-profile/reservation-sender-profile-page.component.ts
+++ b/front-office/src/app/pages/reservation-sender-profile/reservation-sender-profile-page.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit, inject } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { forkJoin } from 'rxjs';
 import {
@@ -180,20 +181,21 @@ export class ReservationSenderProfilePageComponent implements OnInit {
 
     forkJoin({
       trip: this.tripService.getTripById(tripId),
-      bookings: this.tripService.getTripBookings(tripId),
+      booking: this.tripService.getTripBookingById(tripId, bookingId),
       senderProfile: this.tripService.getBookingSenderProfile(tripId, bookingId),
     }).subscribe({
-      next: ({ trip, bookings, senderProfile }) => {
+      next: ({ trip, booking, senderProfile }) => {
         this.trip = trip;
+        this.booking = booking;
         this.senderProfile = senderProfile;
-        this.booking = bookings.find((currentBooking) => currentBooking.id === bookingId) ?? null;
         this.isLoading = false;
-
-        if (!this.booking) {
-          this.loadError = 'Impossible de retrouver ce profil pour cette réservation.';
-        }
       },
-      error: () => {
+      error: (error: HttpErrorResponse) => {
+        if (error.status === 404) {
+          void this.router.navigate(['/404']);
+          return;
+        }
+
         this.trip = null;
         this.booking = null;
         this.senderProfile = null;

--- a/front-office/src/app/services/trip.service.spec.ts
+++ b/front-office/src/app/services/trip.service.spec.ts
@@ -258,6 +258,33 @@ describe('TripService', () => {
     ]);
   });
 
+  it('gets a single trip booking and normalizes booking media fields', () => {
+    service.getTripBookingById(12, 34).subscribe((booking) => {
+      expect(booking.id).toBe(34);
+      expect(booking.senderPhotoUrl).toBe('/api/uploads/sender.png');
+      expect(booking.packagePhotoUrl).toBe('/api/uploads/package.png');
+      expect(booking.senderRatingCount).toBe(0);
+    });
+
+    const req = httpMock.expectOne('/api/trips/12/bookings/34');
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      id: 34,
+      tripId: 12,
+      senderId: 2,
+      senderName: 'Alice Martin',
+      senderPhotoUrl: '/uploads/sender.png',
+      senderRatingAverage: 4.8,
+      senderRatingCount: null,
+      title: 'Valise',
+      weight: 2,
+      packagePhotoUrl: '/uploads/package.png',
+      recipientContact: '+22501020304',
+      status: 'PENDING',
+      validationCodeActive: false,
+    });
+  });
+
   it('gets sender profile data for a booking', () => {
     service.getBookingSenderProfile(12, 34).subscribe((profile) => {
       expect(profile.completedTripCount).toBe(5);

--- a/front-office/src/app/services/trip.service.ts
+++ b/front-office/src/app/services/trip.service.ts
@@ -131,6 +131,13 @@ export class TripService {
     );
   }
 
+  /** Get a single booking for a specific trip (received reservation detail). */
+  getTripBookingById(tripId: number, bookingId: number): Observable<BookingResponse> {
+    return this.http.get<BookingResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}`).pipe(
+      map((booking) => this.normalizeBooking(booking))
+    );
+  }
+
   /** Get sender profile data for a specific booking. */
   getBookingSenderProfile(tripId: number, bookingId: number): Observable<BookingSenderProfileResponse> {
     return this.http.get<BookingSenderProfileResponse>(`${this.baseUrl}/${tripId}/bookings/${bookingId}/sender-profile`).pipe(


### PR DESCRIPTION
## Summary
- add a dedicated booking detail endpoint that returns 404 when the booking is hidden, removed, mismatched, or requested by a non-owner
- refactor reservation detail and sender profile pages to load a single booking and redirect to a dedicated `/404` page on not-found responses
- add targeted backend and frontend coverage for the new endpoint, routing, and 404 behavior

## Why
Issue #85 requires hiding reservation details from users who do not own the trip and showing a real 404 page instead of the current generic error state.

## Validation
- `cd back-office && ./mvnw -Dtest=TripServiceImplTest test`
- `cd front-office && npm test -- --watch=false --browsers=ChromeHeadless --include=src/app/app.routes.spec.ts --include=src/app/services/trip.service.spec.ts --include=src/app/pages/reservation-booking-detail/reservation-booking-detail-page.component.spec.ts --include=src/app/pages/reservation-sender-profile/reservation-sender-profile-page.component.spec.ts`