### PR TITLE
Améliorer l’affichage mobile de la page de gestion des trajets

### DIFF
--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.html
@@ -71,6 +71,32 @@
                   <p class="mt-1 font-bold text-text-primary">{{ bookings.length }} total</p>
                 </div>
               </div>
+
+              <div class="grid grid-cols-2 gap-3 md:hidden">
+                <a
+                  [routerLink]="['/propose', trip.id]"
+                  class="inline-flex items-center justify-center gap-2 rounded-xl border border-primary/30 bg-background-secondary px-4 py-2.5 text-sm font-semibold text-primary transition hover:bg-primary/5"
+                  aria-label="Modifier le trajet"
+                >
+                  <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 20h4l10.5-10.5a2.121 2.121 0 10-3-3L5 17v3z" />
+                  </svg>
+                  Modifier
+                </a>
+
+                <button
+                  type="button"
+                  class="inline-flex items-center justify-center gap-2 rounded-xl border border-error/30 bg-background-secondary px-4 py-2.5 text-sm font-semibold text-error transition hover:bg-error/5"
+                  [disabled]="isCompletingTrip || isCancellingTrip"
+                  (click)="openCancelTripModal()"
+                  aria-label="Supprimer le trajet"
+                >
+                  <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 7h12m-10 0V5a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2m-8 0v12a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1V7m-6 0h6" />
+                  </svg>
+                  Supprimer
+                </button>
+              </div>
             </div>
           }
         </div>

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.spec.ts
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.spec.ts
@@ -195,6 +195,39 @@ describe('ReservationDetailsPageComponent', () => {
     expect(component.usedWeightPercentage()).toBe(35);
   });
 
+  it('renders mobile trip actions in the summary card', () => {
+    createComponent();
+
+    component.toggleTripSummary();
+    fixture.detectChanges();
+
+    const editLink = fixture.nativeElement.querySelector(
+      'a[aria-label="Modifier le trajet"]'
+    ) as HTMLAnchorElement | null;
+    const deleteButton = fixture.nativeElement.querySelector(
+      'button[aria-label="Supprimer le trajet"]'
+    ) as HTMLButtonElement | null;
+
+    expect(editLink).not.toBeNull();
+    expect(editLink?.getAttribute('href')).toContain('/propose/12');
+    expect(deleteButton).not.toBeNull();
+  });
+
+  it('opens the cancel trip modal from the mobile delete button', () => {
+    createComponent();
+
+    component.toggleTripSummary();
+    fixture.detectChanges();
+
+    const deleteButton = fixture.nativeElement.querySelector(
+      'button[aria-label="Supprimer le trajet"]'
+    ) as HTMLButtonElement;
+
+    deleteButton.click();
+
+    expect(component.isCancelTripModalOpen).toBeTrue();
+  });
+
   it('accepts a booking and updates it in the page state', () => {
     createComponent();
 

--- a/front-office/src/app/pages/reservation-details/reservation-details-page.component.ts
+++ b/front-office/src/app/pages/reservation-details/reservation-details-page.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit, inject } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { forkJoin } from 'rxjs';
 import { BookingResponse } from '../../models/booking.model';
 import { Trip } from '../../models/trip.model';
@@ -19,6 +19,7 @@ type ReservationStatusTab = 'ALL' | BookingResponse['status'];
     CommonModule,
     BookingRequestCardComponent,
     ConfirmModalComponent,
+    RouterLink,
   ],
   templateUrl: './reservation-details-page.component.html',
 })

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.html
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.html
@@ -11,12 +11,12 @@
         <a
           routerLink="/dashboard"
           data-testid="trips-dashboard-link"
-          class="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-semibold text-primary shadow-sm transition hover:border-primary/30 hover:bg-primary/5 md:hidden"
+          class="inline-flex shrink-0 items-center justify-center rounded-full border border-gray-200 bg-white p-2 text-primary shadow-sm transition hover:border-primary/30 hover:bg-primary/5 md:hidden"
+          aria-label="Retour au dashboard"
         >
-          <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3 13h8V3H3v10Zm10 8h8V11h-8v10Zm0-18v4h8V3h-8ZM3 21h8v-6H3v6Z" />
+          <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
-          Dashboard
         </a>
       </div>
       <a
