### PR TITLE
feat: redirect to published trips after trip creation

### DIFF
--- a/front-office/src/app/pages/propose-trip/propose-trip-page.component.spec.ts
+++ b/front-office/src/app/pages/propose-trip/propose-trip-page.component.spec.ts
@@ -91,7 +91,7 @@ describe('ProposeTripPageComponent', () => {
     paramMapSubject.next(paramMap);
   }
 
-  it('creates a trip in creation mode and redirects to search', () => {
+  it('creates a trip in creation mode and redirects to trips management with a success flag', () => {
     setRouteId();
     fixture.detectChanges();
 
@@ -114,7 +114,9 @@ describe('ProposeTripPageComponent', () => {
       pricePerKilo: 15,
       instantAcceptance: true,
     });
-    expect(router.navigate).toHaveBeenCalledWith(['/search']);
+    expect(router.navigate).toHaveBeenCalledWith(['/trips'], {
+      queryParams: { created: '1' },
+    });
   });
 
   it('loads an active trip in edit mode, pre-fills the form and updates it', () => {

--- a/front-office/src/app/pages/propose-trip/propose-trip-page.component.ts
+++ b/front-office/src/app/pages/propose-trip/propose-trip-page.component.ts
@@ -220,7 +220,7 @@ export class ProposeTripPageComponent implements OnInit {
           this.router.navigate(['/dashboard'], { queryParams: { tab: 'received' } });
           return;
         }
-        this.router.navigate(['/search']);
+        this.router.navigate(['/trips'], { queryParams: { created: '1' } });
       },
       error: (err: unknown) => {
         this.isLoading = false;

--- a/front-office/src/app/pages/search/search-page.component.spec.ts
+++ b/front-office/src/app/pages/search/search-page.component.spec.ts
@@ -354,7 +354,7 @@ describe('SearchPageComponent', () => {
     expect(host.textContent).toContain('Aucun trajet trouvé');
     expect(host.textContent).toContain('Créez une alerte');
     expect(host.textContent).toContain('publiez votre demande');
-    expect(publishLink?.getAttribute('href')).toBe('/propose');
+    expect(publishLink?.getAttribute('href')).toBe('/parcel-requests/new?from=Paris&to=Abidjan');
     expect(alertButton).not.toBeNull();
   });
 

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.html
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.html
@@ -1,5 +1,15 @@
 <div class="min-h-screen bg-bg-primary px-4 pb-12 pt-6 font-sans sm:px-6 md:pt-20">
   <div class="mx-auto max-w-6xl">
+    @if (creationSuccessMessage) {
+      <div
+        class="mb-6 rounded-2xl border border-success/20 bg-success/10 px-4 py-3 text-sm font-medium text-success md:mb-8 md:px-5"
+        role="status"
+        aria-live="polite"
+        data-testid="trip-created-success-alert"
+      >
+        {{ creationSuccessMessage }}
+      </div>
+    }
 
     <!-- ── Section Header ──────────────────────────────────────────────────── -->
     <div class="mb-6 md:mb-8 md:flex md:items-start md:justify-between">

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.spec.ts
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter, Router } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { TripsManagementPageComponent, TripStatusFilter } from './trips-management-page.component';
 import { TripService } from '../../services/trip.service';
@@ -12,6 +12,9 @@ describe('TripsManagementPageComponent', () => {
   let component: TripsManagementPageComponent;
   let fixture: ComponentFixture<TripsManagementPageComponent>;
   let router: Router;
+  let routeMock: {
+    snapshot: { queryParamMap: ReturnType<typeof convertToParamMap> };
+  };
   let tripServiceSpy: jasmine.SpyObj<TripService>;
   let authServiceSpy: jasmine.SpyObj<AuthService>;
   let shareCardMapperSpy: jasmine.SpyObj<ShareCardMapperService>;
@@ -69,6 +72,10 @@ describe('TripsManagementPageComponent', () => {
   ];
 
   beforeEach(async () => {
+    routeMock = {
+      snapshot: { queryParamMap: convertToParamMap({}) },
+    };
+
     tripServiceSpy = jasmine.createSpyObj('TripService', ['getMyTrips', 'getTripBookings', 'completeTrip']);
     tripServiceSpy.getMyTrips.and.returnValue(of(mockTrips.map((t) => ({ ...t }))));
     tripServiceSpy.getTripBookings.and.returnValue(of([...mockBookings]));
@@ -87,6 +94,7 @@ describe('TripsManagementPageComponent', () => {
       imports: [TripsManagementPageComponent],
       providers: [
         provideRouter([]),
+        { provide: ActivatedRoute, useValue: routeMock },
         { provide: TripService, useValue: tripServiceSpy },
         { provide: AuthService, useValue: authServiceSpy },
         { provide: ShareCardMapperService, useValue: shareCardMapperSpy },
@@ -217,6 +225,37 @@ describe('TripsManagementPageComponent', () => {
   });
 
   describe('Template actions', () => {
+    it('should show a success alert when arriving from trip creation and clean the URL flag', () => {
+      routeMock.snapshot.queryParamMap = convertToParamMap({ created: '1' });
+      const navigateSpy = spyOn(router, 'navigate').and.resolveTo(true);
+
+      fixture = TestBed.createComponent(TripsManagementPageComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      const alert = fixture.nativeElement.querySelector(
+        '[data-testid="trip-created-success-alert"]'
+      ) as HTMLDivElement | null;
+
+      expect(component.creationSuccessMessage).toBe('Votre trajet a été créé avec succès.');
+      expect(alert?.textContent).toContain('Votre trajet a été créé avec succès.');
+      expect(navigateSpy).toHaveBeenCalledWith([], {
+        relativeTo: TestBed.inject(ActivatedRoute),
+        queryParams: { created: null },
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      });
+    });
+
+    it('should not show a success alert without the creation flag', () => {
+      const alert = fixture.nativeElement.querySelector(
+        '[data-testid="trip-created-success-alert"]'
+      ) as HTMLDivElement | null;
+
+      expect(component.creationSuccessMessage).toBe('');
+      expect(alert).toBeNull();
+    });
+
     it('should render a dashboard link from the trips page header', () => {
       const dashboardLink = fixture.nativeElement.querySelector(
         '[data-testid="trips-dashboard-link"]'

--- a/front-office/src/app/pages/trips-management/trips-management-page.component.ts
+++ b/front-office/src/app/pages/trips-management/trips-management-page.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component, ElementRef, ViewChild, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { forkJoin, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import * as htmlToImage from 'html-to-image';
@@ -29,6 +29,7 @@ export class TripsManagementPageComponent implements OnInit {
   private readonly shareCardMapperService = inject(ShareCardMapperService);
   private readonly cdr = inject(ChangeDetectorRef);
   private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
   @ViewChild('shareCardCapture') private shareCardCapture?: ElementRef<HTMLElement>;
 
   // ── Data ──────────────────────────────────────────────────────────────────
@@ -36,6 +37,7 @@ export class TripsManagementPageComponent implements OnInit {
   tripBookingsMap: Record<number, BookingResponse[]> = {};
   isLoading = false;
   loadError = '';
+  creationSuccessMessage = '';
 
   // ── Filters ───────────────────────────────────────────────────────────────
   activeFilter: TripStatusFilter = 'ALL';
@@ -65,7 +67,22 @@ export class TripsManagementPageComponent implements OnInit {
       this.router.navigate(['/login']);
       return;
     }
+    this.consumeCreationSuccessFlag();
     this.loadTrips();
+  }
+
+  private consumeCreationSuccessFlag(): void {
+    if (this.route.snapshot.queryParamMap.get('created') !== '1') {
+      return;
+    }
+
+    this.creationSuccessMessage = 'Votre trajet a été créé avec succès.';
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { created: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   }
 
   /** Load all trips belonging to the current user along with their bookings. */


### PR DESCRIPTION
## Summary
- redirect trip creation success from /propose to /trips with a one-time success flag
- display a success alert on the published trips page and clear the URL flag after it is consumed
- align the affected frontend specs, including the existing empty-search CTA expectation

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless --include src/app/pages/propose-trip/propose-trip-page.component.spec.ts --include src/app/pages/trips-management/trips-management-page.component.spec.ts
- npm test -- --watch=false --browsers=ChromeHeadless