### PR TITLE
fix: remove mobile bottom navigation

### DIFF
--- a/front-office/src/app/pages/dashboard/dashboard-page.component.html
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.html
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-background-primary pb-24 md:pb-12 font-sans">
+<div class="min-h-screen bg-background-primary pb-12 font-sans">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 py-6">
 
     <!-- ── Header ──────────────────────────────────────────────────────────── -->
@@ -251,39 +251,4 @@
       </div>
     </div>
   </div>
-
-  <!-- ── Mobile Bottom Navigation ──────────────────────────────────────────── -->
-  <nav class="md:hidden fixed bottom-0 inset-x-0 bg-surface border-t border-border z-50">
-    <div class="flex items-center justify-around h-16">
-      <a routerLink="/dashboard" class="flex flex-col items-center gap-0.5 text-primary">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
-        </svg>
-        <span class="text-[10px] font-medium">Dashboard</span>
-      </a>
-      <a routerLink="/trips" class="flex flex-col items-center gap-0.5 text-text-muted">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
-        </svg>
-        <span class="text-[10px] font-medium">Voyages</span>
-      </a>
-      <a routerLink="/propose" class="flex items-center justify-center w-12 h-12 -mt-5 rounded-full bg-primary text-white shadow-lg">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
-        </svg>
-      </a>
-      <a routerLink="/bookings" class="flex flex-col items-center gap-0.5 text-text-muted">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
-        </svg>
-        <span class="text-[10px] font-medium">Envois</span>
-      </a>
-      <a routerLink="/messages" class="flex flex-col items-center gap-0.5 text-text-muted">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
-        </svg>
-        <span class="text-[10px] font-medium">Messages</span>
-      </a>
-    </div>
-  </nav>
 </div>

--- a/front-office/src/app/pages/dashboard/dashboard-page.component.spec.ts
+++ b/front-office/src/app/pages/dashboard/dashboard-page.component.spec.ts
@@ -153,6 +153,12 @@ describe('DashboardPageComponent', () => {
     expect(sentBookingCard.textContent).toContain('Mai');
   });
 
+  it('does not render the deprecated mobile bottom navigation', () => {
+    const bottomNavigation = fixture.nativeElement.querySelector('nav.fixed.bottom-0') as HTMLElement | null;
+
+    expect(bottomNavigation).toBeNull();
+  });
+
   it('navigates to sent booking detail when clicking a sent booking card', () => {
     const sentBookingCard = fixture.nativeElement.querySelector('article[role="link"]') as HTMLElement;
 


### PR DESCRIPTION
## Summary
- remove the deprecated fixed mobile bottom navigation from the dashboard page
- reduce the dashboard bottom padding now that the fixed bar is gone
- add a regression test to ensure the dashboard no longer renders that bottom navigation

## Tests
- npm test -- --watch=false

Closes #120