@@ -196,7 +196,13 @@
 
           <div class="divide-y divide-gray-100">
             @for (trip of paginatedTrips; track trip.id) {
-              <article class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-4 py-5" data-testid="mobile-trip-row">
+              <button
+                type="button"
+                class="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-4 py-5 text-left transition hover:bg-bg-secondary active:bg-bg-secondary"
+                data-testid="mobile-trip-row"
+                (click)="viewTripDetails(trip.id)"
+                [attr.aria-label]="'Voir les demandes pour ' + trip.departureAddress + ' vers ' + trip.destination"
+              >
                 <div class="min-w-0">
                   <p class="truncate text-sm font-bold text-primary">{{ trip.departureAddress }} → {{ trip.destination }}</p>
                   <p class="mt-1 text-[0.7rem] font-medium text-text-muted">{{ formatTripDate(trip.departureTime) }}</p>
@@ -204,7 +210,7 @@
                 <span class="inline-flex min-w-12 justify-center rounded-lg bg-bg-secondary px-3 py-1.5 text-[0.7rem] font-bold text-primary">
                   {{ trip.maxWeight }} kg
                 </span>
-              </article>
+              </button>
             }
           </div>
         </div>

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.html
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.html
@@ -1,15 +1,27 @@
-<div class="min-h-screen bg-bg-primary pt-20 pb-12 font-sans">
-  <div class="mx-auto max-w-6xl px-6">
+<div class="min-h-screen bg-bg-primary px-4 pb-12 pt-6 font-sans sm:px-6 md:pt-20">
+  <div class="mx-auto max-w-6xl">
 
     <!-- ── Section Header ──────────────────────────────────────────────────── -->
-    <div class="mb-8 flex items-start justify-between">
-      <div>
-        <h1 class="text-2xl font-bold text-primary">Gestion des trajets</h1>
-        <p class="mt-1 text-sm text-text-secondary">Visualisez et gérez vos propositions de transport.</p>
+    <div class="mb-6 md:mb-8 md:flex md:items-start md:justify-between">
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <h1 class="text-2xl font-bold leading-tight text-primary">Gestion des trajets</h1>
+          <p class="mt-1 text-sm text-text-secondary">Visualisez et gérez vos propositions de transport.</p>
+        </div>
+        <a
+          routerLink="/dashboard"
+          data-testid="trips-dashboard-link"
+          class="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-semibold text-primary shadow-sm transition hover:border-primary/30 hover:bg-primary/5 md:hidden"
+        >
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 13h8V3H3v10Zm10 8h8V11h-8v10Zm0-18v4h8V3h-8ZM3 21h8v-6H3v6Z" />
+          </svg>
+          Dashboard
+        </a>
       </div>
       <a
         routerLink="/propose"
-        class="inline-flex items-center gap-2 rounded-xl bg-secondary px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-secondary/90"
+        class="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-secondary px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-secondary/90 md:mt-0 md:w-auto"
       >
         <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
@@ -22,14 +34,14 @@
     <div class="overflow-hidden rounded-2xl bg-white shadow-sm">
 
       <!-- ── Filter Bar ──────────────────────────────────────────────────── -->
-      <div class="flex items-center justify-between border-b border-gray-100 px-6 py-4">
+      <div class="border-b border-gray-100 px-4 py-4 md:flex md:items-center md:justify-between md:px-6">
         <!-- Tabs -->
-        <div class="flex gap-6">
+        <div class="-mx-1 flex gap-5 overflow-x-auto px-1 pb-3 md:mx-0 md:gap-6 md:overflow-visible md:px-0 md:pb-0">
           @for (tab of filterTabs; track tab.id) {
             <button
               type="button"
               (click)="setFilter(tab.id)"
-              class="relative pb-2 text-sm font-medium transition"
+              class="relative shrink-0 pb-2 text-sm font-medium transition"
               [class.text-secondary]="activeFilter === tab.id"
               [class.text-text-muted]="activeFilter !== tab.id"
               [class.hover:text-text-secondary]="activeFilter !== tab.id"
@@ -43,7 +55,7 @@
         </div>
 
         <!-- Search -->
-        <div class="relative">
+        <div class="relative mt-3 md:mt-0">
           <svg class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
           </svg>
@@ -52,7 +64,7 @@
             [(ngModel)]="searchQuery"
             (ngModelChange)="onSearchChange()"
             placeholder="Rechercher un trajet..."
-            class="w-64 rounded-lg border border-gray-200 bg-bg-secondary py-2 pl-10 pr-4 text-sm text-text-primary placeholder:text-text-muted focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary"
+            class="w-full rounded-lg border border-gray-200 bg-bg-secondary py-2 pl-10 pr-4 text-sm text-text-primary placeholder:text-text-muted focus:border-secondary focus:outline-none focus:ring-1 focus:ring-secondary md:w-64"
           />
         </div>
       </div>
@@ -78,7 +90,7 @@
 
       <!-- ── Table ───────────────────────────────────────────────────────── -->
       @if (!isLoading && !loadError && filteredTrips.length > 0) {
-        <table class="w-full">
+        <table class="hidden w-full md:table">
           <thead>
             <tr class="border-b border-gray-100">
               <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">Trajet / Date</th>
@@ -122,7 +134,7 @@
                 <!-- ACTIONS -->
                 <td class="px-6 py-4">
                   <div class="flex items-center justify-end gap-2">
-                    <!-- Eye icon — View details -->
+                    <!-- Eye icon - View details -->
                     <button
                       type="button"
                       (click)="viewTripDetails(trip.id)"
@@ -138,7 +150,7 @@
                       </span>
                     </button>
 
-                    <!-- Pencil icon — Edit with pending badge -->
+                    <!-- Pencil icon - Edit with pending badge -->
                     <div class="relative">
                       <button
                         type="button"
@@ -157,7 +169,7 @@
                       }
                     </div>
 
-                    <!-- Three dots — Options menu -->
+                    <!-- Three dots - Options menu -->
                     <app-trip-options-menu
                       [tripId]="trip.id"
                       [tripLabel]="trip.departureAddress + ' vers ' + trip.destination"
@@ -175,9 +187,31 @@
           </tbody>
         </table>
 
+        <!-- ── Mobile List ────────────────────────────────────────────────── -->
+        <div class="md:hidden" data-testid="mobile-trips-list">
+          <div class="grid grid-cols-[1fr_auto] gap-4 border-b border-gray-100 bg-bg-secondary px-4 py-4">
+            <p class="text-[0.65rem] font-bold uppercase tracking-wider text-text-muted">Trajet / Date</p>
+            <p class="text-right text-[0.65rem] font-bold uppercase tracking-wider text-text-muted">Capacité</p>
+          </div>
+
+          <div class="divide-y divide-gray-100">
+            @for (trip of paginatedTrips; track trip.id) {
+              <article class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-4 py-5" data-testid="mobile-trip-row">
+                <div class="min-w-0">
+                  <p class="truncate text-sm font-bold text-primary">{{ trip.departureAddress }} → {{ trip.destination }}</p>
+                  <p class="mt-1 text-[0.7rem] font-medium text-text-muted">{{ formatTripDate(trip.departureTime) }}</p>
+                </div>
+                <span class="inline-flex min-w-12 justify-center rounded-lg bg-bg-secondary px-3 py-1.5 text-[0.7rem] font-bold text-primary">
+                  {{ trip.maxWeight }} kg
+                </span>
+              </article>
+            }
+          </div>
+        </div>
+
         <!-- ── Pagination ──────────────────────────────────────────────────── -->
-        <div class="flex items-center justify-between border-t border-gray-100 px-6 py-4">
-          <p class="text-sm text-text-secondary">
+        <div class="flex flex-col items-center gap-4 border-t border-gray-100 px-4 py-4 md:flex-row md:justify-between md:px-6">
+          <p class="text-center text-sm text-text-secondary md:text-left">
             Affichage de {{ paginatedTrips.length }} sur {{ filteredTrips.length }} trajets
           </p>
           <div class="flex items-center gap-1">
@@ -185,7 +219,7 @@
               type="button"
               (click)="goToPage(currentPage - 1)"
               [disabled]="currentPage === 1"
-              class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-sm text-text-secondary transition hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+              class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-sm text-text-secondary transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
               aria-label="Page précédente"
             >
               <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
@@ -211,7 +245,7 @@
               type="button"
               (click)="goToPage(currentPage + 1)"
               [disabled]="currentPage === totalPages"
-              class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-sm text-text-secondary transition hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+              class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-sm text-text-secondary transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
               aria-label="Page suivante"
             >
               <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.spec.ts
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.spec.ts
@@ -224,7 +224,7 @@ describe('TripsManagementPageComponent', () => {
 
       expect(dashboardLink).not.toBeNull();
       expect(dashboardLink?.getAttribute('href')).toContain('/dashboard');
-      expect(dashboardLink?.textContent).toContain('Dashboard');
+      expect(dashboardLink?.getAttribute('aria-label')).toBe('Retour au dashboard');
     });
 
     it('should keep the propose trip call to action accessible', () => {
@@ -241,13 +241,14 @@ describe('TripsManagementPageComponent', () => {
     it('should render trips in the compact mobile list with route, date and capacity', () => {
       const mobileRows = fixture.nativeElement.querySelectorAll(
         '[data-testid="mobile-trip-row"]'
-      ) as NodeListOf<HTMLElement>;
+      ) as NodeListOf<HTMLButtonElement>;
 
       expect(mobileRows.length).toBe(5);
       expect(mobileRows[0].textContent).toContain('Paris');
       expect(mobileRows[0].textContent).toContain('Lyon');
       expect(mobileRows[0].textContent).toContain('15 Mars 2024');
       expect(mobileRows[0].textContent).toContain('20 kg');
+      expect(mobileRows[0].getAttribute('aria-label')).toContain('Voir les demandes');
     });
 
     it('should render the total booking count badge on the view button', () => {
@@ -279,6 +280,18 @@ describe('TripsManagementPageComponent', () => {
       ) as HTMLButtonElement;
 
       viewButton.click();
+
+      expect(router.navigate).toHaveBeenCalledWith(['/trips', 1, 'reservations']);
+    });
+
+    it('should navigate to trip reservations when clicking a mobile row', () => {
+      spyOn(router, 'navigate').and.resolveTo(true);
+
+      const mobileRow = fixture.nativeElement.querySelector(
+        '[data-testid="mobile-trip-row"]'
+      ) as HTMLButtonElement;
+
+      mobileRow.click();
 
       expect(router.navigate).toHaveBeenCalledWith(['/trips', 1, 'reservations']);
     });

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.spec.ts
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.spec.ts
@@ -217,6 +217,39 @@ describe('TripsManagementPageComponent', () => {
   });
 
   describe('Template actions', () => {
+    it('should render a dashboard link from the trips page header', () => {
+      const dashboardLink = fixture.nativeElement.querySelector(
+        '[data-testid="trips-dashboard-link"]'
+      ) as HTMLAnchorElement | null;
+
+      expect(dashboardLink).not.toBeNull();
+      expect(dashboardLink?.getAttribute('href')).toContain('/dashboard');
+      expect(dashboardLink?.textContent).toContain('Dashboard');
+    });
+
+    it('should keep the propose trip call to action accessible', () => {
+      const proposeLink = Array.from(
+        fixture.nativeElement.querySelectorAll('a')
+      ).find((link): link is HTMLAnchorElement =>
+        (link as HTMLAnchorElement).textContent?.includes('Proposer un voyage') ?? false
+      );
+
+      expect(proposeLink).toBeDefined();
+      expect(proposeLink?.getAttribute('href')).toContain('/propose');
+    });
+
+    it('should render trips in the compact mobile list with route, date and capacity', () => {
+      const mobileRows = fixture.nativeElement.querySelectorAll(
+        '[data-testid="mobile-trip-row"]'
+      ) as NodeListOf<HTMLElement>;
+
+      expect(mobileRows.length).toBe(5);
+      expect(mobileRows[0].textContent).toContain('Paris');
+      expect(mobileRows[0].textContent).toContain('Lyon');
+      expect(mobileRows[0].textContent).toContain('15 Mars 2024');
+      expect(mobileRows[0].textContent).toContain('20 kg');
+    });
+
     it('should render the total booking count badge on the view button', () => {
       const badge = fixture.nativeElement.querySelector(
         'button[aria-label="Voir les demandes"] span'


### PR DESCRIPTION
## Summary
- Responsive la page de gestion des trajets pour mieux s’adapter aux petits écrans.
- Ajoute un lien vers le dashboard dans l’en-tête mobile.
- Introduit une liste compacte mobile pour afficher trajet, date et capacité sans dépendre du tableau desktop.
- Ajuste les espacements, la barre de filtres, la recherche et la pagination pour un meilleur confort sur mobile.
- Renforce la couverture de tests sur les actions du template et le rendu mobile.

## Testing
- Tests unitaires ajoutés pour vérifier le lien dashboard, l’appel à l’action de proposition et le rendu de la liste mobile.
- Validation fonctionnelle du comportement responsive du template.
- Not run (not requested)